### PR TITLE
Improve sphere generators

### DIFF
--- a/porespy/generators/__imgen__.py
+++ b/porespy/generators/__imgen__.py
@@ -437,7 +437,7 @@ def lattice_spheres(shape: List[int], radius: int, offset: int = 0,
 
 
 def overlapping_spheres(shape: List[int], radius: int, porosity: float,
-                        iter_max: int = 10, tol: float = 0.01):
+                        iter_max: int = 10, tol: float = 0.02):
     r"""
     Generate a packing of overlapping mono-disperse spheres
 

--- a/porespy/generators/__imgen__.py
+++ b/porespy/generators/__imgen__.py
@@ -484,12 +484,12 @@ def overlapping_spheres(shape: List[int], radius: int, porosity: float,
     N = int(sp.ceil((1 - porosity)*bulk_vol/s_vol))
     im = sp.random.random(size=shape)
 
-    # Newton's method for getting image porosity match the given
+    # Helper functions for calculating porosity: phi = g(f(N))
     f = lambda N: spim.distance_transform_edt(im > N/bulk_vol) < radius
     g = lambda im: 1 - im.sum() / sp.prod(shape)
-    # Perturbation in N for calculating df in Newton's algorithm
-    dN = int(0.04**im.ndim * bulk_vol)
-    w = 0.5  # Damping factor
+
+    # Newton's method for getting image porosity match the given
+    w, dN = 1.0, 25  # Damping factor, perturbation
     for i in range(iter_max):
         err = g(f(N)) - porosity
         d_err = (g(f(N+dN)) - g(f(N))) / dN

--- a/porespy/generators/__imgen__.py
+++ b/porespy/generators/__imgen__.py
@@ -488,11 +488,13 @@ def overlapping_spheres(shape: List[int], radius: int, porosity: float,
     f = lambda N: spim.distance_transform_edt(im > N/bulk_vol) < radius
     g = lambda im: 1 - im.sum() / sp.prod(shape)
     # Perturbation in N for calculating df in Newton's algorithm
-    dN = int(0.05**im.ndim * bulk_vol)
+    dN = int(0.025**im.ndim * bulk_vol)
     w = 0.5  # Damping factor
     for i in range(iter_max):
         err = g(f(N)) - porosity
         d_err = (g(f(N+dN)) - g(f(N))) / dN
+        if d_err == 0:
+            break
         if abs(err) <= tol:
             break
         N2 = N - int(err/d_err)   # xnew = xold - f/df

--- a/porespy/generators/__imgen__.py
+++ b/porespy/generators/__imgen__.py
@@ -183,7 +183,7 @@ def bundle_of_tubes(shape: List[int], spacing: int):
 
 
 def polydisperse_spheres(shape: List[int], porosity: float, dist,
-                         nbins: int = 5):
+                         nbins: int = 5, r_min: int = 5):
     r"""
     Create an image of randomly place, overlapping spheres with a distribution
     of radii.
@@ -224,12 +224,14 @@ def polydisperse_spheres(shape: List[int], porosity: float, dist,
     Rs = dist.interval(sp.linspace(0.05, 0.95, nbins))
     Rs = sp.vstack(Rs).T
     Rs = (Rs[:-1] + Rs[1:])/2
-    Rs = Rs.flatten()
-    phi = 1 - (1 - porosity)/(len(Rs))
+    Rs = sp.clip(Rs.flatten(), a_min=r_min, a_max=None)
+    phi_desired = 1 - (1 - porosity)/(len(Rs))
     im = sp.ones(shape, dtype=bool)
     for r in Rs:
-        temp = overlapping_spheres(shape=shape, radius=r, porosity=phi)
-        im = im*temp
+        phi_im = im.sum() / sp.prod(shape)
+        phi_corrected = 1 - (1 - phi_desired) / phi_im
+        temp = overlapping_spheres(shape=shape, radius=r, porosity=phi_corrected)
+        im = im * temp
     return im
 
 

--- a/porespy/generators/__imgen__.py
+++ b/porespy/generators/__imgen__.py
@@ -500,6 +500,18 @@ def overlapping_spheres(shape: List[int], radius: int, porosity: float,
         N2 = N - int(err/d_err)   # xnew = xold - f/df
         N = w * N2 + (1-w) * N
 
+    # # Bisection search: N is always undershoot (bc. of overlaps)
+    # N_low, N_high = N, 4*N
+    # for i in range(iter_max):
+    #     N = sp.mean([N_high, N_low], dtype=int)
+    #     err = g(f(N)) - porosity
+    #     if err > 0:
+    #         N_low = N
+    #     else:
+    #         N_high = N
+    #     if abs(err) <= tol:
+    #         break
+
     return ~f(N)
 
 

--- a/porespy/generators/__imgen__.py
+++ b/porespy/generators/__imgen__.py
@@ -25,7 +25,7 @@ def insert_shape(im, center, element, value=1):
         lower_el = sp.amax((lower_im - center[dim] + r, 0))
         upper_el = sp.amin((upper_im - center[dim] + r, element.shape[dim]))
         s_el.append(slice(lower_el, upper_el))
-    im[s_im] = im[s_im] + element[s_el]*value
+    im[tuple(s_im)] = im[tuple(s_im)] + element[tuple(s_el)]*value
     return im
 
 
@@ -167,7 +167,7 @@ def bundle_of_tubes(shape: List[int], spacing: int):
                              shape[1]-(spacing/2)-1,
                              shape[1]/spacing))
     Yi = sp.array(Yi, dtype=int)
