### PR TITLE
No squeeze of 3d to 2d images i.e [500, 500, 1] -> [500, 500]

### DIFF
--- a/porespy/filters/__funcs__.py
+++ b/porespy/filters/__funcs__.py
@@ -121,13 +121,17 @@ def snow_partitioning(im, r_max=4, sigma=0.4, return_all=False):
 
     """
     tup = namedtuple('results', field_names=['im', 'dt', 'peaks', 'regions'])
-    im = im.squeeze()
     print('_'*60)
     print("Beginning SNOW Algorithm")
-
+    im_shape = sp.array(im.shape)
     if im.dtype == 'bool':
         print('Peforming Distance Transform')
-        dt = spim.distance_transform_edt(input=im)
+        if sp.any(im_shape == 1):
+            ax = sp.where(im_shape == 1)[0][0]
+            dt = spim.distance_transform_edt(input=im.squeeze())
+            dt = sp.expand_dims(dt, ax)
+        else:
+            dt = spim.distance_transform_edt(input=im)
     else:
         dt = im
         im = dt > 0
@@ -191,7 +195,6 @@ def find_peaks(dt, r=4, footprint=None):
     This automatically uses a square structuring element which is significantly
     faster than using a circular or spherical element.
     """
-    dt = dt.squeeze()
     im = dt > 0
     if footprint is None:
         if im.ndim == 2:

--- a/porespy/network_extraction/__getnet__.py
+++ b/porespy/network_extraction/__getnet__.py
@@ -66,8 +66,9 @@ def regions_to_network(im, dt=None, voxel_size=1):
     t_area = []
     t_perimeter = []
     t_coords = []
-
+    dt_shape = sp.array(dt.shape)
     # Start extracting size information for pores and throats
+
     for i in tqdm(Ps):
         pore = i - 1
     #        if slices[pore] is None:
@@ -78,7 +79,13 @@ def regions_to_network(im, dt=None, voxel_size=1):
         pore_im = sub_im == i
         # ---------------------------------------------------------------------
         padded_mask = sp.pad(pore_im, pad_width=1, mode='constant')
-        pore_dt = spim.distance_transform_edt(padded_mask)
+        if sp.any(dt_shape == 1):
+            mask_2d = sp.pad(pore_im.squeeze(), pad_width=1, mode='constant')
+            ax = sp.where(dt_shape == 1)[0][0]
+            pore_dt = spim.distance_transform_edt(input=mask_2d.squeeze())
+            pore_dt = sp.expand_dims(pore_dt, ax)
+        else:
+            pore_dt = spim.distance_transform_edt(padded_mask)
         if padded_mask.ndim == 3:
             filter_mask = spim.convolve(padded_mask*1.0,
                                         weights=ball(1))/sp.sum(ball(1))

--- a/test/unit/test_network_extraction.py
+++ b/test/unit/test_network_extraction.py
@@ -111,6 +111,35 @@ class NetExtractTest():
         with pytest.raises(Exception):
             mapped = ps.network_extraction.map_to_regions(regions, values)
 
+    def planar_2d_image(self):
+        np.random.seed(1)
+        im1 = ps.generators.blobs([100, 100, 1])
+        np.random.seed(1)
+        im2 = ps.generators.blobs([100, 1, 100])
+        np.random.seed(1)
+        im3 = ps.generators.blobs([1, 100, 100])
+        np.random.seed(1)
+        snow_out1 = ps.filters.snow_partitioning(im1, return_all=True)
+        pore_map1 = snow_out1.im * snow_out1.regions
+        net1 = ps.network_extraction.regions_to_network(im=pore_map1,
+                                                        dt=snow_out1.dt,
+                                                        voxel_size=1)
+        np.random.seed(1)
+        snow_out2 = ps.filters.snow_partitioning(im2, return_all=True)
+        pore_map2 = snow_out2.im * snow_out2.regions
+        net2 = ps.network_extraction.regions_to_network(im=pore_map2,
+                                                        dt=snow_out2.dt,
+                                                        voxel_size=1)
+        np.random.seed(1)
+        snow_out3 = ps.filters.snow_partitioning(im3, return_all=True)
+        pore_map3 = snow_out3.im * snow_out3.regions
+        net3 = ps.network_extraction.regions_to_network(im=pore_map3,
+                                                        dt=snow_out3.dt,
+                                                        voxel_size=1)
+        assert net1['pore.coords'][:, 0] == net2['pore.coords'][:, 0]
+        assert net1['pore.coords'][:, 1] == net2['pore.coords'][:, 2]
+        assert net1['pore.coords'][:, 0] == net3['pore.coords'][:, 1]
+
 
 if __name__ == '__main__':
     t = NetExtractTest()

--- a/test/unit/test_network_extraction.py
+++ b/test/unit/test_network_extraction.py
@@ -111,7 +111,7 @@ class NetExtractTest():
         with pytest.raises(Exception):
             mapped = ps.network_extraction.map_to_regions(regions, values)
 
-    def planar_2d_image(self):
+    def test_planar_2d_image(self):
         np.random.seed(1)
         im1 = ps.generators.blobs([100, 100, 1])
         np.random.seed(1)
@@ -136,9 +136,12 @@ class NetExtractTest():
         net3 = ps.network_extraction.regions_to_network(im=pore_map3,
                                                         dt=snow_out3.dt,
                                                         voxel_size=1)
-        assert net1['pore.coords'][:, 0] == net2['pore.coords'][:, 0]
-        assert net1['pore.coords'][:, 1] == net2['pore.coords'][:, 2]
-        assert net1['pore.coords'][:, 0] == net3['pore.coords'][:, 1]
+        assert np.allclose(net1['pore.coords'][:, 0],
+                           net2['pore.coords'][:, 0])
+        assert np.allclose(net1['pore.coords'][:, 1],
+                           net2['pore.coords'][:, 2])
+        assert np.allclose(net1['pore.coords'][:, 0],
+                           net3['pore.coords'][:, 1])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Don't squeeze 2d images in output but do for dt calculation. Preserves the planar orientation of the array