### PR TITLE
trim_non_percolating_paths to remove isolated solids from image.

### DIFF
--- a/porespy/filters/__funcs__.py
+++ b/porespy/filters/__funcs__.py
@@ -132,30 +132,30 @@ def trim_nonpercolating_paths(im, inlet_axis=0, outlet_axis=0):
     labels = spim.label(im)[0]
     inlet = sp.zeros_like(im,dtype=int)
     outlet = sp.zeros_like(im,dtype=int)
-    if im.ndim == 3
-        if inlet_axis = 0:
+    if im.ndim == 3:
+        if inlet_axis == 0:
             inlet[0,:,:] = 1
-        elif inlet_axis = 1:
+        elif inlet_axis == 1:
             inlet[:,0,:] = 1
-        else inlet_axis = 2:
+        elif inlet_axis == 2:
             inlet[:,:,0] = 1
         
-        if outlet_axis = 0:
+        if outlet_axis == 0:
             outlet[-1,:,:] = 1
-        elif outlet_axis = 1:
+        elif outlet_axis == 1:
             outlet[:,-1,:] = 1
-        else outlet_axis = 2:
+        elif outlet_axis == 2:
             outlet[:,:,-1] = 1
     
-    if im.ndim == 2
-        if inlet_axis = 0:
+    if im.ndim == 2:
+        if inlet_axis == 0:
             inlet[0,:] = 1
-        else inlet_axis = 1:
+        elif inlet_axis == 1:
             inlet[:,0] = 1
         
-        if outlet_axis = 0:
+        if outlet_axis == 0:
             outlet[-1,:] = 1
-        else outlet_axis = 1:
+        elif outlet_axis == 1:
             outlet[:,-1] = 1       
     IN = sp.unique(labels*inlet)
     OUT = sp.unique(labels*outlet)

--- a/porespy/filters/__funcs__.py
+++ b/porespy/filters/__funcs__.py
@@ -129,7 +129,7 @@ def trim_nonpercolating_paths(im, inlet_axis=0, outlet_axis=0):
 
     """
     im = trim_floating_solid(im)
-    labels = spim.label(im)[0]
+    labels = spim.label(~im)[0]
     inlet = sp.zeros_like(im,dtype=int)
     outlet = sp.zeros_like(im,dtype=int)
     if im.ndim == 3:
@@ -159,8 +159,8 @@ def trim_nonpercolating_paths(im, inlet_axis=0, outlet_axis=0):
             outlet[:,-1] = 1       
     IN = sp.unique(labels*inlet)
     OUT = sp.unique(labels*outlet)
-    new_im = sp.isin(im,list(set(IN) ^ set(OUT)))
-    im[new_im == True] = False
+    new_im = sp.isin(labels,list(set(IN) ^ set(OUT)), invert=True)
+    im[new_im == False] = True
     return im
 
 def trim_extrema(im, h, mode='maxima'):

--- a/porespy/filters/__funcs__.py
+++ b/porespy/filters/__funcs__.py
@@ -99,6 +99,69 @@ def trim_floating_solid(im):
     im[holes] = True
     return im
 
+def trim_nonpercolating_paths(im, inlet_axis=0, outlet_axis=0):
+    r"""
+    Removes all disconnected solid clusters including edges that are 
+    nonpercolating.
+
+    Parameters
+    ----------
+    im : ND-array
+        The image of the porous material
+    
+    inlet_axis : int
+        Inlet axis of boundary condition. For three dimensional image the 
+        number ranges from 0 to 2. For two dimensional image the range is 
+        between 0 to 1.
+    
+    outlet_axis : int
+        Outlet axis of boundary condition. For three dimensional image the 
+        number ranges from 0 to 2. For two dimensional image the range is 
+        between 0 to 1.
+
+    Returns
+    -------
+        A version of ``im`` but with all the disconnected solid removed.
+
+    See Also
+    --------
+    find_disconnected_voxels
+
+    """
+    im = trim_floating_solid(im)
+    labels = spim.label(im)[0]
+    inlet = sp.zeros_like(im,dtype=int)
+    outlet = sp.zeros_like(im,dtype=int)
+    if im.ndim == 3
+        if inlet_axis = 0:
+            inlet[0,:,:] = 1
+        elif inlet_axis = 1:
+            inlet[:,0,:] = 1
+        else inlet_axis = 2:
+            inlet[:,:,0] = 1
+        
+        if outlet_axis = 0:
+            outlet[-1,:,:] = 1
+        elif outlet_axis = 1:
+            outlet[:,-1,:] = 1
+        else outlet_axis = 2:
+            outlet[:,:,-1] = 1
+    
+    if im.ndim == 2
+        if inlet_axis = 0:
+            inlet[0,:] = 1
+        else inlet_axis = 1:
+            inlet[:,0] = 1
+        
+        if outlet_axis = 0:
+            outlet[-1,:] = 1
+        else outlet_axis = 1:
+            outlet[:,-1] = 1       
+    IN = sp.unique(labels*inlet)
+    OUT = sp.unique(labels*outlet)
+    new_im = sp.isin(im,list(set(IN) ^ set(OUT)))
+    im[new_im == True] = False
+    return im
 
 def trim_extrema(im, h, mode='maxima'):
     r"""

