### PR TITLE
Fixes issue #131: chord length distribution error

### DIFF
--- a/porespy/filters/__funcs__.py
+++ b/porespy/filters/__funcs__.py
@@ -677,7 +677,7 @@ def region_size(im):
     Returns
     -------
     An ND array with each voxel value indicating the size of the region to
-    which is belongs.  This is particularly useful for finding chord sizes
+    which it belongs.  This is particularly useful for finding chord sizes
     on the image produced by ``apply_chords``.
     """
     if im.dtype == bool:

--- a/porespy/metrics/__funcs__.py
+++ b/porespy/metrics/__funcs__.py
@@ -443,8 +443,6 @@ def chord_counts(im):
     function is ``sp.bincount`` which gives the number of chords of each
     length in a format suitable for ``plt.plot``.
     """
-    if (im.dtype == bool) or (im.max() == 1):
-        raise Exception ('Image does not have chords')
     labels, N = spim.label(im > 0)
     props = regionprops(labels)
     chord_lens = sp.array([i.filled_area for i in props])

--- a/porespy/metrics/__funcs__.py
+++ b/porespy/metrics/__funcs__.py
@@ -443,7 +443,8 @@ def chord_counts(im):
     function is ``sp.bincount`` which gives the number of chords of each
     length in a format suitable for ``plt.plot``.
     """
-    
+    if (im.dtype == bool) or (im.max() == 1):
+        raise Exception ('Image does not have chords')
     labels, N = spim.label(im > 0)
     props = regionprops(labels)
     chord_lens = sp.array([i.filled_area for i in props])

--- a/porespy/metrics/__funcs__.py
+++ b/porespy/metrics/__funcs__.py
@@ -443,11 +443,8 @@ def chord_counts(im):
     function is ``sp.bincount`` which gives the number of chords of each
     length in a format suitable for ``plt.plot``.
     """
-    # Determine if image has been labelled as regions yet
-    if (im.dtype == bool) or (im.max() == 1):
-        labels, N = spim.label(im > 0)
-    else:
-        labels = im
+    
+    labels, N = spim.label(im > 0)
     props = regionprops(labels)
     chord_lens = sp.array([i.filled_area for i in props])
     return chord_lens


### PR DESCRIPTION
Addresses wrong chord lengths calculated by chord_counts when a 3D image with chords applied in all three principal axes is supplied. The error was due to the fact that chord_counts calculated chord lengths using labels associated with directions (1,2,3) rather than from labels associated with regions. 