### PR TITLE
fixed the porosimetry mio edge issue as well as removed the halo feat…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ docs/_build/
 dist/
 
 \.pytest_cache/
+porespy/network_extraction/__snow_dual__.py
+porespy/metrics/.ipynb_checkpoints/__regionprops__-checkpoint.py
+bin/clean
+bin/test

--- a/porespy/filters/__funcs__.py
+++ b/porespy/filters/__funcs__.py
@@ -965,5 +965,5 @@ def porosimetry(im, sizes=25, inlets=None, access_limited=True,
                 imtemp = fftconvolve(imtemp, strel(r), mode='same') > 0.0001
                 imresults[(imresults == 0)*imtemp] = r
     else:
-        raise Exception('Unreckognized mode '+ mode)
+        raise Exception('Unreckognized mode ' + mode)
     return imresults

--- a/porespy/filters/__funcs__.py
+++ b/porespy/filters/__funcs__.py
@@ -957,7 +957,7 @@ def porosimetry(im, sizes=25, inlets=None, access_limited=True,
                 imresults[(imresults == 0)*imtemp] = r
     if mode == 'fft':
         for r in tqdm(sizes):
-            imtemp = dt > r
+            imtemp = dt >= r
             if access_limited:
                 imtemp = trim_blobs(imtemp, inlets)
             if sp.any(imtemp):

--- a/porespy/tools/__funcs__.py
+++ b/porespy/tools/__funcs__.py
@@ -758,3 +758,43 @@ def mesh_region(region: bool, strel=None):
     result.norm = norm
     result.val = val
     return result
+
+
+def ps_disk(radius):
+    r"""
+    Creates circular disk structuring element for morphological operations
+
+    Parameters
+    ----------
+    radius : float or int
+        The desired radius of the structuring element
+
+    Returns
+    -------
+    A 2D numpy bool array of the structring element
+    """
+    rad = int(sp.ceil(radius))
+    other = sp.ones((2*rad+1, 2*rad+1), dtype=bool)
+    other[rad, rad] = False
+    disk = spim.distance_transform_edt(other) < radius
+    return disk
+
+
+def ps_ball(radius):
+    r"""
+    Creates spherical ball structuring element for morphological operations
+
+    Parameters
+    ----------
+    radius : float or int
+        The desired radius of the structuring element
+
+    Returns
+    -------
+    A 2D numpy array of the structuring element
+    """
+    rad = int(sp.ceil(radius))
+    other = sp.ones((2*rad+1, 2*rad+1, 2*rad+1), dtype=bool)
+    other[rad, rad, rad] = False
+    ball = spim.distance_transform_edt(other) < radius
+    return ball

--- a/porespy/tools/__funcs__.py
+++ b/porespy/tools/__funcs__.py
@@ -84,7 +84,8 @@ def fftmorphology(im, strel, mode='opening'):
 
     >>> result = ps.filters.fftmorphology(im, strel=disk(5), mode='closing')
     >>> temp = spim.binary_closing(im, structure=disk(5))
-    >>> # This one does not work yet!!
+    >>> array_equal(result, temp)
+    True
 
     """
     def erode(im, strel):
@@ -174,7 +175,7 @@ def subdivide(im, divs=2):
     (100, 100)
     """
     # Expand scalar divs
-    if sp.array(divs, ndmin=1).size == 1:
+    if isinstance(divs, int):
         divs = [divs for i in range(im.ndim)]
     s = shape_split(im.shape, axis=divs)
     return s

--- a/porespy/tools/__init__.py
+++ b/porespy/tools/__init__.py
@@ -39,3 +39,5 @@ from .__funcs__ import mesh_region
 from .__funcs__ import norm_to_uniform
 from .__funcs__ import randomize_colors
 from .__funcs__ import subdivide
+from .__funcs__ import ps_disk
+from .__funcs__ import ps_ball

--- a/porespy/tools/__init__.py
+++ b/porespy/tools/__init__.py
@@ -21,6 +21,8 @@ that do NOT return a modified version of the original image.
 .. autofunction:: norm_to_uniform
 .. autofunction:: randomize_colors
 .. autofunction:: subdivide
+.. autofunction:: ps_disk
+.. autofunction:: ps_ball
 
 '''
 from .__funcs__ import align_image_with_openpnm

--- a/test/unit/test_filters.py
+++ b/test/unit/test_filters.py
@@ -26,10 +26,10 @@ class FilterTest():
 
     def test_porosimetry_npts_10(self):
         mip = ps.filters.porosimetry(im=self.im, sizes=10)
-        ans = sp.array([0.00000000, 1.00000000, 1.37871571, 1.61887041,
-                        1.90085700, 2.23196205, 2.62074139, 3.07724114,
-                        3.61325732])
-        assert sp.allclose(sp.unique(mip), ans)
+        steps = sp.unique(mip)
+        ans = sp.array([0.00000000, 1.37871571, 1.61887041, 1.90085700,
+                        2.23196205, 2.62074139, 3.07724114, 3.61325732])
+        assert sp.allclose(steps, ans)
 
     def test_porosimetry_compare_modes_3D(self):
         im = self.im
@@ -167,7 +167,11 @@ class FilterTest():
         assert max1 > max2
 
     def test_local_thickness(self):
-        lt = ps.filters.local_thickness(self.im)
+        lt = ps.filters.local_thickness(self.im, mode='dt')
+        assert lt.max() == self.im_dt.max()
+        lt = ps.filters.local_thickness(self.im, mode='mio')
+        assert lt.max() == self.im_dt.max()
+        lt = ps.filters.local_thickness(self.im, mode='fft')
         assert lt.max() == self.im_dt.max()
 
     def test_porosimetry(self):

--- a/test/unit/test_filters.py
+++ b/test/unit/test_filters.py
@@ -27,13 +27,14 @@ class FilterTest():
     def test_porosimetry_npts_10(self):
         mip = ps.filters.porosimetry(im=self.im, sizes=10)
         steps = sp.unique(mip)
-        ans = sp.array([0.00000000, 1.37871571, 1.61887041, 1.90085700,
-                        2.23196205, 2.62074139, 3.07724114, 3.61325732])
+        ans = sp.array([0.00000000, 1.00000000, 1.37871571, 1.61887041,
+                        1.90085700, 2.23196205, 2.62074139, 3.07724114,
+                        3.61325732])
         assert sp.allclose(steps, ans)
 
     def test_porosimetry_compare_modes_3D(self):
         im = self.im
-        fft = ps.filters.porosimetry(im, mode='fft')
+        fft = ps.filters.porosimetry(im, mode='hybrid')
         mio = ps.filters.porosimetry(im, mode='mio')
         dt = ps.filters.porosimetry(im, mode='dt')
 #        assert sp.all(fft == dt)
@@ -41,7 +42,7 @@ class FilterTest():
 
     def test_porosimetry_compare_modes_2D(self):
         im = self.im[:, :, 50]
-        fft = ps.filters.porosimetry(im, mode='fft')
+        fft = ps.filters.porosimetry(im, mode='hybrid')
         mio = ps.filters.porosimetry(im, mode='mio')
         dt = ps.filters.porosimetry(im, mode='dt')
 #        assert sp.all(fft == dt)
@@ -171,7 +172,7 @@ class FilterTest():
         assert lt.max() == self.im_dt.max()
         lt = ps.filters.local_thickness(self.im, mode='mio')
         assert lt.max() == self.im_dt.max()
-        lt = ps.filters.local_thickness(self.im, mode='fft')
+        lt = ps.filters.local_thickness(self.im, mode='hybrid')
         assert lt.max() == self.im_dt.max()
 
     def test_porosimetry(self):


### PR DESCRIPTION
Fixes how the mio option in porosimetry handles the edges of the image and also fixes the one voxel feature that was appearing around edges when using the fft option. Two new structuring elements were added to ps.tools, ps_ball and ps_disk. They are cleaner representations of the skimage structuring elements ball and disk which were responsible for the edge bug. @jgostick there is now a minor issue in the mio option when access_limited is True, I know the problem is how the inlets are treated in the padded image but I can't seem to get it to work, should be a quick fix for you