--- a/porespy/filters/__init__.py
+++ b/porespy/filters/__init__.py
@@ -27,3 +27,4 @@ from .__funcs__ import local_thickness
 from .__funcs__ import porosimetry
 from .__funcs__ import trim_extrema
 from .__funcs__ import trim_floating_solid
+from .__funcs__ import trim_nonpercolating_paths

--- a/test/unit/test_filters.py
+++ b/test/unit/test_filters.py
@@ -86,6 +86,7 @@ class FilterTest():
     def test_find_disconnected_voxels_2d(self):
         h = ps.filters.find_disconnected_voxels(self.im[:, :, 0])
         assert sp.sum(h) == 477
+#        print(sp.sum(h))
 
     def test_find_disconnected_voxels_2d_conn4(self):
         h = ps.filters.find_disconnected_voxels(self.im[:, :, 0], conn=4)
@@ -99,6 +100,31 @@ class FilterTest():
         h = ps.filters.find_disconnected_voxels(self.im, conn=6)
         assert sp.sum(h) == 202
 
+    def test_trim_nonpercolating_paths_2d_axis0(self):
+        h = ps.filters.trim_nonpercolating_paths(self.im[:, :, 0],inlet_axis=0,
+                                                 outlet_axis=0)
+        assert sp.sum(h) == 5030
+
+    def test_trim_nonpercolating_paths_2d_axis1(self):
+        h = ps.filters.trim_nonpercolating_paths(self.im[:, :, 0],inlet_axis=1,
+                                                 outlet_axis=1)
+        assert sp.sum(h) == 5185
+        
+    def test_trim_nonpercolating_paths_3d_axis0(self):
+        h = ps.filters.trim_nonpercolating_paths(self.im,inlet_axis=0,
+                                                 outlet_axis=0)
+        assert sp.sum(h) == 500283
+        
+    def test_trim_nonpercolating_paths_3d_axis1(self):
+        h = ps.filters.trim_nonpercolating_paths(self.im,inlet_axis=1,
+                                                 outlet_axis=1)
+        assert sp.sum(h) == 500402
+        
+    def test_trim_nonpercolating_paths_3d_axis2(self):
+        h = ps.filters.trim_nonpercolating_paths(self.im,inlet_axis=2,
+                                                 outlet_axis=2)
+        assert sp.sum(h) == 500413
+        
     def test_fill_blind_pores(self):
         h = ps.filters.find_disconnected_voxels(self.im)
         b = ps.filters.fill_blind_pores(h)
@@ -164,4 +190,9 @@ if __name__ == '__main__':
     t.test_porosimetry()
     t.test_porosimetry_npts_10()
     t.test_porosimetry_with_sizes()
+    t.test_trim_nonpercolating_paths_2d_axis0()
+    t.test_trim_nonpercolating_paths_2d_axis1()
+    t.test_trim_nonpercolating_paths_3d_axis0()
+    t.test_trim_nonpercolating_paths_3d_axis1()
+    t.test_trim_nonpercolating_paths_3d_axis2()
     self = t


### PR DESCRIPTION
This function removes hanging solid in a binary image along with isolated solids at inlet and outlet edges.