### PR TITLE
Image bundle

### DIFF
--- a/porespy/tools/__Bundle__.py
+++ b/porespy/tools/__Bundle__.py
@@ -1,8 +1,8 @@
 from porespy.metrics import porosity
 import matplotlib.pyplot as plt
 import scipy.ndimage as spim
-from porespy.visualization import sem
 from porespy.filters import porosimetry
+from porespy.visualization import show_slices as _show_slices
 
 
 class Bundle():
@@ -51,7 +51,7 @@ class Bundle():
 
     dt = property(fget=_get_dt, fset=_set_dt)
 
-    def show_psd(self, bins=25):
+    def show_psd(self, bins=10):
         plt.hist(self.lt[self.im], bins=bins, normed=True)
 
     @property
@@ -74,19 +74,9 @@ class Bundle():
         if self.ndim == 3:
             return self.im.shape[2]
 
-    def show_slice(self):
-        if self.ndim == 2:
-            im = self.im
-        else:
-            z = int(self.Lz/2)
-            im = self.im[:, :, z]
-        plt.imshow(im)
-        plt.axis('off')
+    def show_slices(self, n=1, visible_phase=0, stride=1):
+        r"""
+        """
+        _show_slices(self.im, n=n, visible_phase=visible_phase, stride=stride)
 
-    def show_3D(self):
-        rot = spim.rotate(input=self.im, angle=35, axes=[2, 0], order=0,
-                          mode='constant', cval=1)
-        rot = spim.rotate(input=rot, angle=25, axes=[1, 0], order=0,
-                          mode='constant', cval=1)
-        plt.imshow(sem(rot), cmap=plt.cm.bone)
-        plt.axis('off')
+    show_slices.__doc__ = _show_slices.__doc__

--- a/porespy/tools/__Bundle__.py
+++ b/porespy/tools/__Bundle__.py
@@ -1,0 +1,71 @@
+from porespy.metrics import porosity
+import matplotlib.pyplot as plt
+import scipy.ndimage as spim
+from porespy.visualization import sem
+
+
+class Bundle(dict):
+
+    def __init__(self, im, dt=None):
+        self.__dict__ = self
+        self['im'] = im
+        self['dt'] = dt
+
+    @property
+    def porosity(self):
+        if not hasattr(self, '_phi'):
+            self._phi = porosity(self._im)
+        return self._phi
+
+    @property
+    def phi(self):
+        return self.porosity
+
+    @property
+    def shape(self):
+        return self.im.shape
+
+    @property
+    def ndim(self):
+        return self.im.ndim
+
+    def _get_dt(self):
+        if self['dt'] is None:
+            print('Calculating distance transform for the first time...')
+            dt = spim.distance_transform_edt(self['im'])
+            self.update({'dt': dt})
+        else:
+            dt = self['dt']
+        return dt
+
+    dt = property(fget=_get_dt)
+
+    @property
+    def Lx(self):
+        return self.im.shape[0]
+
+    @property
+    def Ly(self):
+        return self.im.shape[1]
+
+    @property
+    def Lz(self):
+        if self.ndim == 3:
+            return self.im.shape[2]
+
+    def show(self):
+        if self.ndim == 2:
+            im = self.im
+        else:
+            z = int(self.Lz/2)
+            im = self.im[:, :, z]
+        plt.imshow(im)
+        plt.axis('off')
+
+    def show3D(self):
+        rot = spim.rotate(input=self.im, angle=35, axes=[2, 0], order=0,
+                          mode='constant', cval=1)
+        rot = spim.rotate(input=rot, angle=25, axes=[1, 0], order=0,
+                          mode='constant', cval=1)
+        plt.imshow(sem(rot), cmap=plt.cm.bone)
+        plt.axis('off')

--- a/porespy/visualization/__funcs__.py
+++ b/porespy/visualization/__funcs__.py
@@ -1,4 +1,8 @@
 import matplotlib.pyplot as plt
+from mpl_toolkits.mplot3d import Axes3D
+import scipy as sp
+import scipy.ndimage as spim
+from porespy.visualization import sem
 
 
 def set_mpl_style():
@@ -35,3 +39,88 @@ def set_mpl_style():
     plt.rc('ytick', **ytick_props)
     plt.rc('legend', **legend_props)
     plt.rc('figure', **figure_props)