-    temp[sp.meshgrid(Xi, Yi)] = 1
+    temp[tuple(sp.meshgrid(Xi, Yi))] = 1
     inds = sp.where(temp)
     for i in range(len(inds[0])):
         r = sp.random.randint(1, (spacing/2))
@@ -261,7 +261,7 @@ def voronoi_edges(shape: List[int], radius: int, ncells: int,
 
     """
     print(78*'―')
-    print('voronoi_edges: Generating', ncells, ' cells')
+    print('voronoi_edges: Generating', ncells, 'cells')
     shape = sp.array(shape)
     if sp.size(shape) == 1:
         shape = sp.full((3, ), int(shape))
@@ -288,7 +288,7 @@ def voronoi_edges(shape: List[int], radius: int, ncells: int,
         pts = vor.vertices[row].astype(int)
         if sp.all(pts >= 0) and sp.all(pts < im.shape):
             line_pts = line_segment(pts[0], pts[1])
-            im[line_pts] = True
+            im[tuple(line_pts)] = True
     im = spim.distance_transform_edt(~im) > radius
     return im
 

--- a/porespy/generators/__imgen__.py
+++ b/porespy/generators/__imgen__.py
@@ -437,7 +437,7 @@ def lattice_spheres(shape: List[int], radius: int, offset: int = 0,
 
 
 def overlapping_spheres(shape: List[int], radius: int, porosity: float,
-                        iter_max: int = 10, tol: float = 0.02):
+                        iter_max: int = 10, tol: float = 0.01):
     r"""
     Generate a packing of overlapping mono-disperse spheres
 
@@ -488,7 +488,7 @@ def overlapping_spheres(shape: List[int], radius: int, porosity: float,
     f = lambda N: spim.distance_transform_edt(im > N/bulk_vol) < radius
     g = lambda im: 1 - im.sum() / sp.prod(shape)
     # Perturbation in N for calculating df in Newton's algorithm
-    dN = int(0.025**im.ndim * bulk_vol)
+    dN = int(0.04**im.ndim * bulk_vol)
     w = 0.5  # Damping factor
     for i in range(iter_max):
         err = g(f(N)) - porosity

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,6 +7,7 @@ pep8ignore =
     E402  # Module level import not at top of file
     E226  # Space around arithmetic operators
 	W503  # Line break before binary operator
+	E731  # Avoid lambda expressions
 
 addopts =
     --doctest-modules

--- a/test/unit/test_generators.py
+++ b/test/unit/test_generators.py
@@ -38,18 +38,18 @@ class GeneratorTest():
     def test_overlapping_spheres_2d(self):
         phis = sp.arange(0.1, 0.9, 0.2)
         for phi in phis:
-            im = ps.generators.overlapping_spheres(shape=[101, 101], radius=6,
-                                                    porosity=phi)
+            im = ps.generators.overlapping_spheres(shape=[101, 101], radius=5,
+                                                   porosity=phi)
             phi_actual = im.sum() / sp.size(im)
-            assert abs(phi_actual - phi) < 0.01
+            assert abs(phi_actual - phi) < 0.02
 
     def test_overlapping_spheres_3d(self):
         phis = sp.arange(0.1, 0.9, 0.2)
         for phi in phis:
             im = ps.generators.overlapping_spheres(shape=[100, 100, 50],
-                                                    radius=8, porosity=phi)
+                                                   radius=8, porosity=phi)
             phi_actual = im.sum() / sp.size(im)
-            assert abs(phi_actual - phi) < 0.01
+            assert abs(phi_actual - phi) < 0.02
 
     def test_polydisperse_spheres(self):
         phis = sp.arange(0.1, 0.9, 0.2)
@@ -59,47 +59,47 @@ class GeneratorTest():
                                                     porosity=phi, dist=dist,
                                                     nbins=10)
             phi_actual = im.sum() / sp.size(im)
