### PR TITLE
Added two functions to tools module: size_to_seq and seq_to_satn

### DIFF
--- a/porespy/filters/__funcs__.py
+++ b/porespy/filters/__funcs__.py
@@ -1615,38 +1615,3 @@ def chunked_func(func, divs=2, cores=None, im_arg=['input', 'image', 'im'],
         # Insert image chunk into main image
         im2[a] = ims[i][b]
     return im2
-
-
-def seq_to_satn(seq, solid=0, uninvaded=-1):
-    r"""
-    Converts an image of invasion sequence values to saturation values.
-
-    Parameters
-    ----------
-    seq : ND-image
-        The image containing invasion sequence values in each voxel.
-        Note that the invasion steps must be positive integers, solid voxels
-        indicated by 0, and uninvaded voxels indicated by -1.
-
-    Returns
-    -------
-    satn : ND-image
-        An ND-iamge the same size as ``seq`` but with sequnece values replaced
-        by the fraction of pores invaded at or below the sequence number.
-        Solid voxels and uninvaded voxels are represented by 0 and -1
-        respectively.
-
-    """
-    seq = sp.copy(seq).astype(int)
-    solid = seq == 0
-    uninvaded = seq == -1
-    seq = sp.clip(seq, a_min=0, a_max=None)
-    seq = make_contiguous(seq)
-    b = sp.bincount(seq.flatten())
-    b[0] = 0
-    c = sp.cumsum(b)
-    satn = c[seq]/c.max()
-    satn *= 1 - solid.sum()/solid.size - uninvaded.sum()/solid.size
-    satn[solid] = 0.0
-    satn[uninvaded] = -1.0
-    return satn

--- a/porespy/filters/__init__.py
+++ b/porespy/filters/__init__.py
@@ -28,6 +28,7 @@ altered values.
     porespy.filters.prune_branches
     porespy.filters.reduce_peaks
     porespy.filters.region_size
+    porespy.filters.seq_to_satn
     porespy.filters.snow_partitioning
     porespy.filters.snow_partitioning_n
     porespy.filters.trim_disconnected_blobs
@@ -56,6 +57,7 @@ altered values.
 .. autofunction:: prune_branches
 .. autofunction:: reduce_peaks
 .. autofunction:: region_size
+.. autofunction:: seq_to_satn
 .. autofunction:: snow_partitioning
 .. autofunction:: snow_partitioning_n
 .. autofunction:: trim_disconnected_blobs
@@ -85,6 +87,7 @@ from .__funcs__ import porosimetry
 from .__funcs__ import prune_branches
 from .__funcs__ import reduce_peaks
 from .__funcs__ import region_size
+from .__funcs__ import seq_to_satn
 from .__funcs__ import snow_partitioning
 from .__funcs__ import snow_partitioning_n
 from .__funcs__ import trim_disconnected_blobs

--- a/porespy/filters/__init__.py
+++ b/porespy/filters/__init__.py
@@ -28,7 +28,6 @@ altered values.
     porespy.filters.prune_branches
     porespy.filters.reduce_peaks
     porespy.filters.region_size
-    porespy.filters.seq_to_satn
     porespy.filters.snow_partitioning
     porespy.filters.snow_partitioning_n
     porespy.filters.trim_disconnected_blobs
@@ -57,7 +56,6 @@ altered values.
 .. autofunction:: prune_branches
 .. autofunction:: reduce_peaks
 .. autofunction:: region_size
-.. autofunction:: seq_to_satn
 .. autofunction:: snow_partitioning
 .. autofunction:: snow_partitioning_n
 .. autofunction:: trim_disconnected_blobs
@@ -87,7 +85,6 @@ from .__funcs__ import porosimetry
 from .__funcs__ import prune_branches
 from .__funcs__ import reduce_peaks
 from .__funcs__ import region_size
-from .__funcs__ import seq_to_satn
 from .__funcs__ import snow_partitioning
 from .__funcs__ import snow_partitioning_n
 from .__funcs__ import trim_disconnected_blobs

--- a/porespy/tools/__funcs__.py
+++ b/porespy/tools/__funcs__.py
@@ -1126,7 +1126,36 @@ def extract_regions(regions, labels: list, trim=True):
     return im_new
 
 
-def seq_to_satn(seq, solid=0, uninvaded=-1):
+def size_to_seq(size):
+    r"""
+    Converts an image of invasion size values into sequence values.
+
+    This is meant to accept the output of the ``porosimetry`` function.
+
+    Parameters
+    ----------
+    size : ND-image
+        The image containing invasion size values in each voxel.
+
+    Returns
+    -------
+    sequence : ND-image
+        An ND-image the same shape as ``size`` with invasion size values
+        replaced by the invasion sequence.  This assumes that the invasion
+        process occurs via increasing pressure steps, such as produced by
+        the ``porosimetry`` function.
+
+    """
+    solid = size == 0
+    vals = sp.digitize(size,
+                       bins=range(0, sp.ceil(size.max()).astype(int)),
+                       right=True)
+    vals = -(vals - vals.max() - 1)*~solid
+    vals = make_contiguous(vals)
+    return vals
+
+
+def seq_to_satn(seq):
     r"""
     Converts an image of invasion sequence values to saturation values.
 

--- a/porespy/tools/__funcs__.py
+++ b/porespy/tools/__funcs__.py
@@ -1188,8 +1188,7 @@ def seq_to_satn(seq):
     b = sp.bincount(seq.flatten())
     b[0] = 0
     c = sp.cumsum(b)
-    satn = c[seq]/c.max()
-    satn *= 1 - solid.sum()/solid.size - uninvaded.sum()/solid.size
+    satn = c[seq]/((seq > 0).sum() + uninvaded.sum())
     satn[solid] = 0.0
     satn[uninvaded] = -1.0
     return satn

--- a/porespy/tools/__funcs__.py
+++ b/porespy/tools/__funcs__.py
@@ -1152,6 +1152,11 @@ def size_to_seq(size):
                        right=True)
     vals = -(vals - vals.max() - 1)*~solid
     vals = make_contiguous(vals)
+
+    # Possibly simpler way?
+    #    vals = (-(sizes - sizes.max())).astype(int) + 1
+    #    vals[vals > sizes.max()] = 0
+
     return vals
 
 

--- a/porespy/tools/__funcs__.py
+++ b/porespy/tools/__funcs__.py
@@ -1124,3 +1124,38 @@ def extract_regions(regions, labels: list, trim=True):
             bbox = bbox_to_slices([x_min, y_min, x_max, y_max])
         im_new = im_new[bbox]
     return im_new
+
+
+def seq_to_satn(seq, solid=0, uninvaded=-1):
+    r"""
+    Converts an image of invasion sequence values to saturation values.
+
+    Parameters
+    ----------
+    seq : ND-image
+        The image containing invasion sequence values in each voxel.
+        Note that the invasion steps must be positive integers, solid voxels
+        indicated by 0, and uninvaded voxels indicated by -1.
+
+    Returns
+    -------
+    satn : ND-image
+        An ND-iamge the same size as ``seq`` but with sequnece values replaced
+        by the fraction of pores invaded at or below the sequence number.
+        Solid voxels and uninvaded voxels are represented by 0 and -1
+        respectively.
+
+    """
+    seq = sp.copy(seq).astype(int)
+    solid = seq == 0
+    uninvaded = seq == -1
+    seq = sp.clip(seq, a_min=0, a_max=None)
+    seq = make_contiguous(seq)
+    b = sp.bincount(seq.flatten())
+    b[0] = 0
+    c = sp.cumsum(b)
+    satn = c[seq]/c.max()
+    satn *= 1 - solid.sum()/solid.size - uninvaded.sum()/solid.size
+    satn[solid] = 0.0
+    satn[uninvaded] = -1.0
+    return satn

--- a/porespy/tools/__init__.py
+++ b/porespy/tools/__init__.py
@@ -34,6 +34,7 @@ that do NOT return a modified version of the original image.
     porespy.tools.pad_faces
     porespy.tools.randomize_colors
     porespy.tools.seq_to_satn
+    porespy.tools.size_to_seq
     porespy.tools.subdivide
 
 .. autofunction:: align_image_with_openpnm
@@ -58,6 +59,7 @@ that do NOT return a modified version of the original image.
 .. autofunction:: pad_faces
 .. autofunction:: randomize_colors
 .. autofunction:: seq_to_satn
+.. autofunction:: size_to_seq
 .. autofunction:: subdivide
 
 '''
@@ -84,5 +86,6 @@ from .__funcs__ import randomize_colors
 from .__funcs__ import ps_disk
 from .__funcs__ import ps_ball
 from .__funcs__ import pad_faces
-from .__funcs__ import subdivide
 from .__funcs__ import seq_to_satn
+from .__funcs__ import size_to_seq
+from .__funcs__ import subdivide

--- a/porespy/tools/__init__.py
+++ b/porespy/tools/__init__.py
@@ -29,11 +29,12 @@ that do NOT return a modified version of the original image.
     porespy.tools.mesh_region
     porespy.tools.norm_to_uniform
     porespy.tools.overlay
-    porespy.tools.randomize_colors
-    porespy.tools.subdivide
     porespy.tools.ps_disk
     porespy.tools.ps_ball
     porespy.tools.pad_faces
+    porespy.tools.randomize_colors
+    porespy.tools.seq_to_satn
+    porespy.tools.subdivide
 
 .. autofunction:: align_image_with_openpnm
 .. autofunction:: bbox_to_slices
@@ -56,6 +57,7 @@ that do NOT return a modified version of the original image.
 .. autofunction:: ps_ball
 .. autofunction:: pad_faces
 .. autofunction:: randomize_colors
+.. autofunction:: seq_to_satn
 .. autofunction:: subdivide
 
 '''
@@ -83,3 +85,4 @@ from .__funcs__ import ps_disk
 from .__funcs__ import ps_ball
 from .__funcs__ import pad_faces
 from .__funcs__ import subdivide
+from .__funcs__ import seq_to_satn

--- a/test/unit/test_filters.py
+++ b/test/unit/test_filters.py
@@ -35,7 +35,7 @@ class FilterTest():
         steps = sp.unique(mip)
         ans = sp.array([0.00000000, 1.00000000, 1.37871571, 1.61887041,
                         1.90085700, 2.23196205, 2.62074139, 3.07724114,
-                        3.61325732, 4.24264069])
+                        3.61325732])
         assert sp.allclose(steps, ans)
 
     def test_porosimetry_compare_modes_3D(self):

--- a/test/unit/test_tools.py
+++ b/test/unit/test_tools.py
@@ -124,6 +124,29 @@ class ToolsTest():
         assert ims.shape == (2, 2)
         assert im[tuple(ims[0, 0])].sum() == sp.prod(im.shape)/4
 
+    def test_size_to_seq(self):
+        im = self.im2D
+        sz = ps.filters.porosimetry(im)
+        nsizes = sp.size(sp.unique(sp.around(sz, decimals=0)))
+        sq = ps.tools.size_to_seq(sz)
+        nsteps = sp.size(sp.unique(sq))
+        assert nsteps == nsizes
+
+    def test_seq_to_sat_fully_filled(self):
+        im = self.im2D
+        sz = ps.filters.porosimetry(im)
+        sq = ps.tools.size_to_seq(sz)
+        sat = ps.tools.seq_to_satn(sq)
+        assert sat.max() == 1
+
+    def test_seq_to_sat_partially_filled(self):
+        im = self.im2D
+        sz = ps.filters.porosimetry(im)
+        sq = ps.tools.size_to_seq(sz)
+        sq[sq == sq.max()] = -1
+        sat = ps.tools.seq_to_satn(sq)
+        assert sat.max() < 1
+
 
 if __name__ == '__main__':
     t = ToolsTest()


### PR DESCRIPTION
These two functions take an image of a drainage simulation, such as that returned by ``porosimetry``, and convert the size values to a contiguous sequence, and then a sequence to a saturation.  The images returned by these functions are easier to threshold and convert into an animation.