+
+
+def show_slices(im, n=1, visible_phase=0, stride=1):
+    r"""
+    Show a view of the slices though the material with solids set to visible.
+
+    Parameter
+    ---------
+    im : ND-image
+        The image of the porous material
+
+    n : int (default = 1)
+        The number of slices to show in the z-direction.  For ``n = 1``, the
+        middle slice is show, for all higher values, the top and bottom are
+        always shown, with the remainder evenly spaced through the image.  For
+        2D images, this is ignored since there is only one slice.
+
+    visible_phase : int (default = 0)
+        This controls which phase is set to visible in the slices.  The default
+        is the solid phase (False or 0), but any value can be used, provided
+        that it is present in the image.
+
+    stride : int (default = 1)
+        Controls how many of the voxels are represented in the image.  If
+        set to 1, then every voxel is shown by a marker, which could get
+        slow to plot for large images.  Higher values skip voxels to produce
+        a more sparse image.
+
+    Returns
+    -------
+    This function creates a Matplotlib figure and automatically shows it.
+
+    Notes
+    -----
+    In order to handle 2D and 3D images equally, this function creates a
+    scatter plot for each slice and puts markers at the location of the
+    ``visible_phase``.  For 2D image, users can just call matplotlib's
+    ``imshow`` or ``matshow`` functions to get more standard image.
+
+    """
+
+    if im.ndim == 2:
+        slices = [0]
+    elif n == 1:
+        slices = [int(im.shape[2]/2)]
+    else:
+        slices = sp.linspace(0, im.shape[2], n).astype(int)
+        slices[-1] -= 1
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection='3d')
+    for n in slices:
+        pts = sp.where(im[::stride, ::stride, n] == visible_phase)
+        ax.plot(*pts, zs=n, marker='.', linestyle='None')
+    plt.axis('equal')
+
+
+def show_3D(im, visible_phase=0):
+    r"""
+    Shows a view of the image stack from an angle with solids set to visible.
+
+    Parameters
+    ----------
+    im : ND-array
+        A 3D image of the porous material.
+
+    visible_phase : int (default = 0)
+        This controls which phase is set to visible in the slices.  The default
+        is the solid phase (False or 0), but any value can be used, provided
+        that it is present in the image.
+
+    Notes
+    -----
+    This function first rotates the image, then passes it to the ``sem`` view.
+    The end result is a reasonbly decent view of the stack that is useful to
+    ensure everything is looking as it's supposed to.
+
+    """
+
+    im = im == visible_phase
+    rot = spim.rotate(input=im, angle=35, axes=[2, 0], order=0,
+                      mode='constant', cval=1)
+    rot = spim.rotate(input=rot, angle=25, axes=[1, 0], order=0,
+                      mode='constant', cval=1)
+    plt.imshow(sem(rot), cmap=plt.cm.bone)
+    plt.axis('off')

--- a/porespy/visualization/__init__.py
+++ b/porespy/visualization/__init__.py
@@ -16,3 +16,5 @@ This module contains functions for quickly visualizing 3D images in 2D views.
 from .__views__ import sem
 from .__views__ import xray
 from .__funcs__ import set_mpl_style
+from .__funcs__ import show_3D
+from .__funcs__ import show_slices

--- a/porespy/visualization/__views__.py
+++ b/porespy/visualization/__views__.py
@@ -19,9 +19,11 @@ def sem(im, direction='X'):
 
     Returns
     -------
-    A 2D greyscale image suitable for use in matplotlib\'s ```imshow```
+    A 2D greyscale image suitable for use in matplotlib\'s ``imshow``
     function.
+
     """
+
     im = sp.array(~im, dtype=int)
     if direction in ['Y', 'y']:
         im = sp.transpose(im, axes=[1, 0, 2])
@@ -53,9 +55,11 @@ def xray(im, direction='X'):
 
     Returns
     -------
-    A 2D greyscale image suitable for use in matplotlib\'s ```imshow```
+    A 2D greyscale image suitable for use in matplotlib\'s ``imshow``
     function.
+
     """
+
     im = sp.array(~im, dtype=int)
     if direction in ['Y', 'y']:
         im = sp.transpose(im, axes=[1, 0, 2])


### PR DESCRIPTION
This PR introduces the concept of an image bundle.  This is basically an object oriented approach to working with the main aspects of porespy, and adds a bit of convenience.  This is just experimental, open to discussion, and subject to rejection, but still worth considering. 

For example, it works like this:
``` python
b = ps.tools.Bundle(im)
b.phi  # will print the porosity
b.dt  # will return the distance transform and calculate it if needed
b.show()  # will print a slice of a 3d stack or just the 2d image, as needed
b.show_3d()  # will print a nice rotated view of the image stack
b.show_psd()  # will calculate the local thickness if needed, save it under b.lt, the plot a histogram

```