-            assert abs(phi_actual - phi) < 0.03
+            assert abs(phi_actual - phi) < 0.05
 
     def test_voronoi_edges(self):
         sp.random.seed(0)
         im = ps.generators.voronoi_edges(shape=[50, 50, 50],
-                                          radius=2,
-                                          ncells=25,
-                                          flat_faces=True)
+                                         radius=2,
+                                         ncells=25,
+                                         flat_faces=True)
         top_slice = im[:, :, 0]
         assert sp.sum(top_slice) == 1409
 
     def test_lattice_spheres_square(self):
         im = ps.generators.lattice_spheres(shape=[101, 101], radius=5,
-                                            offset=0, lattice='sc')
+                                           offset=0, lattice='sc')
         labels, N = spim.label(input=~im)
         assert N == 100
 
     def test_lattice_spheres_triangular(self):
         im = ps.generators.lattice_spheres(shape=[101, 101], radius=5,
-                                            lattice='triangular')
+                                           lattice='triangular')
         labels, N = spim.label(input=~im)
         assert N == 85
 
     def test_lattice_spheres_sc(self):
         im = ps.generators.lattice_spheres(shape=[101, 101, 101],
-                                            radius=4, offset=1,
-                                            lattice='sc')
+                                           radius=4, offset=1,
+                                           lattice='sc')
         labels, N = spim.label(input=~im)
         assert N == 1000
 
     def test_lattice_spheres_fcc(self):
         im = ps.generators.lattice_spheres(shape=[101, 101, 101],
-                                            radius=4, offset=2,
-                                            lattice='fcc')
+                                           radius=4, offset=2,
+                                           lattice='fcc')
         labels, N = spim.label(input=~im)
         assert N == 392
 
     def test_lattice_spheres_bcc(self):
         im = ps.generators.lattice_spheres(shape=[101, 101, 101],
-                                            radius=4, offset=2,
-                                            lattice='bcc')
+                                           radius=4, offset=2,
+                                           lattice='bcc')
         labels, N = spim.label(input=~im)
         assert N == 1024
 
@@ -138,7 +138,7 @@ class GeneratorTest():
     def test_RSA_mask_edge_2d(self):
         im = sp.zeros([100, 100], dtype=int)
         im = ps.generators.RSA(im, radius=10, volume_fraction=0.5,
-                                mode='contained')
+                               mode='contained')
         coords = sp.argwhere(im == 2)
         assert ~sp.any(coords < 10)
         assert ~sp.any(coords > 90)
@@ -146,7 +146,7 @@ class GeneratorTest():
     def test_RSA_mask_edge_3d(self):
         im = sp.zeros([50, 50, 50], dtype=int)
         im = ps.generators.RSA(im, radius=5, volume_fraction=0.5,
-                                mode='contained')
+                               mode='contained')
         coords = sp.argwhere(im == 2)
         assert ~sp.any(coords < 5)
         assert ~sp.any(coords > 45)

--- a/test/unit/test_generators.py
+++ b/test/unit/test_generators.py
@@ -9,7 +9,7 @@ plt.close('all')
 class GeneratorTest():
 
     def setup_class(self):
-        sp.random.seed(0)
+        sp.random.seed(10)
 
     def test_cylinders(self):
         X = 100
@@ -36,70 +36,70 @@ class GeneratorTest():
         assert N == 100
 
     def test_overlapping_spheres_2d(self):
-        im = ps.generators.overlapping_spheres(shape=[101, 101], radius=5,
-                                               porosity=0.5)
-        poro = sp.sum(im)/sp.size(im)
-        print(poro)
-        plt.figure()
-        plt.imshow(im[:, :])
-        assert (poro-0.5)**2 < 0.1
+        phis = sp.arange(0.1, 0.9, 0.2)
+        for phi in phis:
+            im = ps.generators.overlapping_spheres(shape=[101, 101], radius=6,
+                                                    porosity=phi)
+            phi_actual = im.sum() / sp.size(im)
+            assert abs(phi_actual - phi) < 0.01
 
     def test_overlapping_spheres_3d(self):
-        target = 0.5
-        im = ps.generators.overlapping_spheres(shape=[50, 50, 50], radius=5,
-                                               porosity=target)
-        poro = sp.sum(im)/sp.size(im)
-        assert (poro-target)**2 < 0.15
+        phis = sp.arange(0.1, 0.9, 0.2)
+        for phi in phis:
+            im = ps.generators.overlapping_spheres(shape=[100, 100, 50],
+                                                    radius=8, porosity=phi)
+            phi_actual = im.sum() / sp.size(im)
+            assert abs(phi_actual - phi) < 0.01
 
     def test_polydisperse_spheres(self):
-        target = 0.5
-        dist = sp.stats.norm(loc=5, scale=1)
-        im = ps.generators.polydisperse_spheres(shape=[50, 50, 50],
-                                                porosity=target,
-                                                dist=dist,
-                                                nbins=10)
-        poro = sp.sum(im)/sp.size(im)
-        assert (poro-target)**2 < 0.15
+        phis = sp.arange(0.1, 0.9, 0.2)
+        dist = sp.stats.norm(loc=7, scale=2)
+        for phi in phis:
+            im = ps.generators.polydisperse_spheres(shape=[100, 100, 50],
+                                                    porosity=phi, dist=dist,
+                                                    nbins=10)
+            phi_actual = im.sum() / sp.size(im)
+            assert abs(phi_actual - phi) < 0.03
 
     def test_voronoi_edges(self):
         sp.random.seed(0)
         im = ps.generators.voronoi_edges(shape=[50, 50, 50],
-                                         radius=2,
-                                         ncells=25,
-                                         flat_faces=True)
+                                          radius=2,
+                                          ncells=25,
+                                          flat_faces=True)
         top_slice = im[:, :, 0]
         assert sp.sum(top_slice) == 1409
 
     def test_lattice_spheres_square(self):
         im = ps.generators.lattice_spheres(shape=[101, 101], radius=5,
-                                           offset=0, lattice='sc')
+                                            offset=0, lattice='sc')
         labels, N = spim.label(input=~im)
         assert N == 100
 
     def test_lattice_spheres_triangular(self):
         im = ps.generators.lattice_spheres(shape=[101, 101], radius=5,
-                                           lattice='triangular')
+                                            lattice='triangular')
         labels, N = spim.label(input=~im)
         assert N == 85
 
     def test_lattice_spheres_sc(self):
         im = ps.generators.lattice_spheres(shape=[101, 101, 101],
-                                           radius=4, offset=1,
-                                           lattice='sc')
+                                            radius=4, offset=1,
+                                            lattice='sc')
         labels, N = spim.label(input=~im)
         assert N == 1000
 
     def test_lattice_spheres_fcc(self):
         im = ps.generators.lattice_spheres(shape=[101, 101, 101],
-                                           radius=4, offset=2,
-                                           lattice='fcc')
+                                            radius=4, offset=2,
+                                            lattice='fcc')
         labels, N = spim.label(input=~im)
         assert N == 392
 
     def test_lattice_spheres_bcc(self):
         im = ps.generators.lattice_spheres(shape=[101, 101, 101],
-                                           radius=4, offset=2,
-                                           lattice='bcc')
+                                            radius=4, offset=2,
+                                            lattice='bcc')
         labels, N = spim.label(input=~im)
         assert N == 1024
 
@@ -138,7 +138,7 @@ class GeneratorTest():
     def test_RSA_mask_edge_2d(self):
         im = sp.zeros([100, 100], dtype=int)
         im = ps.generators.RSA(im, radius=10, volume_fraction=0.5,
-                               mode='contained')
+                                mode='contained')
         coords = sp.argwhere(im == 2)
         assert ~sp.any(coords < 10)
         assert ~sp.any(coords > 90)
@@ -146,7 +146,7 @@ class GeneratorTest():
     def test_RSA_mask_edge_3d(self):
         im = sp.zeros([50, 50, 50], dtype=int)
         im = ps.generators.RSA(im, radius=5, volume_fraction=0.5,
-                               mode='contained')
+                                mode='contained')
         coords = sp.argwhere(im == 2)
         assert ~sp.any(coords < 5)
         assert ~sp.any(coords > 45)


### PR DESCRIPTION
This PR improves our sphere generators, i.e. `overlapping_spheres` and `polydisperse_spheres`. In the new approach, porosity of the generated image is closer to the desired value. Here's how the two approaches compare
![plot_old](https://user-images.githubusercontent.com/14086031/54299026-5e3a5880-4590-11e9-97be-340176ac3ca5.png)
Note that the main problem is generating low-porosity images, where the old approach is the most erroneous. I ran some stress tests and the porosity deviation was consistently below 2%.

The API is the same, except that I added two new arguments to `overlapping_spheres`:
- `iter_max`: maximum number of iterations allowed for converging to the desired porosity (default is 10)
- `tol`: acceptable tolerance for porosity (default is 0.02, i.e. 2% deviation in porosity)

Also, note that since the new approach is iterative, it's generally slower than the old approach, but you can override it by passing `iter_max=0` in case the desired porosity doesn't need to be precise.

I also made some changes to `polydisperse_spheres` and now the image porosity is accurate to 2%.

PS. The reason I made this PR is because I'm using these generators to generate hierarchical networks and so I needed the void fraction to be as accurate as possible for comparison between different structures.