### PR TITLE
Convert sp.blah to np.blah throughout

### DIFF
--- a/porespy/__init__.py
+++ b/porespy/__init__.py
@@ -52,7 +52,7 @@ Create a test image (or load one using ``skimage.io.imread``)
 .. code-block:: python
 
     >>> import porespy as ps
-    >>> import scipy as sp
+    >>> import numpy as np
     >>> import scipy.ndimage as spim
     >>> np.random.seed(0)  # Set number generator for same image each time
     >>> im = ps.generators.blobs(shape=[250, 250])

--- a/porespy/__init__.py
+++ b/porespy/__init__.py
@@ -54,7 +54,7 @@ Create a test image (or load one using ``skimage.io.imread``)
     >>> import porespy as ps
     >>> import scipy as sp
     >>> import scipy.ndimage as spim
-    >>> sp.random.seed(0)  # Set number generator for same image each time
+    >>> np.random.seed(0)  # Set number generator for same image each time
     >>> im = ps.generators.blobs(shape=[250, 250])
 
 Apply a filter to the image using tools from ``scipy.ndimage``:

--- a/porespy/filters/__funcs__.py
+++ b/porespy/filters/__funcs__.py
@@ -117,28 +117,28 @@ def distance_transform_lin(im, axis=0, mode='both'):
                       ' Reduce dimensionality with np.squeeze(im) to avoid' +
                       ' unexpected behavior.')
     if mode in ['backward', 'reverse']:
-        im = sp.flip(im, axis)
+        im = np.flip(im, axis)
         im = distance_transform_lin(im=im, axis=axis, mode='forward')
-        im = sp.flip(im, axis)
+        im = np.flip(im, axis)
         return im
     elif mode in ['both']:
         im_f = distance_transform_lin(im=im, axis=axis, mode='forward')
         im_b = distance_transform_lin(im=im, axis=axis, mode='backward')
         return sp.minimum(im_f, im_b)
     else:
-        b = sp.cumsum(im > 0, axis=axis)
-        c = sp.diff(b*(im == 0), axis=axis)
-        d = sp.minimum.accumulate(c, axis=axis)
+        b = np.cumsum(im > 0, axis=axis)
+        c = np.diff(b*(im == 0), axis=axis)
+        d = np.minimum.accumulate(c, axis=axis)
         if im.ndim == 1:
-            e = sp.pad(d, pad_width=[1, 0], mode='constant', constant_values=0)
+            e = np.pad(d, pad_width=[1, 0], mode='constant', constant_values=0)
         elif im.ndim == 2:
             ax = [[[1, 0], [0, 0]], [[0, 0], [1, 0]]]
-            e = sp.pad(d, pad_width=ax[axis], mode='constant', constant_values=0)
+            e = np.pad(d, pad_width=ax[axis], mode='constant', constant_values=0)
         elif im.ndim == 3:
             ax = [[[1, 0], [0, 0], [0, 0]],
                   [[0, 0], [1, 0], [0, 0]],
                   [[0, 0], [0, 0], [1, 0]]]
-            e = sp.pad(d, pad_width=ax[axis], mode='constant', constant_values=0)
+            e = np.pad(d, pad_width=ax[axis], mode='constant', constant_values=0)
         f = im*(b + e)
         return f
 

--- a/porespy/filters/__funcs__.py
+++ b/porespy/filters/__funcs__.py
@@ -45,9 +45,9 @@ def trim_small_clusters(im, size=1):
         strel = ball(1)
     else:
         raise Exception('Only 2D or 3D images are accepted')
-    filtered_array = sp.copy(im)
+    filtered_array = np.copy(im)
     labels, N = spim.label(filtered_array, structure=strel)
-    id_sizes = sp.array(spim.sum(im, labels, range(N + 1)))
+    id_sizes = np.array(spim.sum(im, labels, range(N + 1)))
     area_mask = (id_sizes <= size)
     filtered_array[area_mask[labels]] = 0
     return filtered_array
@@ -124,7 +124,7 @@ def distance_transform_lin(im, axis=0, mode='both'):
     elif mode in ['both']:
         im_f = distance_transform_lin(im=im, axis=axis, mode='forward')
         im_b = distance_transform_lin(im=im, axis=axis, mode='backward')
-        return sp.minimum(im_f, im_b)
+        return np.minimum(im_f, im_b)
     else:
         b = np.cumsum(im > 0, axis=axis)
         c = np.diff(b*(im == 0), axis=axis)
@@ -211,16 +211,16 @@ def snow_partitioning(im, dt=None, r_max=4, sigma=0.4, return_all=False,
     tup = namedtuple('results', field_names=['im', 'dt', 'peaks', 'regions'])
     print('_'*60)
     print("Beginning SNOW Algorithm")
-    im_shape = sp.array(im.shape)
+    im_shape = np.array(im.shape)
     if im.dtype is not bool:
         print('Converting supplied image (im) to boolean')
         im = im > 0
     if dt is None:
         print('Peforming Distance Transform')
-        if sp.any(im_shape == 1):
-            ax = sp.where(im_shape == 1)[0][0]
+        if np.any(im_shape == 1):
+            ax = np.where(im_shape == 1)[0][0]
             dt = spim.distance_transform_edt(input=im.squeeze())
-            dt = sp.expand_dims(dt, ax)
+            dt = np.expand_dims(dt, ax)
         else:
             dt = spim.distance_transform_edt(input=im)
 
@@ -331,8 +331,8 @@ def snow_partitioning_n(im, r_max=4, sigma=0.4, return_all=True,
     # Get alias if provided by user
     al = _create_alias_map(im=im, alias=alias)
     # Perform snow on each phase and merge all segmentation and dt together
-    phases_num = sp.unique(im * 1)
-    phases_num = sp.trim_zeros(phases_num)
+    phases_num = np.unique(im * 1)
+    phases_num = np.trim_zeros(phases_num)
     combined_dt = 0
     combined_region = 0
     num = [0]
@@ -356,7 +356,7 @@ def snow_partitioning_n(im, r_max=4, sigma=0.4, return_all=True,
             phase_ws = phase_snow.regions * phase_snow.im
             phase_ws[phase_ws == num[i - 1]] = 0
             combined_region += phase_ws
-        num.append(sp.amax(combined_region))
+        num.append(np.amax(combined_region))
     if return_all:
         tup = namedtuple('results', field_names=['im', 'dt', 'phase_max_label',
                                                  'regions'])
@@ -452,10 +452,10 @@ def reduce_peaks(peaks):
     markers, N = spim.label(input=peaks, structure=strel(3))
     inds = spim.measurements.center_of_mass(input=peaks,
                                             labels=markers,
-                                            index=sp.arange(1, N+1))
-    inds = sp.floor(inds).astype(int)
+                                            index=np.arange(1, N+1))
+    inds = np.floor(inds).astype(int)
     # Centroid may not be on old pixel, so create a new peaks image
-    peaks_new = sp.zeros_like(peaks, dtype=bool)
+    peaks_new = np.zeros_like(peaks, dtype=bool)
     peaks_new[tuple(inds.T)] = True
     return peaks_new
 
@@ -493,7 +493,7 @@ def trim_saddle_points(peaks, dt, max_iters=10):
     using marker-based watershed segmenation".  Physical Review E. (2017)
 
     """
-    peaks = sp.copy(peaks)
+    peaks = np.copy(peaks)
     if dt.ndim == 2:
         from skimage.morphology import square as cube
     else:
@@ -506,16 +506,16 @@ def trim_saddle_points(peaks, dt, max_iters=10):
         dt_i = dt[s]
         im_i = dt_i > 0
         iters = 0
-        peaks_dil = sp.copy(peaks_i)
+        peaks_dil = np.copy(peaks_i)
         while iters < max_iters:
             iters += 1
             peaks_dil = spim.binary_dilation(input=peaks_dil,
                                              structure=cube(3))
-            peaks_max = peaks_dil*sp.amax(dt_i*peaks_dil)
+            peaks_max = peaks_dil*np.amax(dt_i*peaks_dil)
             peaks_extended = (peaks_max == dt_i)*im_i
-            if sp.all(peaks_extended == peaks_i):
+            if np.all(peaks_extended == peaks_i):
                 break  # Found a true peak
-            elif sp.sum(peaks_extended*peaks_i) == 0:
+            elif np.sum(peaks_extended*peaks_i) == 0:
                 peaks_i = False
                 break  # Found a saddle point
         peaks[s] = peaks_i
@@ -557,15 +557,15 @@ def trim_nearby_peaks(peaks, dt):
     [1] Gostick, J. "A versatile and efficient network extraction algorithm
     using marker-based watershed segmenation".  Physical Review E. (2017)
     """
-    peaks = sp.copy(peaks)
+    peaks = np.copy(peaks)
     if dt.ndim == 2:
         from skimage.morphology import square as cube
     else:
         from skimage.morphology import cube
     peaks, N = spim.label(peaks, structure=cube(3))
     crds = spim.measurements.center_of_mass(peaks, labels=peaks,
-                                            index=sp.arange(1, N+1))
-    crds = sp.vstack(crds).astype(int)  # Convert to numpy array of ints
+                                            index=np.arange(1, N+1))
+    crds = np.vstack(crds).astype(int)  # Convert to numpy array of ints
     # Get distance between each peak as a distance map
     tree = sptl.cKDTree(data=crds)
     temp = tree.query(x=crds, k=2)
@@ -573,7 +573,7 @@ def trim_nearby_peaks(peaks, dt):
     dist_to_neighbor = temp[0][:, 1]
     del temp, tree  # Free-up memory
     dist_to_solid = dt[tuple(crds.T)]  # Get distance to solid for each peak
-    hits = sp.where(dist_to_neighbor < dist_to_solid)[0]
+    hits = np.where(dist_to_neighbor < dist_to_solid)[0]
     # Drop peak that is closer to the solid than it's neighbor
     drop_peaks = []
     for peak in hits:
@@ -581,7 +581,7 @@ def trim_nearby_peaks(peaks, dt):
             drop_peaks.append(peak)
         else:
             drop_peaks.append(nearest_neighbor[peak])
-    drop_peaks = sp.unique(drop_peaks)
+    drop_peaks = np.unique(drop_peaks)
     # Remove peaks from image
     slices = spim.find_objects(input=peaks)
     for s in drop_peaks:
@@ -665,7 +665,7 @@ def fill_blind_pores(im, conn=None):
     find_disconnected_voxels
 
     """
-    im = sp.copy(im)
+    im = np.copy(im)
     holes = find_disconnected_voxels(im, conn=conn)
     im[holes] = False
     return im
@@ -694,7 +694,7 @@ def trim_floating_solid(im, conn=None):
     find_disconnected_voxels
 
     """
-    im = sp.copy(im)
+    im = np.copy(im)
     holes = find_disconnected_voxels(~im, conn=conn)
     im[holes] = True
     return im
@@ -748,7 +748,7 @@ def trim_nonpercolating_paths(im, inlet_axis=0, outlet_axis=0,
     im = trim_floating_solid(~im)
     labels = spim.label(~im)[0]
     if inlets is None:
-        inlets = sp.zeros_like(im, dtype=bool)
+        inlets = np.zeros_like(im, dtype=bool)
         if im.ndim == 3:
             if inlet_axis == 0:
                 inlets[0, :, :] = True
@@ -762,7 +762,7 @@ def trim_nonpercolating_paths(im, inlet_axis=0, outlet_axis=0,
             elif inlet_axis == 1:
                 inlets[:, 0] = True
     if outlets is None:
-        outlets = sp.zeros_like(im, dtype=bool)
+        outlets = np.zeros_like(im, dtype=bool)
         if im.ndim == 3:
             if outlet_axis == 0:
                 outlets[-1, :, :] = True
@@ -775,9 +775,9 @@ def trim_nonpercolating_paths(im, inlet_axis=0, outlet_axis=0,
                 outlets[-1, :] = True
             elif outlet_axis == 1:
                 outlets[:, -1] = True
-    IN = sp.unique(labels*inlets)
-    OUT = sp.unique(labels*outlets)
-    new_im = sp.isin(labels, list(set(IN) ^ set(OUT)), invert=True)
+    IN = np.unique(labels*inlets)
+    OUT = np.unique(labels*outlets)
+    new_im = np.isin(labels, list(set(IN) ^ set(OUT)), invert=True)
     im[new_im == 0] = True
     return ~im
 
@@ -862,7 +862,7 @@ def flood(im, regions=None, mode='max'):
     if regions is None:
         labels, N = spim.label(mask)
     else:
-        labels = sp.copy(regions)
+        labels = np.copy(regions)
         N = labels.max()
     mode = 'sum' if mode == 'size' else mode
     mode = 'maximum' if mode == 'max' else mode
@@ -901,12 +901,12 @@ def find_dt_artifacts(dt):
         the image.  Obviously, voxels with a value of zero have no error.
 
     """
-    temp = sp.ones(shape=dt.shape)*sp.inf
+    temp = np.ones(shape=dt.shape)*np.inf
     for ax in range(dt.ndim):
-        dt_lin = distance_transform_lin(sp.ones_like(temp, dtype=bool),
+        dt_lin = distance_transform_lin(np.ones_like(temp, dtype=bool),
                                         axis=ax, mode='both')
-        temp = sp.minimum(temp, dt_lin)
-    result = sp.clip(dt - temp, a_min=0, a_max=sp.inf)
+        temp = np.minimum(temp, dt_lin)
+    result = np.clip(dt - temp, a_min=0, a_max=np.inf)
     return result
 
 
@@ -931,7 +931,7 @@ def region_size(im):
     """
     if im.dtype == bool:
         im = spim.label(im)[0]
-    counts = sp.bincount(im.flatten())
+    counts = np.bincount(im.flatten())
     counts[0] = 0
     chords = counts[im]
     return chords
@@ -984,15 +984,15 @@ def apply_chords(im, spacing=1, axis=0, trim_edges=True, label=False):
         raise Exception('Spacing cannot be less than 0')
     if spacing == 0:
         label = True
-    result = sp.zeros(im.shape, dtype=int)  # Will receive chords at end
+    result = np.zeros(im.shape, dtype=int)  # Will receive chords at end
     slxyz = [slice(None, None, spacing*(axis != i) + 1) for i in [0, 1, 2]]
     slices = tuple(slxyz[:im.ndim])
     s = [[0, 1, 0], [0, 1, 0], [0, 1, 0]]  # Straight-line structuring element
     if im.ndim == 3:  # Make structuring element 3D if necessary
-        s = sp.pad(sp.atleast_3d(s), pad_width=((0, 0), (0, 0), (1, 1)),
+        s = np.pad(np.atleast_3d(s), pad_width=((0, 0), (0, 0), (1, 1)),
                    mode='constant', constant_values=0)
     im = im[slices]
-    s = sp.swapaxes(s, 0, axis)
+    s = np.swapaxes(s, 0, axis)
     chords = spim.label(im, structure=s)[0]
     if trim_edges:  # Label on border chords will be set to 0
         chords = clear_border(chords)
@@ -1047,7 +1047,7 @@ def apply_chords_3D(im, spacing=0, trim_edges=True):
         raise Exception('Must be a 3D image to use this function')
     if spacing < 0:
         raise Exception('Spacing cannot be less than 0')
-    ch = sp.zeros_like(im, dtype=int)
+    ch = np.zeros_like(im, dtype=int)
     ch[:, ::4+2*spacing, ::4+2*spacing] = 1  # X-direction
     ch[::4+2*spacing, :, 2::4+2*spacing] = 2  # Y-direction
     ch[2::4+2*spacing, 2::4+2*spacing, :] = 3  # Z-direction
@@ -1209,9 +1209,9 @@ def porosimetry(im, sizes=25, inlets=None, access_limited=True,
         inlets = get_border(im.shape, mode='faces')
 
     if isinstance(sizes, int):
-        sizes = sp.logspace(start=sp.log10(sp.amax(dt)), stop=0, num=sizes)
+        sizes = np.logspace(start=np.log10(np.amax(dt)), stop=0, num=sizes)
     else:
-        sizes = sp.unique(sizes)[-1::-1]
+        sizes = np.unique(sizes)[-1::-1]
 
     if im.ndim == 2:
         strel = ps_disk
@@ -1219,35 +1219,35 @@ def porosimetry(im, sizes=25, inlets=None, access_limited=True,
         strel = ps_ball
 
     if mode == 'mio':
-        pw = int(sp.floor(dt.max()))
-        impad = sp.pad(im, mode='symmetric', pad_width=pw)
-        inlets = sp.pad(inlets, mode='symmetric', pad_width=pw)
-#        sizes = sp.unique(sp.around(sizes, decimals=0).astype(int))[-1::-1]
-        imresults = sp.zeros(sp.shape(impad))
+        pw = int(np.floor(dt.max()))
+        impad = np.pad(im, mode='symmetric', pad_width=pw)
+        inlets = np.pad(inlets, mode='symmetric', pad_width=pw)
+#        sizes = np.unique(np.around(sizes, decimals=0).astype(int))[-1::-1]
+        imresults = np.zeros(np.shape(impad))
         for r in tqdm(sizes):
             imtemp = fftmorphology(impad, strel(r), mode='erosion')
             if access_limited:
                 imtemp = trim_disconnected_blobs(imtemp, inlets)
             imtemp = fftmorphology(imtemp, strel(r), mode='dilation')
-            if sp.any(imtemp):
+            if np.any(imtemp):
                 imresults[(imresults == 0)*imtemp] = r
         imresults = extract_subsection(imresults, shape=im.shape)
     elif mode == 'dt':
-        imresults = sp.zeros(sp.shape(im))
+        imresults = np.zeros(np.shape(im))
         for r in tqdm(sizes):
             imtemp = dt >= r
             if access_limited:
                 imtemp = trim_disconnected_blobs(imtemp, inlets)
-            if sp.any(imtemp):
+            if np.any(imtemp):
                 imtemp = spim.distance_transform_edt(~imtemp) < r
                 imresults[(imresults == 0)*imtemp] = r
     elif mode == 'hybrid':
-        imresults = sp.zeros(sp.shape(im))
+        imresults = np.zeros(np.shape(im))
         for r in tqdm(sizes):
             imtemp = dt >= r
             if access_limited:
                 imtemp = trim_disconnected_blobs(imtemp, inlets)
-            if sp.any(imtemp):
+            if np.any(imtemp):
                 imtemp = fftconvolve(imtemp, strel(r), mode='same') > 0.0001
                 imresults[(imresults == 0)*imtemp] = r
     else:
@@ -1281,8 +1281,8 @@ def trim_disconnected_blobs(im, inlets, strel=None):
         voxels not connected to the ``inlets`` removed.
     """
     if type(inlets) == tuple:
-        temp = sp.copy(inlets)
-        inlets = sp.zeros_like(im, dtype=bool)
+        temp = np.copy(inlets)
+        inlets = np.zeros_like(im, dtype=bool)
         inlets[temp] = True
     elif (inlets.shape == im.shape) and (inlets.max() == 1):
         inlets = inlets.astype(bool)
@@ -1294,12 +1294,12 @@ def trim_disconnected_blobs(im, inlets, strel=None):
     else:
         square = square
     labels = spim.label(inlets + (im > 0), structure=square(3))[0]
-    keep = sp.unique(labels[inlets])
+    keep = np.unique(labels[inlets])
     keep = keep[keep > 0]
     if len(keep) > 0:
-        im2 = sp.reshape(sp.in1d(labels, keep), newshape=im.shape)
+        im2 = np.reshape(np.in1d(labels, keep), newshape=im.shape)
     else:
-        im2 = sp.zeros_like(im)
+        im2 = np.zeros_like(im)
     im2 = im2*im
     return im2
 
@@ -1444,7 +1444,7 @@ def prune_branches(skel, branch_points=None, iterations=1):
     else:
         from skimage.morphology import cube
     # Create empty image to house results
-    im_result = sp.zeros_like(skel)
+    im_result = np.zeros_like(skel)
     # If branch points are not supplied, attempt to find them
     if branch_points is None:
         branch_points = spim.convolve(skel*1.0, weights=cube(3)) > 3
@@ -1466,17 +1466,17 @@ def prune_branches(skel, branch_points=None, iterations=1):
         # Find branch point labels the overlap current arc
         hits = pts_labels[s]*(arc_labels[s] == label_num)
         # If image contains 2 branch points, then it's not a tail.
-        if len(sp.unique(hits)) == 3:
+        if len(np.unique(hits)) == 3:
             im_result[s] += arc_labels[s] == label_num
     # Add missing branch points back to arc image to make complete skeleton
     im_result += skel*pts_orig
     if iterations > 1:
         iterations -= 1
-        im_temp = sp.copy(im_result)
+        im_temp = np.copy(im_result)
         im_result = prune_branches(skel=im_result,
                                    branch_points=None,
                                    iterations=iterations)
-        if sp.all(im_temp == im_result):
+        if np.all(im_temp == im_result):
             iterations = 0
     return im_result
 
@@ -1565,7 +1565,7 @@ def chunked_func(func, divs=2, cores=None, im_arg=['input', 'image', 'im'],
     ...                               structure=ball(3))
     Applying function to 8 subsections...
     >>> im3 = spim.binary_dilation(input=im, structure=ball(3))
-    >>> sp.all(im2 == im3)
+    >>> np.all(im2 == im3)
     True
 
     """
@@ -1589,14 +1589,14 @@ def chunked_func(func, divs=2, cores=None, im_arg=['input', 'image', 'im'],
             strel_arg = item
             break
     from array_split import shape_split, ARRAY_BOUNDS
-    divs = sp.ones((im.ndim, ), dtype=int)*sp.array(divs)
+    divs = np.ones((im.ndim, ), dtype=int)*np.array(divs)
     # This covers the possibility that strel was given as size, which is
     # possible in some ndimage functions
-    if sp.isscalar(strel):
+    if np.isscalar(strel):
         halo = strel*(divs > 1)
     else:
-        halo = sp.array(strel.shape) * (divs > 1)
-    slices = sp.ravel(shape_split(im.shape, axis=divs,
+        halo = np.array(strel.shape) * (divs > 1)
+    slices = np.ravel(shape_split(im.shape, axis=divs,
                                   halo=halo.tolist(),
                                   tile_bounds_policy=ARRAY_BOUNDS))
     # Apply func to each subsection of the image
@@ -1610,7 +1610,7 @@ def chunked_func(func, divs=2, cores=None, im_arg=['input', 'image', 'im'],
     with ProgressBar():
         ims = dask.compute(res, num_workers=cores)[0]
     # Finally, put the pieces back together into a single master image, im2
-    im2 = sp.zeros_like(im, dtype=im.dtype)
+    im2 = np.zeros_like(im, dtype=im.dtype)
     for i, s in enumerate(slices):
         # Prepare new slice objects into main and sub-sliced image
         a = []  # Slices into main image

--- a/porespy/filters/__funcs__.py
+++ b/porespy/filters/__funcs__.py
@@ -1,5 +1,4 @@
 from collections import namedtuple
-import scipy as sp
 import numpy as np
 import operator as op
 import scipy.ndimage as spim

--- a/porespy/generators/__imgen__.py
+++ b/porespy/generators/__imgen__.py
@@ -328,7 +328,7 @@ def voronoi_edges(shape: List[int], radius: int, ncells: int,
     if np.size(shape) == 1:
         shape = np.full((3, ), int(shape))
     im = np.zeros(shape, dtype=bool)
-    base_pts = np.rand(ncells, 3)*shape
+    base_pts = np.random.rand(ncells, 3)*shape
     if flat_faces:
         # Reflect base points
         Nx, Ny, Nz = shape
@@ -761,10 +761,10 @@ def cylinders(shape: List[int], radius: int, ncylinders: int,
     n = 0
     while n < ncylinders:
         # Choose a random starting point in domain
-        x = np.rand(3)*shape
+        x = np.random.rand(3)*shape
         # Chose a random phi and theta within given ranges
-        phi = (np.pi/2 - np.pi*np.rand())*phi_max/90
-        theta = (np.pi/2 - np.pi*np.rand())*theta_max/90
+        phi = (np.pi/2 - np.pi*np.random.rand())*phi_max/90
+        theta = (np.pi/2 - np.pi*np.random.rand())*theta_max/90
         X0 = R*np.array([np.cos(phi)*np.cos(theta),
                          np.cos(phi)*np.sin(theta),
                          np.sin(phi)])

--- a/porespy/generators/__imgen__.py
+++ b/porespy/generators/__imgen__.py
@@ -1,5 +1,5 @@
 import porespy as ps
-import scipy as sp
+import numpy as np
 import scipy.spatial as sptl
 import scipy.ndimage as spim
 from porespy.tools import norm_to_uniform, ps_ball, ps_disk
@@ -54,25 +54,25 @@ def insert_shape(im, element, center=None, corner=None, value=1,
     s_el = []
     if (center is not None) and (corner is None):
         for dim in range(im.ndim):
-            r, d = sp.divmod(element.shape[dim], 2)
+            r, d = np.divmod(element.shape[dim], 2)
             if d == 0:
                 raise Exception('Cannot specify center point when element ' +
                                 'has one or more even dimension')
-            lower_im = sp.amax((center[dim] - r, 0))
-            upper_im = sp.amin((center[dim] + r + 1, im.shape[dim]))
+            lower_im = np.amax((center[dim] - r, 0))
+            upper_im = np.amin((center[dim] + r + 1, im.shape[dim]))
             s_im.append(slice(lower_im, upper_im))
-            lower_el = sp.amax((lower_im - center[dim] + r, 0))
-            upper_el = sp.amin((upper_im - center[dim] + r,
+            lower_el = np.amax((lower_im - center[dim] + r, 0))
+            upper_el = np.amin((upper_im - center[dim] + r,
                                 element.shape[dim]))
             s_el.append(slice(lower_el, upper_el))
     elif (corner is not None) and (center is None):
         for dim in range(im.ndim):
             L = int(element.shape[dim])
-            lower_im = sp.amax((corner[dim], 0))
-            upper_im = sp.amin((corner[dim] + L, im.shape[dim]))
+            lower_im = np.amax((corner[dim], 0))
+            upper_im = np.amin((corner[dim] + L, im.shape[dim]))
             s_im.append(slice(lower_im, upper_im))
-            lower_el = sp.amax((lower_im - corner[dim], 0))
-            upper_el = sp.amin((upper_im - corner[dim],
+            lower_el = np.amax((lower_im - corner[dim], 0))
+            upper_el = np.amin((upper_im - corner[dim],
                                 element.shape[dim]))
             s_el.append(slice(min(lower_el, upper_el), upper_el))
     else:
@@ -152,13 +152,13 @@ def RSA(im: array, radius: int, volume_fraction: int = 1,
     else:
         im_strel = ps_ball(radius)
         mask_strel = ps_ball(mrad)
-    if sp.any(im > 0):
+    if np.any(im > 0):
         # Dilate existing objects by im_strel to remove pixels near them
         # from consideration for sphere placement
         mask = ps.tools.fftmorphology(im > 0, im_strel > 0, mode='dilate')
         mask = mask.astype(int)
     else:
-        mask = sp.zeros_like(im)
+        mask = np.zeros_like(im)
     if mode == 'contained':
         mask = _remove_edge(mask, radius)
     elif mode == 'extended':
@@ -168,10 +168,10 @@ def RSA(im: array, radius: int, volume_fraction: int = 1,
     else:
         raise Exception('Unrecognized mode: ' + mode)
     vf = im.sum()/im.size
-    free_spots = sp.argwhere(mask == 0)
+    free_spots = np.argwhere(mask == 0)
     i = 0
     while vf <= volume_fraction and len(free_spots) > 0:
-        choice = sp.random.randint(0, len(free_spots), size=1)
+        choice = np.random.randint(0, len(free_spots), size=1)
         if d2:
             [x, y] = free_spots[choice].flatten()
             im = _fit_strel_to_im_2d(im, im_strel, radius, x, y)
@@ -182,7 +182,7 @@ def RSA(im: array, radius: int, volume_fraction: int = 1,
             im = _fit_strel_to_im_3d(im, im_strel, radius, x, y, z)
             mask = _fit_strel_to_im_3d(mask, mask_strel, mrad, x, y, z)
             im[x, y, z] = 2
-        free_spots = sp.argwhere(mask == 0)
+        free_spots = np.argwhere(mask == 0)
         vf = im.sum()/im.size
         i += 1
     if vf > volume_fraction:
@@ -213,32 +213,32 @@ def bundle_of_tubes(shape: List[int], spacing: int):
     image : ND-array
         A boolean array with ``True`` values denoting the pore space
     """
-    shape = sp.array(shape)
-    if sp.size(shape) == 1:
-        shape = sp.full((3, ), int(shape))
-    if sp.size(shape) == 2:
-        shape = sp.hstack((shape, [1]))
-    temp = sp.zeros(shape=shape[:2])
-    Xi = sp.ceil(sp.linspace(spacing/2,
+    shape = np.array(shape)
+    if np.size(shape) == 1:
+        shape = np.full((3, ), int(shape))
+    if np.size(shape) == 2:
+        shape = np.hstack((shape, [1]))
+    temp = np.zeros(shape=shape[:2])
+    Xi = np.ceil(np.linspace(spacing/2,
                              shape[0]-(spacing/2)-1,
                              int(shape[0]/spacing)))
-    Xi = sp.array(Xi, dtype=int)
-    Yi = sp.ceil(sp.linspace(spacing/2,
+    Xi = np.array(Xi, dtype=int)
+    Yi = np.ceil(np.linspace(spacing/2,
                              shape[1]-(spacing/2)-1,
                              int(shape[1]/spacing)))
-    Yi = sp.array(Yi, dtype=int)
-    temp[tuple(sp.meshgrid(Xi, Yi))] = 1
-    inds = sp.where(temp)
+    Yi = np.array(Yi, dtype=int)
+    temp[tuple(np.meshgrid(Xi, Yi))] = 1
+    inds = np.where(temp)
     for i in range(len(inds[0])):
-        r = sp.random.randint(1, (spacing/2))
+        r = np.random.randint(1, (spacing/2))
         try:
             s1 = slice(inds[0][i]-r, inds[0][i]+r+1)
             s2 = slice(inds[1][i]-r, inds[1][i]+r+1)
             temp[s1, s2] = ps_disk(r)
         except ValueError:
-            odd_shape = sp.shape(temp[s1, s2])
+            odd_shape = np.shape(temp[s1, s2])
             temp[s1, s2] = ps_disk(r)[:odd_shape[0], :odd_shape[1]]
-    im = sp.broadcast_to(array=sp.atleast_3d(temp), shape=shape)
+    im = np.broadcast_to(array=np.atleast_3d(temp), shape=shape)
     return im
 
 
@@ -278,17 +278,17 @@ def polydisperse_spheres(shape: List[int], porosity: float, dist,
     image : ND-array
         A boolean array with ``True`` values denoting the pore space
     """
-    shape = sp.array(shape)
-    if sp.size(shape) == 1:
-        shape = sp.full((3, ), int(shape))
-    Rs = dist.interval(sp.linspace(0.05, 0.95, nbins))
-    Rs = sp.vstack(Rs).T
+    shape = np.array(shape)
+    if np.size(shape) == 1:
+        shape = np.full((3, ), int(shape))
+    Rs = dist.interval(np.linspace(0.05, 0.95, nbins))
+    Rs = np.vstack(Rs).T
     Rs = (Rs[:-1] + Rs[1:])/2
-    Rs = sp.clip(Rs.flatten(), a_min=r_min, a_max=None)
+    Rs = np.clip(Rs.flatten(), a_min=r_min, a_max=None)
     phi_desired = 1 - (1 - porosity)/(len(Rs))
-    im = sp.ones(shape, dtype=bool)
+    im = np.ones(shape, dtype=bool)
     for r in Rs:
-        phi_im = im.sum() / sp.prod(shape)
+        phi_im = im.sum() / np.prod(shape)
         phi_corrected = 1 - (1 - phi_desired) / phi_im
         temp = overlapping_spheres(shape=shape, radius=r, porosity=phi_corrected)
         im = im * temp
@@ -324,31 +324,31 @@ def voronoi_edges(shape: List[int], radius: int, ncells: int,
     """
     print(78*'―')
     print('voronoi_edges: Generating', ncells, 'cells')
-    shape = sp.array(shape)
-    if sp.size(shape) == 1:
-        shape = sp.full((3, ), int(shape))
-    im = sp.zeros(shape, dtype=bool)
-    base_pts = sp.rand(ncells, 3)*shape
+    shape = np.array(shape)
+    if np.size(shape) == 1:
+        shape = np.full((3, ), int(shape))
+    im = np.zeros(shape, dtype=bool)
+    base_pts = np.rand(ncells, 3)*shape
     if flat_faces:
         # Reflect base points
         Nx, Ny, Nz = shape
         orig_pts = base_pts
-        base_pts = sp.vstack((base_pts,
+        base_pts = np.vstack((base_pts,
                               [-1, 1, 1] * orig_pts + [2.0*Nx, 0, 0]))
-        base_pts = sp.vstack((base_pts,
+        base_pts = np.vstack((base_pts,
                               [1, -1, 1] * orig_pts + [0, 2.0*Ny, 0]))
-        base_pts = sp.vstack((base_pts,
+        base_pts = np.vstack((base_pts,
                               [1, 1, -1] * orig_pts + [0, 0, 2.0*Nz]))
-        base_pts = sp.vstack((base_pts, [-1, 1, 1] * orig_pts))
-        base_pts = sp.vstack((base_pts, [1, -1, 1] * orig_pts))
-        base_pts = sp.vstack((base_pts, [1, 1, -1] * orig_pts))
+        base_pts = np.vstack((base_pts, [-1, 1, 1] * orig_pts))
+        base_pts = np.vstack((base_pts, [1, -1, 1] * orig_pts))
+        base_pts = np.vstack((base_pts, [1, 1, -1] * orig_pts))
     vor = sptl.Voronoi(points=base_pts)
-    vor.vertices = sp.around(vor.vertices)
-    vor.vertices *= (sp.array(im.shape)-1) / sp.array(im.shape)
+    vor.vertices = np.around(vor.vertices)
+    vor.vertices *= (np.array(im.shape)-1) / np.array(im.shape)
     vor.edges = _get_Voronoi_edges(vor)
     for row in vor.edges:
         pts = vor.vertices[row].astype(int)
-        if sp.all(pts >= 0) and sp.all(pts < im.shape):
+        if np.all(pts >= 0) and np.all(pts < im.shape):
             line_pts = line_segment(pts[0], pts[1])
             im[tuple(line_pts)] = True
     im = spim.distance_transform_edt(~im) > radius
@@ -377,15 +377,15 @@ def _get_Voronoi_edges(vor):
         # Create a closed cycle of vertices that define the facet
         edges[0].extend(facet[:-1]+[facet[-1]])
         edges[1].extend(facet[1:]+[facet[0]])
-    edges = sp.vstack(edges).T  # Convert to scipy-friendly format
-    mask = sp.any(edges == -1, axis=1)  # Identify edges at infinity
+    edges = np.vstack(edges).T  # Convert to scipy-friendly format
+    mask = np.any(edges == -1, axis=1)  # Identify edges at infinity
     edges = edges[~mask]  # Remove edges at infinity
-    edges = sp.sort(edges, axis=1)  # Move all points to upper triangle
+    edges = np.sort(edges, axis=1)  # Move all points to upper triangle
     # Remove duplicate pairs
     edges = edges[:, 0] + 1j*edges[:, 1]  # Convert to imaginary
-    edges = sp.unique(edges)  # Remove duplicates
-    edges = sp.vstack((sp.real(edges), sp.imag(edges))).T  # Back to real
-    edges = sp.array(edges, dtype=int)
+    edges = np.unique(edges)  # Remove duplicates
+    edges = np.vstack((np.real(edges), np.imag(edges))).T  # Back to real
+    edges = np.array(edges, dtype=int)
     return edges
 
 
@@ -426,10 +426,10 @@ def lattice_spheres(shape: List[int], radius: int, offset: int = 0,
     print(78*'―')
     print('lattice_spheres: Generating ' + lattice + ' lattice')
     r = radius
-    shape = sp.array(shape)
-    if sp.size(shape) == 1:
-        shape = sp.full((3, ), int(shape))
-    im = sp.zeros(shape, dtype=bool)
+    shape = np.array(shape)
+    if np.size(shape) == 1:
+        shape = np.full((3, ), int(shape))
+    im = np.zeros(shape, dtype=bool)
     im = im.squeeze()
 
     # Parse lattice type
@@ -442,53 +442,53 @@ def lattice_spheres(shape: List[int], radius: int, offset: int = 0,
 
     if lattice in ['sq', 'square']:
         spacing = 2*r
-        s = int(spacing/2) + sp.array(offset)
-        coords = sp.mgrid[r:im.shape[0]-r:2*s,
+        s = int(spacing/2) + np.array(offset)
+        coords = np.mgrid[r:im.shape[0]-r:2*s,
                           r:im.shape[1]-r:2*s]
         im[coords[0], coords[1]] = 1
     elif lattice in ['tri', 'triangular']:
-        spacing = 2*sp.floor(sp.sqrt(2*(r**2))).astype(int)
+        spacing = 2*np.floor(np.sqrt(2*(r**2))).astype(int)
         s = int(spacing/2) + offset
-        coords = sp.mgrid[r:im.shape[0]-r:2*s,
+        coords = np.mgrid[r:im.shape[0]-r:2*s,
                           r:im.shape[1]-r:2*s]
         im[coords[0], coords[1]] = 1
-        coords = sp.mgrid[s+r:im.shape[0]-r:2*s,
+        coords = np.mgrid[s+r:im.shape[0]-r:2*s,
                           s+r:im.shape[1]-r:2*s]
         im[coords[0], coords[1]] = 1
     elif lattice in ['sc', 'simple cubic', 'cubic']:
         spacing = 2*r
-        s = int(spacing/2) + sp.array(offset)
-        coords = sp.mgrid[r:im.shape[0]-r:2*s,
+        s = int(spacing/2) + np.array(offset)
+        coords = np.mgrid[r:im.shape[0]-r:2*s,
                           r:im.shape[1]-r:2*s,
                           r:im.shape[2]-r:2*s]
         im[coords[0], coords[1], coords[2]] = 1
     elif lattice in ['bcc', 'body cenetered cubic']:
-        spacing = 2*sp.floor(sp.sqrt(4/3*(r**2))).astype(int)
+        spacing = 2*np.floor(np.sqrt(4/3*(r**2))).astype(int)
         s = int(spacing/2) + offset
-        coords = sp.mgrid[r:im.shape[0]-r:2*s,
+        coords = np.mgrid[r:im.shape[0]-r:2*s,
                           r:im.shape[1]-r:2*s,
                           r:im.shape[2]-r:2*s]
         im[coords[0], coords[1], coords[2]] = 1
-        coords = sp.mgrid[s+r:im.shape[0]-r:2*s,
+        coords = np.mgrid[s+r:im.shape[0]-r:2*s,
                           s+r:im.shape[1]-r:2*s,
                           s+r:im.shape[2]-r:2*s]
         im[coords[0], coords[1], coords[2]] = 1
     elif lattice in ['fcc', 'face centered cubic']:
-        spacing = 2*sp.floor(sp.sqrt(2*(r**2))).astype(int)
+        spacing = 2*np.floor(np.sqrt(2*(r**2))).astype(int)
         s = int(spacing/2) + offset
-        coords = sp.mgrid[r:im.shape[0]-r:2*s,
+        coords = np.mgrid[r:im.shape[0]-r:2*s,
                           r:im.shape[1]-r:2*s,
                           r:im.shape[2]-r:2*s]
         im[coords[0], coords[1], coords[2]] = 1
-        coords = sp.mgrid[r:im.shape[0]-r:2*s,
+        coords = np.mgrid[r:im.shape[0]-r:2*s,
                           s+r:im.shape[1]-r:2*s,
                           s+r:im.shape[2]-r:2*s]
         im[coords[0], coords[1], coords[2]] = 1
-        coords = sp.mgrid[s+r:im.shape[0]-r:2*s,
+        coords = np.mgrid[s+r:im.shape[0]-r:2*s,
                           s:im.shape[1]-r:2*s,
                           s+r:im.shape[2]-r:2*s]
         im[coords[0], coords[1], coords[2]] = 1
-        coords = sp.mgrid[s+r:im.shape[0]-r:2*s,
+        coords = np.mgrid[s+r:im.shape[0]-r:2*s,
                           s+r:im.shape[1]-r:2*s,
                           s:im.shape[2]-r:2*s]
         im[coords[0], coords[1], coords[2]] = 1
@@ -532,19 +532,19 @@ def overlapping_spheres(shape: List[int], radius: int, porosity: float,
     returned image.
 
     """
-    shape = sp.array(shape)
-    if sp.size(shape) == 1:
-        shape = sp.full((3, ), int(shape))
+    shape = np.array(shape)
+    if np.size(shape) == 1:
+        shape = np.full((3, ), int(shape))
     ndim = (shape != 1).sum()
     s_vol = ps_disk(radius).sum() if ndim == 2 else ps_ball(radius).sum()
 
-    bulk_vol = sp.prod(shape)
-    N = int(sp.ceil((1 - porosity)*bulk_vol/s_vol))
-    im = sp.random.random(size=shape)
+    bulk_vol = np.prod(shape)
+    N = int(np.ceil((1 - porosity)*bulk_vol/s_vol))
+    im = np.random.random(size=shape)
 
     # Helper functions for calculating porosity: phi = g(f(N))
     f = lambda N: spim.distance_transform_edt(im > N/bulk_vol) < radius
-    g = lambda im: 1 - im.sum() / sp.prod(shape)
+    g = lambda im: 1 - im.sum() / np.prod(shape)
 
     # # Newton's method for getting image porosity match the given
     # w = 1.0                         # Damping factor
@@ -562,7 +562,7 @@ def overlapping_spheres(shape: List[int], radius: int, porosity: float,
     # Bisection search: N is always undershoot (bc. of overlaps)
     N_low, N_high = N, 4*N
     for i in range(iter_max):
-        N = sp.mean([N_high, N_low], dtype=int)
+        N = np.mean([N_high, N_low], dtype=int)
         err = g(f(N)) - porosity
         if err > 0:
             N_low = N
@@ -627,9 +627,9 @@ def generate_noise(shape: List[int], porosity=None, octaves: int = 3,
         import noise
     except ModuleNotFoundError:
         raise Exception("The noise package must be installed")
-    shape = sp.array(shape)
-    if sp.size(shape) == 1:
-        Lx, Ly, Lz = sp.full((3, ), int(shape))
+    shape = np.array(shape)
+    if np.size(shape) == 1:
+        Lx, Ly, Lz = np.full((3, ), int(shape))
     elif len(shape) == 2:
         Lx, Ly = shape
         Lz = 1
@@ -639,14 +639,14 @@ def generate_noise(shape: List[int], porosity=None, octaves: int = 3,
         f = noise.snoise3
     else:
         f = noise.pnoise3
-    frequency = sp.atleast_1d(frequency)
+    frequency = np.atleast_1d(frequency)
     if frequency.size == 1:
-        freq = sp.full(shape=[3, ], fill_value=frequency[0])
+        freq = np.full(shape=[3, ], fill_value=frequency[0])
     elif frequency.size == 2:
-        freq = sp.concatenate((frequency, [1]))
+        freq = np.concatenate((frequency, [1]))
     else:
-        freq = sp.array(frequency)
-    im = sp.zeros(shape=[Lx, Ly, Lz], dtype=float)
+        freq = np.array(frequency)
+    im = np.zeros(shape=[Lx, Ly, Lz], dtype=float)
     for x in range(Lx):
         for y in range(Ly):
             for z in range(Lz):
@@ -690,12 +690,12 @@ def blobs(shape: List[int], porosity: float = 0.5, blobiness: int = 1):
     norm_to_uniform
 
     """
-    blobiness = sp.array(blobiness)
-    shape = sp.array(shape)
-    if sp.size(shape) == 1:
-        shape = sp.full((3, ), int(shape))
-    sigma = sp.mean(shape)/(40*blobiness)
-    im = sp.random.random(shape)
+    blobiness = np.array(blobiness)
+    shape = np.array(shape)
+    if np.size(shape) == 1:
+        shape = np.full((3, ), int(shape))
+    sigma = np.mean(shape)/(40*blobiness)
+    im = np.random.random(shape)
     im = spim.gaussian_filter(im, sigma=sigma)
     im = norm_to_uniform(im, scale=[0, 1])
     if porosity:
@@ -743,16 +743,16 @@ def cylinders(shape: List[int], radius: int, ncylinders: int,
     image : ND-array
         A boolean array with ``True`` values denoting the pore space
     """
-    shape = sp.array(shape)
-    if sp.size(shape) == 1:
-        shape = sp.full((3, ), int(shape))
-    elif sp.size(shape) == 2:
+    shape = np.array(shape)
+    if np.size(shape) == 1:
+        shape = np.full((3, ), int(shape))
+    elif np.size(shape) == 2:
         raise Exception("2D cylinders don't make sense")
     if length is None:
-        R = sp.sqrt(sp.sum(sp.square(shape))).astype(int)
+        R = np.sqrt(np.sum(np.square(shape))).astype(int)
     else:
         R = length/2
-    im = sp.zeros(shape)
+    im = np.zeros(shape)
     # Adjust max angles to be between 0 and 90
     if (phi_max > 90) or (phi_max < 0):
         raise Exception('phi_max must be betwen 0 and 90')
@@ -761,22 +761,22 @@ def cylinders(shape: List[int], radius: int, ncylinders: int,
     n = 0
     while n < ncylinders:
         # Choose a random starting point in domain
-        x = sp.rand(3)*shape
+        x = np.rand(3)*shape
         # Chose a random phi and theta within given ranges
-        phi = (sp.pi/2 - sp.pi*sp.rand())*phi_max/90
-        theta = (sp.pi/2 - sp.pi*sp.rand())*theta_max/90
-        X0 = R*sp.array([sp.cos(phi)*sp.cos(theta),
-                         sp.cos(phi)*sp.sin(theta),
-                         sp.sin(phi)])
+        phi = (np.pi/2 - np.pi*np.rand())*phi_max/90
+        theta = (np.pi/2 - np.pi*np.rand())*theta_max/90
+        X0 = R*np.array([np.cos(phi)*np.cos(theta),
+                         np.cos(phi)*np.sin(theta),
+                         np.sin(phi)])
         [X0, X1] = [x + X0, x - X0]
         crds = line_segment(X0, X1)
-        lower = ~sp.any(sp.vstack(crds).T < [0, 0, 0], axis=1)
-        upper = ~sp.any(sp.vstack(crds).T >= shape, axis=1)
+        lower = ~np.any(np.vstack(crds).T < [0, 0, 0], axis=1)
+        upper = ~np.any(np.vstack(crds).T >= shape, axis=1)
         valid = upper*lower
-        if sp.any(valid):
+        if np.any(valid):
             im[crds[0][valid], crds[1][valid], crds[2][valid]] = 1
             n += 1
-    im = sp.array(im, dtype=bool)
+    im = np.array(im, dtype=bool)
     dt = spim.distance_transform_edt(~im) < radius
     return ~dt
 
@@ -799,18 +799,18 @@ def line_segment(X0, X1):
         that should be drawn between the start and end points to create a solid
         line.
     """
-    X0 = sp.around(X0).astype(int)
-    X1 = sp.around(X1).astype(int)
+    X0 = np.around(X0).astype(int)
+    X1 = np.around(X1).astype(int)
     if len(X0) == 3:
-        L = sp.amax(sp.absolute([[X1[0]-X0[0]], [X1[1]-X0[1]], [X1[2]-X0[2]]])) + 1
-        x = sp.rint(sp.linspace(X0[0], X1[0], L)).astype(int)
-        y = sp.rint(sp.linspace(X0[1], X1[1], L)).astype(int)
-        z = sp.rint(sp.linspace(X0[2], X1[2], L)).astype(int)
+        L = np.amax(np.absolute([[X1[0]-X0[0]], [X1[1]-X0[1]], [X1[2]-X0[2]]])) + 1
+        x = np.rint(np.linspace(X0[0], X1[0], L)).astype(int)
+        y = np.rint(np.linspace(X0[1], X1[1], L)).astype(int)
+        z = np.rint(np.linspace(X0[2], X1[2], L)).astype(int)
         return [x, y, z]
     else:
-        L = sp.amax(sp.absolute([[X1[0]-X0[0]], [X1[1]-X0[1]]])) + 1
-        x = sp.rint(sp.linspace(X0[0], X1[0], L)).astype(int)
-        y = sp.rint(sp.linspace(X0[1], X1[1], L)).astype(int)
+        L = np.amax(np.absolute([[X1[0]-X0[0]], [X1[1]-X0[1]]])) + 1
+        x = np.rint(np.linspace(X0[0], X1[0], L)).astype(int)
+        y = np.rint(np.linspace(X0[1], X1[1], L)).astype(int)
         return [x, y]
 
 
@@ -890,7 +890,7 @@ def _remove_edge(im, r):
     Fill in the edges of the input image.
     Used by RSA to ensure that no elements are placed too close to the edge.
     '''
-    edge = sp.ones_like(im)
+    edge = np.ones_like(im)
     if len(im.shape) == 2:
         sx, sy = im.shape
         edge[r:sx-r, r:sy-r] = im[r:sx-r, r:sy-r]

--- a/porespy/metrics/__funcs__.py
+++ b/porespy/metrics/__funcs__.py
@@ -1,4 +1,3 @@
-import scipy as sp
 import numpy as np
 import warnings
 from skimage.measure import regionprops
@@ -52,21 +51,21 @@ def representative_elementary_volume(im, npoints=1000):
     (1987)
 
     """
-    im_temp = sp.zeros_like(im)
-    crds = sp.array(sp.rand(npoints, im.ndim)*im.shape, dtype=int)
-    pads = sp.array(sp.rand(npoints)*sp.amin(im.shape)/2+10, dtype=int)
+    im_temp = np.zeros_like(im)
+    crds = np.array(np.rand(npoints, im.ndim)*im.shape, dtype=int)
+    pads = np.array(np.rand(npoints)*np.amin(im.shape)/2+10, dtype=int)
     im_temp[tuple(crds.T)] = True
     labels, N = spim.label(input=im_temp)
     slices = spim.find_objects(input=labels)
-    porosity = sp.zeros(shape=(N,), dtype=float)
-    volume = sp.zeros(shape=(N,), dtype=int)
-    for i in tqdm(sp.arange(0, N)):
+    porosity = np.zeros(shape=(N,), dtype=float)
+    volume = np.zeros(shape=(N,), dtype=int)
+    for i in tqdm(np.arange(0, N)):
         s = slices[i]
         p = pads[i]
         new_s = extend_slice(s, shape=im.shape, pad=p)
         temp = im[new_s]
-        Vp = sp.sum(temp)
-        Vt = sp.size(temp)
+        Vp = np.sum(temp)
+        Vt = np.size(temp)
         porosity[i] = Vp/Vt
         volume[i] = Vt
     profile = namedtuple('profile', ('volume', 'porosity'))
@@ -182,7 +181,7 @@ def radial_density(im, bins=10, voxel_size=1):
     mask = find_dt_artifacts(im) == 0
     im[mask] = 0
     x = im[im > 0].flatten()
-    h = sp.histogram(x, bins=bins, density=True)
+    h = np.histogram(x, bins=bins, density=True)
     h = _parse_histogram(h=h, voxel_size=voxel_size)
     rdf = namedtuple('radial_density_function',
                      ('R', 'pdf', 'cdf', 'bin_centers', 'bin_edges',
@@ -226,9 +225,9 @@ def porosity(im):
     calculation of accessible porosity, rather than overall porosity.
 
     """
-    im = sp.array(im, dtype=int)
-    Vp = sp.sum(im == 1)
-    Vs = sp.sum(im == 0)
+    im = np.array(im, dtype=int)
+    Vp = np.sum(im == 1)
+    Vs = np.sum(im == 0)
     e = Vp/(Vs + Vp)
     return e
 
@@ -253,7 +252,7 @@ def two_point_correlation_bf(im, spacing=10):
         function.  The x array is the distances between points and the y array
         is corresponding probabilities that points of a given distance both
         lie in the void space. The distance values are binned as follows:
-        ``bins = range(start=0, stop=sp.amin(im.shape)/2, stride=spacing)``
+        ``bins = range(start=0, stop=np.amin(im.shape)/2, stride=spacing)``
 
     Notes
     -----
@@ -269,23 +268,23 @@ def two_point_correlation_bf(im, spacing=10):
                       + ' Reduce dimensionality with np.squeeze(im) to avoid'
                       + ' unexpected behavior.')
     if im.ndim == 2:
-        pts = sp.meshgrid(range(0, im.shape[0], spacing),
+        pts = np.meshgrid(range(0, im.shape[0], spacing),
                           range(0, im.shape[1], spacing))
-        crds = sp.vstack([pts[0].flatten(),
+        crds = np.vstack([pts[0].flatten(),
                           pts[1].flatten()]).T
     elif im.ndim == 3:
-        pts = sp.meshgrid(range(0, im.shape[0], spacing),
+        pts = np.meshgrid(range(0, im.shape[0], spacing),
                           range(0, im.shape[1], spacing),
                           range(0, im.shape[2], spacing))
-        crds = sp.vstack([pts[0].flatten(),
+        crds = np.vstack([pts[0].flatten(),
                           pts[1].flatten(),
                           pts[2].flatten()]).T
     dmat = sptl.distance.cdist(XA=crds, XB=crds)
     hits = im[tuple(pts)].flatten()
     dmat = dmat[hits, :]
-    h1 = sp.histogram(dmat, bins=range(0, int(sp.amin(im.shape)/2), spacing))
+    h1 = np.histogram(dmat, bins=range(0, int(np.amin(im.shape)/2), spacing))
     dmat = dmat[:, hits]
-    h2 = sp.histogram(dmat, bins=h1[1])
+    h2 = np.histogram(dmat, bins=h1[1])
     tpcf = namedtuple('two_point_correlation_function',
                       ('distance', 'probability'))
     return tpcf(h2[1][:-1], h2[0]/h1[0])
@@ -311,13 +310,13 @@ def _radial_profile(autocorr, r_max, nbins=100):
         and an array of ``counts`` in each bin.
     """
     if len(autocorr.shape) == 2:
-        adj = sp.reshape(autocorr.shape, [2, 1, 1])
-        inds = sp.indices(autocorr.shape) - adj/2
-        dt = sp.sqrt(inds[0]**2 + inds[1]**2)
+        adj = np.reshape(autocorr.shape, [2, 1, 1])
+        inds = np.indices(autocorr.shape) - adj/2
+        dt = np.sqrt(inds[0]**2 + inds[1]**2)
     elif len(autocorr.shape) == 3:
-        adj = sp.reshape(autocorr.shape, [3, 1, 1, 1])
-        inds = sp.indices(autocorr.shape) - adj/2
-        dt = sp.sqrt(inds[0]**2 + inds[1]**2 + inds[2]**2)
+        adj = np.reshape(autocorr.shape, [3, 1, 1, 1])
+        inds = np.indices(autocorr.shape) - adj/2
+        dt = np.sqrt(inds[0]**2 + inds[1]**2 + inds[2]**2)
     else:
         raise Exception('Image dimensions must be 2 or 3')
     bin_size = np.int(np.ceil(r_max/nbins))
@@ -364,9 +363,9 @@ def two_point_correlation_fft(im):
     # Fourier Transform and shift image
     F = sp_ft.ifftshift(sp_ft.fftn(sp_ft.fftshift(im)))
     # Compute Power Spectrum
-    P = sp.absolute(F**2)
+    P = np.absolute(F**2)
     # Auto-correlation is inverse of Power Spectrum
-    autoc = sp.absolute(sp_ft.ifftshift(sp_ft.ifftn(sp_ft.fftshift(P))))
+    autoc = np.absolute(sp_ft.ifftshift(sp_ft.ifftn(sp_ft.fftshift(P))))
     tpcf = _radial_profile(autoc, r_max=np.min(hls))
     return tpcf
 
@@ -428,8 +427,8 @@ def pore_size_distribution(im, bins=10, log=True, voxel_size=1):
     im = im.flatten()
     vals = im[im > 0]*voxel_size
     if log:
-        vals = sp.log10(vals)
-    h = _parse_histogram(sp.histogram(vals, bins=bins, density=True))
+        vals = np.log10(vals)
+    h = _parse_histogram(np.histogram(vals, bins=bins, density=True))
     psd = namedtuple('pore_size_distribution',
                      (log*'log' + 'R', 'pdf', 'cdf', 'satn',
                       'bin_centers', 'bin_edges', 'bin_widths'))
@@ -441,7 +440,7 @@ def _parse_histogram(h, voxel_size=1):
     delta_x = h[1]
     P = h[0]
     temp = P*(delta_x[1:] - delta_x[:-1])
-    C = sp.cumsum(temp[-1::-1])[-1::-1]
+    C = np.cumsum(temp[-1::-1])[-1::-1]
     S = P*(delta_x[1:] - delta_x[:-1])
     bin_edges = delta_x * voxel_size
     bin_widths = (delta_x[1:] - delta_x[:-1]) * voxel_size
@@ -469,13 +468,13 @@ def chord_counts(im):
     Notes
     ----
     The returned array can be passed to ``plt.hist`` to plot the histogram,
-    or to ``sp.histogram`` to get the histogram data directly. Another useful
-    function is ``sp.bincount`` which gives the number of chords of each
+    or to ``np.histogram`` to get the histogram data directly. Another useful
+    function is ``np.bincount`` which gives the number of chords of each
     length in a format suitable for ``plt.plot``.
     """
     labels, N = spim.label(im > 0)
     props = regionprops(labels)
-    chord_lens = sp.array([i.filled_area for i in props])
+    chord_lens = np.array([i.filled_area for i in props])
     return chord_lens
 
 
@@ -514,7 +513,7 @@ def linear_density(im, bins=25, voxel_size=1, log=False):
 
     """
     x = im[im > 0]
-    h = list(sp.histogram(x, bins=bins, density=True))
+    h = list(np.histogram(x, bins=bins, density=True))
     h = _parse_histogram(h=h, voxel_size=voxel_size)
     cld = namedtuple('linear_density_function',
                      ('L', 'pdf', 'cdf', 'relfreq',
@@ -595,16 +594,16 @@ def chord_length_distribution(im, bins=None, log=False, voxel_size=1,
     """
     x = chord_counts(im)
     if bins is None:
-        bins = sp.array(range(0, x.max()+2))*voxel_size
+        bins = np.array(range(0, x.max()+2))*voxel_size
     x = x*voxel_size
     if log:
-        x = sp.log10(x)
+        x = np.log10(x)
     if normalization == 'length':
-        h = list(sp.histogram(x, bins=bins, density=False))
+        h = list(np.histogram(x, bins=bins, density=False))
         h[0] = h[0]*(h[1][1:]+h[1][:-1])/2  # Scale bin heigths by length
         h[0] = h[0]/h[0].sum()/(h[1][1:]-h[1][:-1])  # Normalize h[0] manually
     elif normalization in ['number', 'count']:
-        h = sp.histogram(x, bins=bins, density=True)
+        h = np.histogram(x, bins=bins, density=True)
     else:
         raise Exception('Unsupported normalization:', normalization)
     h = _parse_histogram(h)
@@ -664,8 +663,8 @@ def region_interface_areas(regions, areas, voxel_size=1, strel=None):
     # Get 'slices' into im for each region
     slices = spim.find_objects(im)
     # Initialize arrays
-    Ps = sp.arange(1, sp.amax(im)+1)
-    sa = sp.zeros_like(Ps, dtype=float)
+    Ps = np.arange(1, np.amax(im)+1)
+    sa = np.zeros_like(Ps, dtype=float)
     sa_combined = []  # Difficult to preallocate since number of conns unknown
     cn = []
     # Start extracting area from im
@@ -679,7 +678,7 @@ def region_interface_areas(regions, areas, voxel_size=1, strel=None):
             im_w_throats = spim.binary_dilation(input=mask_im,
                                                 structure=ball_elem(1))
             im_w_throats = im_w_throats*sub_im
-            Pn = sp.unique(im_w_throats)[1:] - 1
+            Pn = np.unique(im_w_throats)[1:] - 1
             for j in Pn:
                 if j > reg:
                     cn.append([reg, j])
@@ -696,7 +695,7 @@ def region_interface_areas(regions, areas, voxel_size=1, strel=None):
                     mesh = mesh_region(region=merged_region, strel=strel)
                     sa_combined.append(mesh_surface_area(mesh))
     # Interfacial area calculation
-    cn = sp.array(cn)
+    cn = np.array(cn)
     ia = 0.5 * (sa[cn[:, 0]] + sa[cn[:, 1]] - sa_combined)
     ia[ia <= 0] = 1
     result = namedtuple('interfacial_areas', ('conns', 'area'))
@@ -741,8 +740,8 @@ def region_surface_areas(regions, voxel_size=1, strel=None):
     # Get 'slices' into im for each pore region
     slices = spim.find_objects(im)
     # Initialize arrays
-    Ps = sp.arange(1, sp.amax(im)+1)
-    sa = sp.zeros_like(Ps, dtype=float)
+    Ps = np.arange(1, np.amax(im)+1)
+    sa = np.zeros_like(Ps, dtype=float)
     # Start extracting marching cube area from im
     for i in tqdm(Ps):
         reg = i - 1
@@ -820,10 +819,10 @@ def phase_fraction(im, normed=True):
         im = im.astype(int)
     elif im.dtype != int:
         raise Exception('Image must contain integer values for each phase')
-    labels = sp.arange(0, sp.amax(im)+1)
-    results = sp.zeros_like(labels)
+    labels = np.arange(0, np.amax(im)+1)
+    results = np.zeros_like(labels)
     for i in labels:
-        results[i] = sp.sum(im == i)
+        results[i] = np.sum(im == i)
     if normed:
         results = results/im.size
     return results

--- a/porespy/metrics/__funcs__.py
+++ b/porespy/metrics/__funcs__.py
@@ -52,8 +52,8 @@ def representative_elementary_volume(im, npoints=1000):
 
     """
     im_temp = np.zeros_like(im)
-    crds = np.array(np.rand(npoints, im.ndim)*im.shape, dtype=int)
-    pads = np.array(np.rand(npoints)*np.amin(im.shape)/2+10, dtype=int)
+    crds = np.array(np.random.rand(npoints, im.ndim)*im.shape, dtype=int)
+    pads = np.array(np.random.rand(npoints)*np.amin(im.shape)/2+10, dtype=int)
     im_temp[tuple(crds.T)] = True
     labels, N = spim.label(input=im_temp)
     slices = spim.find_objects(input=labels)

--- a/porespy/metrics/__regionprops__.py
+++ b/porespy/metrics/__regionprops__.py
@@ -1,4 +1,4 @@
-import scipy as sp
+import numpy as np
 import scipy.ndimage as spim
 from tqdm import tqdm
 from porespy.tools import extract_subsection, bbox_to_slices
@@ -42,7 +42,7 @@ def props_to_DataFrame(regionprops):
     for item in reg.__dir__():
         if not item.startswith('_'):
             try:
-                if sp.shape(getattr(reg, item)) == ():
+                if np.shape(getattr(reg, item)) == ():
                     metrics.append(item)
             except (TypeError, NotImplementedError, AttributeError):
                 pass
@@ -50,7 +50,7 @@ def props_to_DataFrame(regionprops):
     d = {}
     for k in metrics:
         try:
-            d[k] = sp.array([r[k] for r in regionprops])
+            d[k] = np.array([r[k] for r in regionprops])
         except ValueError:
             print('Error encountered evaluating ' + k + ' so skipping it')
     # Create pandas data frame an return
@@ -90,7 +90,7 @@ def props_to_image(regionprops, shape, prop):
     regionprops_3d
 
     """
-    im = sp.zeros(shape=shape)
+    im = np.zeros(shape=shape)
     for r in regionprops:
         if prop == 'convex':
             mask = r.convex_image
@@ -182,10 +182,9 @@ def regionprops_3D(im):
     results = regionprops(im)
     for i in tqdm(range(len(results))):
         mask = results[i].image
-        mask_padded = sp.pad(mask, pad_width=1, mode='constant')
+        mask_padded = np.pad(mask, pad_width=1, mode='constant')
         temp = spim.distance_transform_edt(mask_padded)
         dt = extract_subsection(temp, shape=mask.shape)
-        # ---------------------------------------------------------------------
         # Slice indices
         results[i].slice = results[i]._slice
         # ---------------------------------------------------------------------
@@ -193,7 +192,7 @@ def regionprops_3D(im):
         results[i].volume = results[i].area
         # ---------------------------------------------------------------------
         # Volume of bounding box, in voxels
-        results[i].bbox_volume = sp.prod(mask.shape)
+        results[i].bbox_volume = np.prod(mask.shape)
         # ---------------------------------------------------------------------
         # Create an image of the border
         results[i].border = dt == 1
@@ -204,7 +203,7 @@ def regionprops_3D(im):
         results[i].inscribed_sphere = inv_dt < r
         # ---------------------------------------------------------------------
         # Find surface area using marching cubes and analyze the mesh
-        tmp = sp.pad(sp.atleast_3d(mask), pad_width=1, mode='constant')
+        tmp = np.pad(np.atleast_3d(mask), pad_width=1, mode='constant')
         tmp = spim.convolve(tmp, weights=ball(1))/5
         verts, faces, norms, vals = marching_cubes_lewiner(volume=tmp, level=0)
         results[i].surface_mesh_vertices = verts
@@ -214,8 +213,8 @@ def regionprops_3D(im):
         # ---------------------------------------------------------------------
         # Find sphericity
         vol = results[i].volume
-        r = (3/4/sp.pi*vol)**(1/3)
-        a_equiv = 4*sp.pi*(r)**2
+        r = (3/4/np.pi*vol)**(1/3)
+        a_equiv = 4*np.pi*(r)**2
         a_region = results[i].surface_area
         results[i].sphericity = a_equiv/a_region
         # ---------------------------------------------------------------------

--- a/porespy/networks/__snow__.py
+++ b/porespy/networks/__snow__.py
@@ -1,3 +1,4 @@
+import numpy as np
 from porespy.networks import regions_to_network, add_boundary_regions
 from porespy.networks import _net_dict
 from porespy.networks import label_boundary_cells
@@ -5,7 +6,6 @@ from porespy.tools import pad_faces
 from porespy.filters import snow_partitioning
 from porespy.tools import make_contiguous
 from porespy.metrics import region_surface_areas, region_interface_areas
-import scipy as sp
 
 
 def snow(im, voxel_size=1,
@@ -64,7 +64,7 @@ def snow(im, voxel_size=1,
     im = regions.im
     dt = regions.dt
     regions = regions.regions
-    b_num = sp.amax(regions)
+    b_num = np.amax(regions)
     # -------------------------------------------------------------------------
     # Boundary Conditions
     regions = add_boundary_regions(regions=regions, faces=boundary_faces)

--- a/porespy/networks/__snow_dual__.py
+++ b/porespy/networks/__snow_dual__.py
@@ -1,4 +1,4 @@
-import scipy as sp
+import numpy as np
 from porespy.networks import regions_to_network
 from porespy.networks import add_boundary_regions
 from porespy.networks import label_boundary_cells
@@ -12,7 +12,6 @@ def snow_dual(im,
               voxel_size=1,
               boundary_faces=['top', 'bottom', 'left', 'right', 'front', 'back'],
               marching_cubes_area=False):
-
     r"""
     Analyzes an image that has been partitioned into void and solid regions
     and extracts the void and solid phase geometry as well as network
@@ -88,11 +87,11 @@ def snow_dual(im,
     solid_regions = solid_regions.regions
     pore_region = pore_regions*im
     solid_region = solid_regions*~im
-    solid_num = sp.amax(pore_regions)
+    solid_num = np.amax(pore_regions)
     solid_region = solid_region + solid_num
     solid_region = solid_region * ~im
     regions = pore_region + solid_region
-    b_num = sp.amax(regions)
+    b_num = np.amax(regions)
     # -------------------------------------------------------------------------
     # Boundary Conditions
     regions = add_boundary_regions(regions=regions, faces=boundary_faces)
@@ -130,24 +129,24 @@ def snow_dual(im,
     solid_labels = ((net['pore.label'] > solid_num) * ~
                     (net['pore.label'] > b_num))
     boundary_labels = net['pore.label'] > b_num
-    b_sa = sp.zeros(len(boundary_labels[boundary_labels == 1.0]))
+    b_sa = np.zeros(len(boundary_labels[boundary_labels == 1.0]))
     # -------------------------------------------------------------------------
     # Calculates void interfacial area that connects with solid and vice versa
     p_conns = net['throat.conns'][:, 0][pore_solid_labels]
     ps = net['throat.area'][pore_solid_labels]
-    p_sa = sp.bincount(p_conns, ps)
+    p_sa = np.bincount(p_conns, ps)
     s_conns = net['throat.conns'][:, 1][pore_solid_labels]
-    s_pa = sp.bincount(s_conns, ps)
-    s_pa = sp.trim_zeros(s_pa)  # remove pore surface area labels
-    p_solid_surf = sp.concatenate((p_sa, s_pa, b_sa))
+    s_pa = np.bincount(s_conns, ps)
+    s_pa = np.trim_zeros(s_pa)  # remove pore surface area labels
+    p_solid_surf = np.concatenate((p_sa, s_pa, b_sa))
     # -------------------------------------------------------------------------
     # Calculates interfacial area using marching cube method
     if marching_cubes_area:
         ps_c = net['throat.area'][pore_solid_labels]
-        p_sa_c = sp.bincount(p_conns, ps_c)
-        s_pa_c = sp.bincount(s_conns, ps_c)
-        s_pa_c = sp.trim_zeros(s_pa_c)  # remove pore surface area labels
-        p_solid_surf = sp.concatenate((p_sa_c, s_pa_c, b_sa))
+        p_sa_c = np.bincount(p_conns, ps_c)
+        s_pa_c = np.bincount(s_conns, ps_c)
+        s_pa_c = np.trim_zeros(s_pa_c)  # remove pore surface area labels
+        p_solid_surf = np.concatenate((p_sa_c, s_pa_c, b_sa))
     # -------------------------------------------------------------------------
     # Adding additional information of dual network
     net['pore.solid_void_area'] = (p_solid_surf * voxel_size**2)

--- a/porespy/networks/__snow_n__.py
+++ b/porespy/networks/__snow_n__.py
@@ -1,4 +1,4 @@
-import scipy as sp
+import numpy as np
 from porespy.networks import regions_to_network
 from porespy.networks import label_boundary_cells
 from porespy.networks import add_boundary_regions
@@ -77,8 +77,8 @@ def snow_n(im,
     dt = pad_faces(im=snow.dt, faces=f)
     # -------------------------------------------------------------------------
     # For only one phase extraction with boundary regions
-    phases_num = sp.unique(im).astype(int)
-    phases_num = sp.trim_zeros(phases_num)
+    phases_num = np.unique(im).astype(int)
+    phases_num = np.trim_zeros(phases_num)
     if len(phases_num) == 1:
         if f is not None:
             snow.im = pad_faces(im=snow.im, faces=f)

--- a/porespy/tools/__funcs__.py
+++ b/porespy/tools/__funcs__.py
@@ -341,7 +341,7 @@ def extract_subsection(im, shape):
 
     Examples
     --------
-    >>> import scipy as sp
+    >>> import numpy as np
     >>> from porespy.tools import extract_subsection
     >>> im = np.array([[1, 1, 1, 1], [1, 2, 2, 2], [1, 2, 3, 3], [1, 2, 3, 4]])
     >>> print(im)
@@ -566,7 +566,7 @@ def make_contiguous(im, keep_zeros=True):
     Example
     -------
     >>> import porespy as ps
-    >>> import scipy as sp
+    >>> import numpy as np
     >>> im = np.array([[0, 2, 9], [6, 8, 3]])
     >>> im = ps.tools.make_contiguous(im)
     >>> print(im)
@@ -632,7 +632,6 @@ def get_border(shape, thickness=1, mode='edges', return_indices=False):
     Examples
     --------
     >>> import porespy as ps
-    >>> import scipy as sp
     >>> mask = ps.tools.get_border(shape=[3, 3], mode='corners')
     >>> print(mask)
     [[ True False  True]

--- a/porespy/tools/__funcs__.py
+++ b/porespy/tools/__funcs__.py
@@ -1,3 +1,4 @@
+import numpy as np
 import scipy as sp
 import scipy.ndimage as spim
 import warnings
@@ -29,12 +30,12 @@ def align_image_with_openpnm(im):
         warnings.warn('Input image conains a singleton axis:' + str(im.shape) +
                       ' Reduce dimensionality with np.squeeze(im) to avoid' +
                       ' unexpected behavior.')
-    im = sp.copy(im)
+    im = np.copy(im)
     if im.ndim == 2:
-        im = (sp.swapaxes(im, 1, 0))
+        im = (np.swapaxes(im, 1, 0))
         im = im[-1::-1, :]
     elif im.ndim == 3:
-        im = (sp.swapaxes(im, 2, 0))
+        im = (np.swapaxes(im, 2, 0))
         im = im[:, -1::-1, :]
     return im
 
@@ -117,7 +118,7 @@ def fftmorphology(im, strel, mode='opening'):
 
     # Perform erosion and dilation
     # The array must be padded with 0's so it works correctly at edges
-    temp = sp.pad(array=im, pad_width=1, mode='constant', constant_values=0)
+    temp = np.pad(array=im, pad_width=1, mode='constant', constant_values=0)
     if mode.startswith('ero'):
         temp = erode(temp, strel)
     if mode.startswith('dila'):
@@ -265,8 +266,8 @@ def find_outer_region(im, r=0):
     """
     if r == 0:
         dt = spim.distance_transform_edt(input=im)
-        r = int(sp.amax(dt)) * 2
-    im_padded = sp.pad(array=im, pad_width=r, mode='constant',
+        r = int(np.amax(dt)) * 2
+    im_padded = np.pad(array=im, pad_width=r, mode='constant',
                        constant_values=True)
     dt = spim.distance_transform_edt(input=im_padded)
     seeds = (dt >= r) + get_border(shape=im_padded.shape)
@@ -309,11 +310,11 @@ def extract_cylinder(im, r=None, axis=0):
     if r is None:
         a = list(im.shape)
         a.pop(axis)
-        r = sp.floor(sp.amin(a) / 2)
+        r = np.floor(np.amin(a) / 2)
     dim = [range(int(-s / 2), int(s / 2) + s % 2) for s in im.shape]
-    inds = sp.meshgrid(*dim, indexing='ij')
+    inds = np.meshgrid(*dim, indexing='ij')
     inds[axis] = inds[axis] * 0
-    d = sp.sqrt(sp.sum(sp.square(inds), axis=0))
+    d = np.sqrt(np.sum(np.square(inds), axis=0))
     mask = d < r
     im_temp = im*mask
     return im_temp
@@ -342,7 +343,7 @@ def extract_subsection(im, shape):
     --------
     >>> import scipy as sp
     >>> from porespy.tools import extract_subsection
-    >>> im = sp.array([[1, 1, 1, 1], [1, 2, 2, 2], [1, 2, 3, 3], [1, 2, 3, 4]])
+    >>> im = np.array([[1, 1, 1, 1], [1, 2, 2, 2], [1, 2, 3, 3], [1, 2, 3, 4]])
     >>> print(im)
     [[1 1 1 1]
      [1 2 2 2]
@@ -355,15 +356,15 @@ def extract_subsection(im, shape):
 
     """
     # Check if shape was given as a fraction
-    shape = sp.array(shape)
+    shape = np.array(shape)
     if shape[0] < 1:
-        shape = sp.array(im.shape) * shape
-    center = sp.array(im.shape) / 2
+        shape = np.array(im.shape) * shape
+    center = np.array(im.shape) / 2
     s_im = []
     for dim in range(im.ndim):
         r = shape[dim] / 2
-        lower_im = sp.amax((center[dim] - r, 0))
-        upper_im = sp.amin((center[dim] + r, im.shape[dim]))
+        lower_im = np.amax((center[dim] - r, 0))
+        upper_im = np.amin((center[dim] + r, im.shape[dim]))
         s_im.append(slice(int(lower_im), int(upper_im)))
     return im[tuple(s_im)]
 
@@ -388,15 +389,15 @@ def get_planes(im, squeeze=True):
     planes : list
         A list of 2D-images
     """
-    x, y, z = (sp.array(im.shape) / 2).astype(int)
+    x, y, z = (np.array(im.shape) / 2).astype(int)
     planes = [im[x, :, :], im[:, y, :], im[:, :, z]]
     if not squeeze:
         imx = planes[0]
-        planes[0] = sp.reshape(imx, [1, imx.shape[0], imx.shape[1]])
+        planes[0] = np.reshape(imx, [1, imx.shape[0], imx.shape[1]])
         imy = planes[1]
-        planes[1] = sp.reshape(imy, [imy.shape[0], 1, imy.shape[1]])
+        planes[1] = np.reshape(imy, [imy.shape[0], 1, imy.shape[1]])
         imz = planes[2]
-        planes[2] = sp.reshape(imz, [imz.shape[0], imz.shape[1], 1])
+        planes[2] = np.reshape(imz, [imz.shape[0], imz.shape[1], 1])
     return planes
 
 
@@ -431,7 +432,7 @@ def extend_slice(s, shape, pad=1):
     --------
     >>> from scipy.ndimage import label, find_objects
     >>> from porespy.tools import extend_slice
-    >>> im = sp.array([[1, 0, 0], [1, 0, 0], [0, 0, 1]])
+    >>> im = np.array([[1, 0, 0], [1, 0, 0], [0, 0, 1]])
     >>> labels = label(im)[0]
     >>> s = find_objects(labels)
 
@@ -504,9 +505,9 @@ def randomize_colors(im, keep_vals=[0]):
     Examples
     --------
     >>> import porespy as ps
-    >>> import scipy as sp
-    >>> sp.random.seed(0)
-    >>> im = sp.random.randint(low=0, high=5, size=[4, 4])
+    >>> import numpy as np
+    >>> np.random.seed(0)
+    >>> im = np.random.randint(low=0, high=5, size=[4, 4])
     >>> print(im)
     [[4 0 3 3]
      [3 1 3 2]
@@ -525,14 +526,14 @@ def randomize_colors(im, keep_vals=[0]):
 
     '''
     im_flat = im.flatten()
-    keep_vals = sp.array(keep_vals)
-    swap_vals = ~sp.in1d(im_flat, keep_vals)
-    im_vals = sp.unique(im_flat[swap_vals])
-    new_vals = sp.random.permutation(im_vals)
-    im_map = sp.zeros(shape=[sp.amax(im_vals) + 1, ], dtype=int)
+    keep_vals = np.array(keep_vals)
+    swap_vals = ~np.in1d(im_flat, keep_vals)
+    im_vals = np.unique(im_flat[swap_vals])
+    new_vals = np.random.permutation(im_vals)
+    im_map = np.zeros(shape=[np.amax(im_vals) + 1, ], dtype=int)
     im_map[im_vals] = new_vals
     im_new = im_map[im_flat]
-    im_new = sp.reshape(im_new, newshape=sp.shape(im))
+    im_new = np.reshape(im_new, newshape=np.shape(im))
     return im_new
 
 
@@ -566,25 +567,25 @@ def make_contiguous(im, keep_zeros=True):
     -------
     >>> import porespy as ps
     >>> import scipy as sp
-    >>> im = sp.array([[0, 2, 9], [6, 8, 3]])
+    >>> im = np.array([[0, 2, 9], [6, 8, 3]])
     >>> im = ps.tools.make_contiguous(im)
     >>> print(im)
     [[0 1 5]
      [3 4 2]]
 
     """
-    im = sp.copy(im)
+    im = np.copy(im)
     if keep_zeros:
         mask = (im == 0)
         im[mask] = im.min() - 1
     im = im - im.min()
     im_flat = im.flatten()
-    im_vals = sp.unique(im_flat)
-    im_map = sp.zeros(shape=sp.amax(im_flat) + 1)
-    im_map[im_vals] = sp.arange(0, sp.size(sp.unique(im_flat)))
+    im_vals = np.unique(im_flat)
+    im_map = np.zeros(shape=np.amax(im_flat) + 1)
+    im_map[im_vals] = np.arange(0, np.size(np.unique(im_flat)))
     im_new = im_map[im_flat]
-    im_new = sp.reshape(im_new, newshape=sp.shape(im))
-    im_new = sp.array(im_new, dtype=im_flat.dtype)
+    im_new = np.reshape(im_new, newshape=np.shape(im))
+    im_new = np.array(im_new, dtype=im_flat.dtype)
     return im_new
 
 
@@ -646,7 +647,7 @@ def get_border(shape, thickness=1, mode='edges', return_indices=False):
     """
     ndims = len(shape)
     t = thickness
-    border = sp.ones(shape, dtype=bool)
+    border = np.ones(shape, dtype=bool)
     if mode == 'faces':
         if ndims == 2:
             border[t:-t, t:-t] = False
@@ -668,7 +669,7 @@ def get_border(shape, thickness=1, mode='edges', return_indices=False):
             border[0::, t:-t, 0::] = False
             border[0::, 0::, t:-t] = False
     if return_indices:
-        border = sp.where(border)
+        border = np.where(border)
     return border
 
 
@@ -724,8 +725,8 @@ def norm_to_uniform(im, scale=None):
     """
     if scale is None:
         scale = [im.min(), im.max()]
-    im = (im - sp.mean(im)) / sp.std(im)
-    im = 1 / 2 * sp.special.erfc(-im / sp.sqrt(2))
+    im = (im - np.mean(im)) / np.std(im)
+    im = 1 / 2 * sp.special.erfc(-im / np.sqrt(2))
     im = (im - im.min()) / (im.max() - im.min())
     im = im * (scale[1] - scale[0]) + scale[0]
     return im
@@ -807,14 +808,14 @@ def mesh_region(region: bool, strel=None):
             strel = ball(1)
         if region.ndim == 2:
             strel = disk(1)
-    pad_width = sp.amax(strel.shape)
+    pad_width = np.amax(strel.shape)
     if im.ndim == 3:
-        padded_mask = sp.pad(im, pad_width=pad_width, mode='constant')
+        padded_mask = np.pad(im, pad_width=pad_width, mode='constant')
         padded_mask = spim.convolve(padded_mask * 1.0,
-                                    weights=strel) / sp.sum(strel)
+                                    weights=strel) / np.sum(strel)
     else:
-        padded_mask = sp.reshape(im, (1,) + im.shape)
-        padded_mask = sp.pad(padded_mask, pad_width=pad_width, mode='constant')
+        padded_mask = np.reshape(im, (1,) + im.shape)
+        padded_mask = np.pad(padded_mask, pad_width=pad_width, mode='constant')
     verts, faces, norm, val = marching_cubes_lewiner(padded_mask)
     result = namedtuple('mesh', ('verts', 'faces', 'norm', 'val'))
     result.verts = verts - pad_width
@@ -838,8 +839,8 @@ def ps_disk(radius):
     strel : 2D-array
         A 2D numpy bool array of the structring element
     """
-    rad = int(sp.ceil(radius))
-    other = sp.ones((2 * rad + 1, 2 * rad + 1), dtype=bool)
+    rad = int(np.ceil(radius))
+    other = np.ones((2 * rad + 1, 2 * rad + 1), dtype=bool)
     other[rad, rad] = False
     disk = spim.distance_transform_edt(other) < radius
     return disk
@@ -859,8 +860,8 @@ def ps_ball(radius):
     strel : 3D-array
         A 3D numpy array of the structuring element
     """
-    rad = int(sp.ceil(radius))
-    other = sp.ones((2 * rad + 1, 2 * rad + 1, 2 * rad + 1), dtype=bool)
+    rad = int(np.ceil(radius))
+    other = np.ones((2 * rad + 1, 2 * rad + 1, 2 * rad + 1), dtype=bool)
     other[rad, rad, rad] = False
     ball = spim.distance_transform_edt(other) < radius
     return ball
@@ -918,17 +919,17 @@ def insert_sphere(im, c, r):
     image : ND-array
         The original image with a sphere inerted at the specified location
     """
-    c = sp.array(c, dtype=int)
+    c = np.array(c, dtype=int)
     if c.size != im.ndim:
         raise Exception('Coordinates do not match dimensionality of image')
 
     bbox = []
-    [bbox.append(sp.clip(c[i] - r, 0, im.shape[i])) for i in range(im.ndim)]
-    [bbox.append(sp.clip(c[i] + r, 0, im.shape[i])) for i in range(im.ndim)]
-    bbox = sp.ravel(bbox)
+    [bbox.append(np.clip(c[i] - r, 0, im.shape[i])) for i in range(im.ndim)]
+    [bbox.append(np.clip(c[i] + r, 0, im.shape[i])) for i in range(im.ndim)]
+    bbox = np.ravel(bbox)
     s = bbox_to_slices(bbox)
     temp = im[s]
-    blank = sp.ones_like(temp)
+    blank = np.ones_like(temp)
     blank[tuple(c - bbox[0:im.ndim])] = 0
     blank = spim.distance_transform_edt(blank) < r
     im[s] = blank
@@ -961,22 +962,22 @@ def insert_cylinder(im, xyz0, xyz1, r):
     if im.ndim != 3:
         raise Exception('This function is only implemented for 3D images')
     # Converting coordinates to numpy array
-    xyz0, xyz1 = [sp.array(xyz).astype(int) for xyz in (xyz0, xyz1)]
+    xyz0, xyz1 = [np.array(xyz).astype(int) for xyz in (xyz0, xyz1)]
     r = int(r)
-    L = sp.absolute(xyz0 - xyz1).max() + 1
-    xyz_line = [sp.linspace(xyz0[i], xyz1[i], L).astype(int) for i in range(3)]
+    L = np.absolute(xyz0 - xyz1).max() + 1
+    xyz_line = [np.linspace(xyz0[i], xyz1[i], L).astype(int) for i in range(3)]
 
-    xyz_min = sp.amin(xyz_line, axis=1) - r
-    xyz_max = sp.amax(xyz_line, axis=1) + r
+    xyz_min = np.amin(xyz_line, axis=1) - r
+    xyz_max = np.amax(xyz_line, axis=1) + r
     shape_template = xyz_max - xyz_min + 1
-    template = sp.zeros(shape=shape_template)
+    template = np.zeros(shape=shape_template)
 
     # Shortcut for orthogonal cylinders
     if (xyz0 == xyz1).sum() == 2:
         unique_dim = [xyz0[i] != xyz1[i] for i in range(3)].index(True)
         shape_template[unique_dim] = 1
         template_2D = disk(radius=r).reshape(shape_template)
-        template = sp.repeat(template_2D, repeats=L, axis=unique_dim)
+        template = np.repeat(template_2D, repeats=L, axis=unique_dim)
         xyz_min[unique_dim] += r
         xyz_max[unique_dim] += -r
     else:
@@ -1036,7 +1037,7 @@ def pad_faces(im, faces):
             faces = [(int('left' in f) * 3, int('right' in f) * 3),
                      (int('front' in f) * 3, int('back' in f) * 3),
                      (int('top' in f) * 3, int('bottom' in f) * 3)]
-        im = sp.pad(im, pad_width=faces, mode='edge')
+        im = np.pad(im, pad_width=faces, mode='edge')
     else:
         im = im
     return im
@@ -1069,14 +1070,14 @@ def _create_alias_map(im, alias=None):
     """
     # -------------------------------------------------------------------------
     # Get alias if provided by user
-    phases_num = sp.unique(im * 1)
-    phases_num = sp.trim_zeros(phases_num)
+    phases_num = np.unique(im * 1)
+    phases_num = np.trim_zeros(phases_num)
     al = {}
     for values in phases_num:
         al[values] = 'phase{}'.format(values)
     if alias is not None:
         alias_sort = dict(sorted(alias.items()))
-        phase_labels = sp.array([*alias_sort])
+        phase_labels = np.array([*alias_sort])
         al = alias
         if set(phase_labels) != set(phases_num):
             raise Exception('Alias labels does not match with image labels '
@@ -1108,8 +1109,8 @@ def extract_regions(regions, labels: list, trim=True):
     if type(labels) is int:
         labels = [labels]
     s = spim.find_objects(regions)
-    im_new = sp.zeros_like(regions)
-    x_min, y_min, z_min = sp.inf, sp.inf, sp.inf
+    im_new = np.zeros_like(regions)
+    x_min, y_min, z_min = np.inf, np.inf, np.inf
     x_max, y_max, z_max = 0, 0, 0
     for i in labels:
         im_new[s[i-1]] = regions[s[i-1]] == i
@@ -1147,8 +1148,8 @@ def size_to_seq(size):
 
     """
     solid = size == 0
-    vals = sp.digitize(size,
-                       bins=range(0, sp.ceil(size.max()).astype(int)),
+    vals = np.digitize(size,
+                       bins=range(0, np.ceil(size.max()).astype(int)),
                        right=True)
     vals = -(vals - vals.max() - 1)*~solid
     vals = make_contiguous(vals)
@@ -1180,14 +1181,14 @@ def seq_to_satn(seq):
         respectively.
 
     """
-    seq = sp.copy(seq).astype(int)
+    seq = np.copy(seq).astype(int)
     solid = seq == 0
     uninvaded = seq == -1
-    seq = sp.clip(seq, a_min=0, a_max=None)
+    seq = np.clip(seq, a_min=0, a_max=None)
     seq = make_contiguous(seq)
-    b = sp.bincount(seq.flatten())
+    b = np.bincount(seq.flatten())
     b[0] = 0
-    c = sp.cumsum(b)
+    c = np.cumsum(b)
     satn = c[seq]/((seq > 0).sum() + uninvaded.sum())
     satn[solid] = 0.0
     satn[uninvaded] = -1.0

--- a/porespy/visualization/__plots__.py
+++ b/porespy/visualization/__plots__.py
@@ -1,4 +1,4 @@
-import scipy as sp
+import numpy as np
 import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d.art3d import Poly3DCollection
 
@@ -18,8 +18,8 @@ def show_mesh(mesh):
     fig : Matplotlib figure
         A handle to a matplotlib 3D axis
     """
-    lim_max = sp.amax(mesh.verts, axis=0)
-    lim_min = sp.amin(mesh.verts, axis=0)
+    lim_max = np.amax(mesh.verts, axis=0)
+    lim_min = np.amin(mesh.verts, axis=0)
 
     # Display resulting triangular mesh using Matplotlib.
     fig = plt.figure()

--- a/porespy/visualization/__views__.py
+++ b/porespy/visualization/__views__.py
@@ -1,4 +1,4 @@
-import scipy as sp
+import numpy as np
 import scipy.ndimage as spim
 # import matplotlib.pyplot as plt
 # from mpl_toolkits.mplot3d.art3d import Poly3DCollection
@@ -27,14 +27,14 @@ def show_3D(im):
     so inverts the image to show the solid material.
 
     """
-    im = ~sp.copy(im)
+    im = ~np.copy(im)
     if im.ndim < 3:
         raise Exception('show_3D only applies to 3D images')
     im = spim.rotate(input=im, angle=22.5, axes=[0, 1], order=0)
     im = spim.rotate(input=im, angle=45, axes=[2, 1], order=0)
     im = spim.rotate(input=im, angle=-17, axes=[0, 1], order=0, reshape=False)
     mask = im != 0
-    view = sp.where(mask.any(axis=2), mask.argmax(axis=2), 0)
+    view = np.where(mask.any(axis=2), mask.argmax(axis=2), 0)
     view = view.max() - view
     f = view.max()/5
     view[view == view.max()] = -f
@@ -58,18 +58,18 @@ def show_planes(im):
         ``matplotlib.pyplot.imshow``.
 
     """
-    if sp.squeeze(im.ndim) < 3:
+    if np.squeeze(im.ndim) < 3:
         raise Exception('This view is only necessary for 3D images')
-    x, y, z = (sp.array(im.shape)/2).astype(int)
+    x, y, z = (np.array(im.shape)/2).astype(int)
     im_xy = im[:, :, z]
     im_xz = im[:, y, :]
-    im_yz = sp.rot90(im[x, :, :])
+    im_yz = np.rot90(im[x, :, :])
 
     new_x = im_xy.shape[0] + im_yz.shape[0] + 10
 
     new_y = im_xy.shape[1] + im_xz.shape[1] + 10
 
-    new_im = sp.zeros([new_x + 20, new_y + 20], dtype=im.dtype)
+    new_im = np.zeros([new_x + 20, new_y + 20], dtype=im.dtype)
 
     # Add xy image to upper left corner
     new_im[10:im_xy.shape[0]+10,
@@ -107,15 +107,15 @@ def sem(im, direction='X'):
         A 2D greyscale image suitable for use in matplotlib\'s ```imshow```
         function.
     """
-    im = sp.array(~im, dtype=int)
+    im = np.array(~im, dtype=int)
     if direction in ['Y', 'y']:
-        im = sp.transpose(im, axes=[1, 0, 2])
+        im = np.transpose(im, axes=[1, 0, 2])
     if direction in ['Z', 'z']:
-        im = sp.transpose(im, axes=[2, 1, 0])
+        im = np.transpose(im, axes=[2, 1, 0])
     t = im.shape[0]
-    depth = sp.reshape(sp.arange(0, t), [t, 1, 1])
+    depth = np.reshape(np.arange(0, t), [t, 1, 1])
     im = im*depth
-    im = sp.amax(im, axis=0)
+    im = np.amax(im, axis=0)
     return im
 
 
@@ -142,10 +142,10 @@ def xray(im, direction='X'):
         A 2D greyscale image suitable for use in matplotlib\'s ```imshow```
         function.
     """
-    im = sp.array(~im, dtype=int)
+    im = np.array(~im, dtype=int)
     if direction in ['Y', 'y']:
-        im = sp.transpose(im, axes=[1, 0, 2])
+        im = np.transpose(im, axes=[1, 0, 2])
     if direction in ['Z', 'z']:
-        im = sp.transpose(im, axes=[2, 1, 0])
-    im = sp.sum(im, axis=0)
+        im = np.transpose(im, axes=[2, 1, 0])
+    im = np.sum(im, axis=0)
     return im

--- a/test/unit/test_filters.py
+++ b/test/unit/test_filters.py
@@ -1,6 +1,5 @@
 import porespy as ps
 import pytest
-import scipy as sp
 import numpy as np
 import scipy.ndimage as spim
 from skimage.morphology import disk, ball

--- a/test/unit/test_filters.py
+++ b/test/unit/test_filters.py
@@ -8,7 +8,7 @@ from skimage.morphology import disk, ball
 
 class FilterTest():
     def setup_class(self):
-        sp.random.seed(0)
+        np.random.seed(0)
         self.im = ps.generators.blobs(shape=[100, 100, 100], blobiness=2)
         # Ensure that im was generated as expeccted
         assert ps.metrics.porosity(self.im) == 0.499829
@@ -23,34 +23,34 @@ class FilterTest():
 
     def test_porosimetry_compare_modes_2D(self):
         im = self.im[:, :, 50]
-        sizes = sp.arange(25, 1, -1)
+        sizes = np.arange(25, 1, -1)
         fft = ps.filters.porosimetry(im, mode='hybrid', sizes=sizes)
         mio = ps.filters.porosimetry(im, mode='mio', sizes=sizes)
         dt = ps.filters.porosimetry(im, mode='dt', sizes=sizes)
-        assert sp.all(fft == dt)
-        assert sp.all(fft == mio)
+        assert np.all(fft == dt)
+        assert np.all(fft == mio)
 
     def test_porosimetry_npts_10(self):
         mip = ps.filters.porosimetry(im=self.im, sizes=10)
-        steps = sp.unique(mip)
-        ans = sp.array([0.00000000, 1.00000000, 1.37871571, 1.61887041,
+        steps = np.unique(mip)
+        ans = np.array([0.00000000, 1.00000000, 1.37871571, 1.61887041,
                         1.90085700, 2.23196205, 2.62074139, 3.07724114,
                         3.61325732])
-        assert sp.allclose(steps, ans)
+        assert np.allclose(steps, ans)
 
     def test_porosimetry_compare_modes_3D(self):
         im = self.im
-        sizes = sp.arange(25, 1, -1)
+        sizes = np.arange(25, 1, -1)
         fft = ps.filters.porosimetry(im, sizes=sizes, mode='hybrid')
         mio = ps.filters.porosimetry(im, sizes=sizes, mode='mio')
         dt = ps.filters.porosimetry(im, sizes=sizes, mode='dt')
-        assert sp.all(fft == dt)
-        assert sp.all(fft == mio)
+        assert np.all(fft == dt)
+        assert np.all(fft == mio)
 
     def test_porosimetry_with_sizes(self):
-        s = sp.logspace(0.01, 0.6, 5)
+        s = np.logspace(0.01, 0.6, 5)
         mip = ps.filters.porosimetry(im=self.im, sizes=s)
-        assert sp.allclose(sp.unique(mip)[1:], s)
+        assert np.allclose(np.unique(mip)[1:], s)
 
     def test_apply_chords_axis0(self):
         c = ps.filters.apply_chords(im=self.im, spacing=3, axis=0)
@@ -87,76 +87,76 @@ class FilterTest():
         im = ~ps.generators.lattice_spheres(shape=[100, 100], offset=3,
                                             radius=10)
         sz = ps.filters.flood(im*2.0, mode='max')
-        assert sp.all(sp.unique(sz) == [0, 2])
+        assert np.all(np.unique(sz) == [0, 2])
         sz = ps.filters.flood(im, mode='min')
-        assert sp.all(sp.unique(sz) == [0, 1])
+        assert np.all(np.unique(sz) == [0, 1])
         sz = ps.filters.flood(im, mode='size')
-        assert sp.all(sp.unique(sz) == [0, 305])
+        assert np.all(np.unique(sz) == [0, 305])
 
     def test_find_disconnected_voxels_2d(self):
         h = ps.filters.find_disconnected_voxels(self.im[:, :, 0])
-        assert sp.sum(h) == 477
+        assert np.sum(h) == 477
 
     def test_find_disconnected_voxels_2d_conn4(self):
         h = ps.filters.find_disconnected_voxels(self.im[:, :, 0], conn=4)
-        assert sp.sum(h) == 652
+        assert np.sum(h) == 652
 
     def test_find_disconnected_voxels_3d(self):
         h = ps.filters.find_disconnected_voxels(self.im)
-        assert sp.sum(h) == 55
+        assert np.sum(h) == 55
 
     def test_find_disconnected_voxels_3d_conn6(self):
         h = ps.filters.find_disconnected_voxels(self.im, conn=6)
-        assert sp.sum(h) == 202
+        assert np.sum(h) == 202
 
     def test_trim_nonpercolating_paths_2d_axis0(self):
         h = ps.filters.trim_nonpercolating_paths(self.im[:, :, 0],
                                                  inlet_axis=0, outlet_axis=0)
-        assert sp.sum(h) == 3178
+        assert np.sum(h) == 3178
 
     def test_trim_nonpercolating_paths_2d_axis1(self):
         h = ps.filters.trim_nonpercolating_paths(self.im[:, :, 0],
                                                  inlet_axis=1, outlet_axis=1)
-        assert sp.sum(h) == 1067
+        assert np.sum(h) == 1067
 
     def test_trim_nonpercolating_paths_3d_axis0(self):
         h = ps.filters.trim_nonpercolating_paths(self.im,
                                                  inlet_axis=0, outlet_axis=0)
-        assert sp.sum(h) == 499733
+        assert np.sum(h) == 499733
 
     def test_trim_nonpercolating_paths_3d_axis1(self):
         h = ps.filters.trim_nonpercolating_paths(self.im,
                                                  inlet_axis=1, outlet_axis=1)
-        assert sp.sum(h) == 499693
+        assert np.sum(h) == 499693
 
     def test_trim_nonpercolating_paths_3d_axis2(self):
         h = ps.filters.trim_nonpercolating_paths(self.im,
                                                  inlet_axis=2, outlet_axis=2)
-        assert sp.sum(h) == 499611
+        assert np.sum(h) == 499611
 
     def test_trim_nonpercolating_paths_masks(self):
         im = ps.generators.blobs(shape=[200, 200])
         im1 = ps.filters.trim_nonpercolating_paths(im,
                                                    inlet_axis=0,
                                                    outlet_axis=0)
-        inlets = sp.zeros_like(im)
+        inlets = np.zeros_like(im)
         inlets[0, :] = True
-        outlets = sp.zeros_like(im)
+        outlets = np.zeros_like(im)
         outlets[-1, :] = True
         im2 = ps.filters.trim_nonpercolating_paths(im,
                                                    inlets=inlets,
                                                    outlets=outlets)
-        assert sp.all(im2 == im1)
+        assert np.all(im2 == im1)
 
     def test_fill_blind_pores(self):
         h = ps.filters.find_disconnected_voxels(self.im)
         b = ps.filters.fill_blind_pores(h)
         h = ps.filters.find_disconnected_voxels(b)
-        assert sp.sum(h) == 0
+        assert np.sum(h) == 0
 
     def test_trim_floating_solid(self):
         f = ps.filters.trim_floating_solid(~self.im)
-        assert sp.sum(f) > sp.sum(~self.im)
+        assert np.sum(f) > np.sum(~self.im)
 
     def test_trim_extrema_min(self):
         dt = self.im_dt[:, :, 45:55]
@@ -181,12 +181,12 @@ class FilterTest():
         assert lt.max() == self.im_dt.max()
 
     def test_local_thickness_known_sizes(self):
-        im = sp.zeros(shape=[300, 300])
+        im = np.zeros(shape=[300, 300])
         im = ps.generators.RSA(im=im, radius=20)
         im = ps.generators.RSA(im=im, radius=10)
         im = im > 0
         lt = ps.filters.local_thickness(im, sizes=[20, 10])
-        assert sp.all(sp.unique(lt) == [0, 10, 20])
+        assert np.all(np.unique(lt) == [0, 10, 20])
 
     def test_porosimetry(self):
         im2d = self.im[:, :, 50]
@@ -201,49 +201,49 @@ class FilterTest():
         im = self.im[:, :, 50]
         truth = spim.binary_dilation(im, structure=disk(3))
         test = ps.tools.fftmorphology(im, strel=disk(3), mode='dilation')
-        assert sp.all(truth == test)
+        assert np.all(truth == test)
 
     def test_morphology_fft_erode_2D(self):
         im = self.im[:, :, 50]
         truth = spim.binary_erosion(im, structure=disk(3))
         test = ps.tools.fftmorphology(im, strel=disk(3), mode='erosion')
-        assert sp.all(truth == test)
+        assert np.all(truth == test)
 
     def test_morphology_fft_opening_2D(self):
         im = self.im[:, :, 50]
         truth = spim.binary_opening(im, structure=disk(3))
         test = ps.tools.fftmorphology(im, strel=disk(3), mode='opening')
-        assert sp.all(truth == test)
+        assert np.all(truth == test)
 
     def test_morphology_fft_closing_2D(self):
         im = self.im[:, :, 50]
         truth = spim.binary_closing(im, structure=disk(3))
         test = ps.tools.fftmorphology(im, strel=disk(3), mode='closing')
-        assert sp.all(truth == test)
+        assert np.all(truth == test)
 
     def test_morphology_fft_dilate_3D(self):
         im = self.im
         truth = spim.binary_dilation(im, structure=ball(3))
         test = ps.tools.fftmorphology(im, strel=ball(3), mode='dilation')
-        assert sp.all(truth == test)
+        assert np.all(truth == test)
 
     def test_morphology_fft_erode_3D(self):
         im = self.im
         truth = spim.binary_erosion(im, structure=ball(3))
         test = ps.tools.fftmorphology(im, strel=ball(3), mode='erosion')
-        assert sp.all(truth == test)
+        assert np.all(truth == test)
 
     def test_morphology_fft_opening_3D(self):
         im = self.im
         truth = spim.binary_opening(im, structure=ball(3))
         test = ps.tools.fftmorphology(im, strel=ball(3), mode='opening')
-        assert sp.all(truth == test)
+        assert np.all(truth == test)
 
     def test_morphology_fft_closing_3D(self):
         im = self.im
         truth = spim.binary_closing(im, structure=ball(3))
         test = ps.tools.fftmorphology(im, strel=ball(3), mode='closing')
-        assert sp.all(truth == test)
+        assert np.all(truth == test)
 
     def test_reduce_peaks(self):
         im = ~ps.generators.lattice_spheres(shape=[50, 50], radius=5, offset=3)
@@ -300,18 +300,18 @@ class FilterTest():
         im = ps.generators.lattice_spheres(shape=[50, 50], radius=4, offset=5)
         dt = spim.distance_transform_edt(im)
         ar = ps.filters.find_dt_artifacts(dt)
-        inds = sp.where(ar == ar.max())
-        assert sp.all(dt[inds] - ar[inds] == 1)
+        inds = np.where(ar == ar.max())
+        assert np.all(dt[inds] - ar[inds] == 1)
 
     def test_snow_partitioning_n(self):
         im = self.im
         snow = ps.filters.snow_partitioning_n(im + 1, r_max=4, sigma=0.4,
                                               return_all=True, mask=True,
                                               randomize=False, alias=None)
-        assert sp.amax(snow.regions) == 44
-        assert not sp.any(sp.isnan(snow.regions))
-        assert not sp.any(sp.isnan(snow.dt))
-        assert not sp.any(sp.isnan(snow.im))
+        assert np.amax(snow.regions) == 44
+        assert not np.any(np.isnan(snow.regions))
+        assert not np.any(np.isnan(snow.dt))
+        assert not np.any(np.isnan(snow.im))
 
     def test_chunked_func_2D(self):
         from skimage.morphology import disk
@@ -320,7 +320,7 @@ class FilterTest():
         s = disk(1)
         a = ps.filters.chunked_func(func=f, im=im, strel=s, mode='erosion')
         b = ps.filters.fftmorphology(im, strel=s, mode='erosion')
-        assert sp.all(a == b)
+        assert np.all(a == b)
 
     def test_chunked_func_3D(self):
         from skimage.morphology import ball
@@ -329,7 +329,7 @@ class FilterTest():
         s = ball(1)
         a = ps.filters.chunked_func(func=f, im=im, strel=s, mode='erosion')
         b = ps.filters.fftmorphology(im, strel=s, mode='erosion')
-        assert sp.all(a == b)
+        assert np.all(a == b)
 
 
 if __name__ == '__main__':

--- a/test/unit/test_generators.py
+++ b/test/unit/test_generators.py
@@ -1,5 +1,5 @@
 import porespy as ps
-import scipy as sp
+import numpy as np
 import pytest
 import scipy.ndimage as spim
 import matplotlib.pyplot as plt
@@ -9,7 +9,7 @@ plt.close('all')
 class GeneratorTest():
 
     def setup_class(self):
-        sp.random.seed(10)
+        np.random.seed(10)
 
     def test_cylinders(self):
         X = 100
@@ -20,104 +20,104 @@ class GeneratorTest():
         # But this works
         im = ps.generators.cylinders(shape=[1, X, Y], radius=1, ncylinders=20)
         assert im.dtype == bool
-        assert sp.shape(im.squeeze()) == (X, Y)
+        assert np.shape(im.squeeze()) == (X, Y)
         im = ps.generators.cylinders(shape=[50, 50, 50], radius=1,
                                      ncylinders=20)
-        assert sp.shape(im.squeeze()) == (50, 50, 50)
+        assert np.shape(im.squeeze()) == (50, 50, 50)
 
     def test_insert_shape_center_defaults(self):
-        im = sp.zeros([11, 11])
-        shape = sp.ones([3, 3])
+        im = np.zeros([11, 11])
+        shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, center=[5, 5])
-        assert sp.sum(im) == sp.prod(shape.shape)
+        assert np.sum(im) == np.prod(shape.shape)
 
-        im = sp.zeros([11, 11])
-        shape = sp.ones([4, 4])
+        im = np.zeros([11, 11])
+        shape = np.ones([4, 4])
         with pytest.raises(Exception):
             im = ps.generators.insert_shape(im, element=shape, center=[5, 5])
 
     def test_insert_shape_center_overlay(self):
-        im = sp.ones([10, 10])
-        shape = sp.ones([3, 3])
+        im = np.ones([10, 10])
+        shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, center=[5, 5],
                                         value=1.0, mode='overlay')
-        assert sp.sum(im) == (sp.prod(im.shape) + sp.prod(shape.shape))
+        assert np.sum(im) == (np.prod(im.shape) + np.prod(shape.shape))
 
     def test_insert_shape_corner_overwrite(self):
-        im = sp.ones([10, 10])
-        shape = sp.ones([3, 3])
+        im = np.ones([10, 10])
+        shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, corner=[5, 5],
                                         value=1.0, mode='overlay')
-        assert sp.sum(im) == (sp.prod(im.shape) + sp.prod(shape.shape))
+        assert np.sum(im) == (np.prod(im.shape) + np.prod(shape.shape))
         assert im[5, 5] == 2
         assert im[4, 5] == 1 and im[5, 4] == 1
 
     def test_insert_shape_center_outside_im(self):
-        im = sp.zeros([11, 11])
-        shape = sp.ones([3, 3])
+        im = np.zeros([11, 11])
+        shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, center=[-1, -1])
-        assert sp.sum(im) == 1
+        assert np.sum(im) == 1
 
-        im = sp.zeros([11, 11])
-        shape = sp.ones([3, 3])
+        im = np.zeros([11, 11])
+        shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, center=[0, -1])
-        assert sp.sum(im) == 2
+        assert np.sum(im) == 2
 
-        im = sp.zeros([11, 11])
-        shape = sp.ones([3, 3])
+        im = np.zeros([11, 11])
+        shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, center=[10, 10])
-        assert sp.sum(im) == 4
+        assert np.sum(im) == 4
 
-        im = sp.zeros([11, 11])
-        shape = sp.ones([3, 3])
+        im = np.zeros([11, 11])
+        shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, center=[14, 14])
-        assert sp.sum(im) == 0
+        assert np.sum(im) == 0
 
-        im = sp.zeros([11, 11])
-        shape = sp.ones([4, 4])
+        im = np.zeros([11, 11])
+        shape = np.ones([4, 4])
         with pytest.raises(Exception):
             im = ps.generators.insert_shape(im, element=shape, center=[10, 10])
 
-        im = sp.zeros([11, 11])
-        shape = sp.ones([4, 3])
+        im = np.zeros([11, 11])
+        shape = np.ones([4, 3])
         with pytest.raises(Exception):
             im = ps.generators.insert_shape(im, element=shape, center=[10, 10])
 
     def test_insert_shape_corner_outside_im(self):
-        im = sp.zeros([11, 11])
-        shape = sp.ones([3, 3])
+        im = np.zeros([11, 11])
+        shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, corner=[-1, -1])
-        assert sp.sum(im) == 4
+        assert np.sum(im) == 4
 
-        im = sp.zeros([11, 11])
-        shape = sp.ones([3, 3])
+        im = np.zeros([11, 11])
+        shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, corner=[-1, 1])
-        assert sp.sum(im) == 6
+        assert np.sum(im) == 6
 
-        im = sp.zeros([11, 11])
-        shape = sp.ones([3, 3])
+        im = np.zeros([11, 11])
+        shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, corner=[-3, -3])
-        assert sp.sum(im) == 0
+        assert np.sum(im) == 0
 
-        im = sp.zeros([11, 11])
-        shape = sp.ones([3, 3])
+        im = np.zeros([11, 11])
+        shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, corner=[10, 9])
-        assert sp.sum(im) == 2
+        assert np.sum(im) == 2
 
-        im = sp.zeros([11, 11])
-        shape = sp.ones([3, 3])
+        im = np.zeros([11, 11])
+        shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, corner=[13, 13])
-        assert sp.sum(im) == 0
+        assert np.sum(im) == 0
 
-        im = sp.zeros([11, 11])
-        shape = sp.ones([3, 4])
+        im = np.zeros([11, 11])
+        shape = np.ones([3, 4])
         im = ps.generators.insert_shape(im, element=shape, corner=[9, 9])
-        assert sp.sum(im) == 4
+        assert np.sum(im) == 4
 
-        im = sp.zeros([11, 11])
-        shape = sp.ones([3, 4])
+        im = np.zeros([11, 11])
+        shape = np.ones([3, 4])
         im = ps.generators.insert_shape(im, element=shape, corner=[0, -1])
-        assert sp.sum(im) == 9
+        assert np.sum(im) == 9
 
     def test_bundle_of_tubes(self):
         im = ps.generators.bundle_of_tubes(shape=[101, 101, 1], spacing=10)
@@ -125,40 +125,40 @@ class GeneratorTest():
         assert N == 100
 
     def test_overlapping_spheres_2d(self):
-        phis = sp.arange(0.1, 0.9, 0.2)
+        phis = np.arange(0.1, 0.9, 0.2)
         for phi in phis:
             im = ps.generators.overlapping_spheres(shape=[101, 101],
                                                    radius=5,
                                                    porosity=phi)
-            phi_actual = im.sum() / sp.size(im)
+            phi_actual = im.sum() / np.size(im)
             assert abs(phi_actual - phi) < 0.02
 
     def test_overlapping_spheres_3d(self):
-        phis = sp.arange(0.1, 0.9, 0.2)
+        phis = np.arange(0.1, 0.9, 0.2)
         for phi in phis:
             im = ps.generators.overlapping_spheres(shape=[100, 100, 50],
                                                    radius=8, porosity=phi)
-            phi_actual = im.sum() / sp.size(im)
+            phi_actual = im.sum() / np.size(im)
             assert abs(phi_actual - phi) < 0.02
 
     def test_polydisperse_spheres(self):
-        phis = sp.arange(0.1, 0.9, 0.2)
-        dist = sp.stats.norm(loc=7, scale=2)
+        phis = np.arange(0.1, 0.9, 0.2)
+        dist = np.stats.norm(loc=7, scale=2)
         for phi in phis:
             im = ps.generators.polydisperse_spheres(shape=[100, 100, 50],
                                                     porosity=phi, dist=dist,
                                                     nbins=10)
-            phi_actual = im.sum() / sp.size(im)
+            phi_actual = im.sum() / np.size(im)
             assert abs(phi_actual - phi) < 0.1
 
     def test_voronoi_edges(self):
-        sp.random.seed(0)
+        np.random.seed(0)
         im = ps.generators.voronoi_edges(shape=[50, 50, 50],
                                          radius=2,
                                          ncells=25,
                                          flat_faces=True)
         top_slice = im[:, :, 0]
-        assert sp.sum(top_slice) == 1409
+        assert np.sum(top_slice) == 1409
 
     def test_lattice_spheres_square(self):
         im = ps.generators.lattice_spheres(shape=[101, 101], radius=5,
@@ -204,56 +204,56 @@ class GeneratorTest():
         assert len(list(im.shape)) == 3
 
     def test_RSA_2d_single(self):
-        sp.random.seed(0)
-        im = sp.zeros([100, 100], dtype=int)
+        np.random.seed(0)
+        im = np.zeros([100, 100], dtype=int)
         im = ps.generators.RSA(im, radius=10, volume_fraction=0.5)
-        assert sp.sum(im > 0) == 5095
-        assert sp.sum(im > 1) == 20
+        assert np.sum(im > 0) == 5095
+        assert np.sum(im > 1) == 20
 
     def test_RSA_2d_multi(self):
-        sp.random.seed(0)
-        im = sp.zeros([100, 100], dtype=int)
+        np.random.seed(0)
+        im = np.zeros([100, 100], dtype=int)
         im = ps.generators.RSA(im, radius=10, volume_fraction=0.5)
         im = ps.generators.RSA(im, radius=5, volume_fraction=0.75)
-        assert sp.sum(im > 0) == 6520
-        assert sp.sum(im > 1) == 44
+        assert np.sum(im > 0) == 6520
+        assert np.sum(im > 1) == 44
 
     def test_RSA_3d_single(self):
-        sp.random.seed(0)
-        im = sp.zeros([50, 50, 50], dtype=int)
+        np.random.seed(0)
+        im = np.zeros([50, 50, 50], dtype=int)
         im = ps.generators.RSA(im, radius=5, volume_fraction=0.5)
-        assert sp.sum(im > 0) == 45602
-        assert sp.sum(im > 1) == 121
+        assert np.sum(im > 0) == 45602
+        assert np.sum(im > 1) == 121
 
     def test_RSA_mask_edge_2d(self):
-        im = sp.zeros([100, 100], dtype=int)
+        im = np.zeros([100, 100], dtype=int)
         im = ps.generators.RSA(im, radius=10, volume_fraction=0.5,
                                mode='contained')
-        coords = sp.argwhere(im == 2)
-        assert ~sp.any(coords < 10)
-        assert ~sp.any(coords > 90)
+        coords = np.argwhere(im == 2)
+        assert ~np.any(coords < 10)
+        assert ~np.any(coords > 90)
 
     def test_RSA_mask_edge_3d(self):
-        im = sp.zeros([50, 50, 50], dtype=int)
+        im = np.zeros([50, 50, 50], dtype=int)
         im = ps.generators.RSA(im, radius=5, volume_fraction=0.5,
                                mode='contained')
-        coords = sp.argwhere(im == 2)
-        assert ~sp.any(coords < 5)
-        assert ~sp.any(coords > 45)
+        coords = np.argwhere(im == 2)
+        assert ~np.any(coords < 5)
+        assert ~np.any(coords > 45)
 
     def test_line_segment(self):
         X0 = [3, 4]
         X1 = [5, 9]
         L1, L2 = ps.generators.line_segment(X0, X1)
-        assert sp.all(L1 == [3, 3, 4, 4, 5, 5])
-        assert sp.all(L2 == [4, 5, 6, 7, 8, 9])
+        assert np.all(L1 == [3, 3, 4, 4, 5, 5])
+        assert np.all(L2 == [4, 5, 6, 7, 8, 9])
 
         X0 = [3, 4, 5]
         X1 = [5, 9, 13]
         L1, L2, L3 = ps.generators.line_segment(X0, X1)
-        assert sp.all(L1 == [3, 3, 4, 4, 4, 4, 4, 5, 5])
-        assert sp.all(L2 == [4, 5, 5, 6, 6, 7, 8, 8, 9])
-        assert sp.all(L3 == [5, 6, 7, 8, 9, 10, 11, 12, 13])
+        assert np.all(L1 == [3, 3, 4, 4, 4, 4, 4, 5, 5])
+        assert np.all(L2 == [4, 5, 5, 6, 6, 7, 8, 8, 9])
+        assert np.all(L3 == [5, 6, 7, 8, 9, 10, 11, 12, 13])
 
 
 if __name__ == '__main__':

--- a/test/unit/test_generators.py
+++ b/test/unit/test_generators.py
@@ -1,5 +1,6 @@
 import porespy as ps
 import numpy as np
+import scipy as sp
 import pytest
 import scipy.ndimage as spim
 import matplotlib.pyplot as plt
@@ -143,7 +144,7 @@ class GeneratorTest():
 
     def test_polydisperse_spheres(self):
         phis = np.arange(0.1, 0.9, 0.2)
-        dist = np.stats.norm(loc=7, scale=2)
+        dist = sp.stats.norm(loc=7, scale=2)
         for phi in phis:
             im = ps.generators.polydisperse_spheres(shape=[100, 100, 50],
                                                     porosity=phi, dist=dist,

--- a/test/unit/test_metrics.py
+++ b/test/unit/test_metrics.py
@@ -1,5 +1,5 @@
 import porespy as ps
-import scipy as sp
+import numpy as np
 import scipy.ndimage as spim
 from skimage import io
 import pytest
@@ -11,7 +11,7 @@ from numpy.testing import assert_allclose
 class MetricsTest():
 
     def setup_class(self):
-        sp.random.seed(0)
+        np.random.seed(0)
         self.im2D = ps.generators.lattice_spheres(shape=[100, 100],
                                                   radius=5, offset=2,
                                                   lattice='square')
@@ -25,7 +25,7 @@ class MetricsTest():
                                          blobiness=[1, 2, 3])
         path = Path(os.path.realpath(__file__),
                     '../../../test/fixtures/partitioned_regions.tif')
-        self.regions = sp.array(io.imread(path))
+        self.regions = np.array(io.imread(path))
 
     def test_porosity(self):
         phi = ps.metrics.porosity(im=self.im2D)
@@ -37,37 +37,37 @@ class MetricsTest():
         # autocorrelation fn should level off at around the porosity
         t = 0.2
         phi1 = ps.metrics.porosity(im=self.im2D)
-        assert sp.sqrt((sp.mean(tpcf_fft_1.probability[-5:]) - phi1)**2) < t
+        assert np.sqrt((np.mean(tpcf_fft_1.probability[-5:]) - phi1)**2) < t
         phi2 = ps.metrics.porosity(im=self.im2D_big)
-        assert sp.sqrt((sp.mean(tpcf_fft_2.probability[-5:]) - phi2)**2) < t
+        assert np.sqrt((np.mean(tpcf_fft_2.probability[-5:]) - phi2)**2) < t
         # Must raise error if 1D image is supplied
         with pytest.raises(Exception):
-            _ = ps._metrics.two_point_correlation_fft(sp.random.rand(10))
+            _ = ps._metrics.two_point_correlation_fft(np.random.rand(10))
 
     def test_tpcf_fft_3d(self):
         tpcf_fft = ps.metrics.two_point_correlation_fft(self.im3D)
         t = 0.2
         phi1 = ps.metrics.porosity(im=self.im3D)
-        assert sp.sqrt((sp.mean(tpcf_fft.probability[-5:]) - phi1)**2) < t
+        assert np.sqrt((np.mean(tpcf_fft.probability[-5:]) - phi1)**2) < t
 
     def test_pore_size_distribution(self):
         mip = ps.filters.porosimetry(self.im3D)
         psd = ps.metrics.pore_size_distribution(mip)
-        assert sp.sum(psd.satn) == 1.0
+        assert np.sum(psd.satn) == 1.0
 
     def test_two_point_correlation_bf(self):
         tpcf_bf = ps.metrics.two_point_correlation_bf(self.im2D)
         # autocorrelation fn should level off at around the porosity
         t = 0.2
         phi1 = ps.metrics.porosity(im=self.im2D)
-        assert sp.sqrt((sp.mean(tpcf_bf.probability[-5:]) - phi1)**2) < t
+        assert np.sqrt((np.mean(tpcf_bf.probability[-5:]) - phi1)**2) < t
         # Throw warning if image contains a singleton axis
         with pytest.warns(UserWarning):
-            _ = ps.metrics.two_point_correlation_bf(sp.atleast_3d(self.im2D))
+            _ = ps.metrics.two_point_correlation_bf(np.atleast_3d(self.im2D))
 
     def test_rev(self):
         rev = ps.metrics.representative_elementary_volume(self.blobs)
-        assert (sp.mean(rev.porosity) - 0.5)**2 < 0.05
+        assert (np.mean(rev.porosity) - 0.5)**2 < 0.05
 
     def test_radial_density(self):
         den = ps.metrics.radial_density(self.blobs)
@@ -115,49 +115,49 @@ class MetricsTest():
         ps.metrics.chord_length_distribution(chords, normalization='length')
 
     def test_chord_counts(self):
-        im = sp.ones([100, 50])
+        im = np.ones([100, 50])
         crds = ps.filters.apply_chords(im, spacing=1, trim_edges=False)
         c = ps.metrics.chord_counts(crds)
-        assert sp.all(c == 100)
+        assert np.all(c == 100)
         crds = ps.filters.apply_chords(im, spacing=1, trim_edges=False, axis=1)
         c = ps.metrics.chord_counts(crds)
-        assert sp.all(c == 50)
+        assert np.all(c == 50)
 
     def test_mesh_surface_area(self):
         region = self.regions == self.regions.max()
         mesh = ps.tools.mesh_region(region)
         a = ps.metrics.mesh_surface_area(mesh)
-        assert sp.around(a, decimals=2) == 258.3
+        assert np.around(a, decimals=2) == 258.3
         b = ps.metrics.mesh_surface_area(verts=mesh.verts, faces=mesh.faces)
-        assert sp.around(b, decimals=2) == sp.around(a, decimals=2)
+        assert np.around(b, decimals=2) == np.around(a, decimals=2)
         with pytest.raises(Exception):
             mesh = ps.metrics.mesh_surface_area(mesh=None)
 
     def test_region_surface_areas(self):
         regions = self.regions
         areas = ps.metrics.region_surface_areas(regions)
-        assert not sp.any(sp.isnan(areas))
+        assert not np.any(np.isnan(areas))
 
     def test_region_interface_areas(self):
         regions = self.regions
         areas = ps.metrics.region_surface_areas(regions)
         ia = ps.metrics.region_interface_areas(regions, areas)
-        assert sp.all(ia.conns[0] == [2, 19])
-        assert sp.around(ia.area[0], decimals=2) == 3.59
+        assert np.all(ia.conns[0] == [2, 19])
+        assert np.around(ia.area[0], decimals=2) == 3.59
         with pytest.warns(UserWarning):
-            im2D = (sp.random.rand(5, 5) * 10).astype(int)
-            _ = ps.metrics.region_interface_areas(sp.atleast_3d(im2D), areas)
+            im2D = (np.random.rand(5, 5) * 10).astype(int)
+            _ = ps.metrics.region_interface_areas(np.atleast_3d(im2D), areas)
 
     def test_phase_fraction(self):
-        im = sp.reshape(sp.random.randint(0, 10, 1000), [10, 10, 10])
-        labels = sp.unique(im, return_counts=True)[1]
+        im = np.reshape(np.random.randint(0, 10, 1000), [10, 10, 10])
+        labels = np.unique(im, return_counts=True)[1]
         counts = ps.metrics.phase_fraction(im, normed=False)
-        assert sp.all(labels == counts)
+        assert np.all(labels == counts)
         fractions = ps.metrics.phase_fraction(im, normed=True)
-        assert sp.isclose(fractions.sum(), 1)
-        assert sp.allclose(fractions, counts/counts.sum())
+        assert np.isclose(fractions.sum(), 1)
+        assert np.allclose(fractions, counts/counts.sum())
         with pytest.raises(Exception):
-            ps.metrics.phase_fraction(sp.rand(10, 10, 10), normed=True)
+            ps.metrics.phase_fraction(np.rand(10, 10, 10), normed=True)
         # The method must also work on boolean images
         counts = ps.metrics.phase_fraction(im.astype(bool))
         assert counts[0] == (im == 0).sum() / im.size
@@ -167,12 +167,12 @@ class MetricsTest():
         im = ps.generators.lattice_spheres(shape=[999, 999],
                                            radius=15, offset=4)
         rev = ps.metrics.representative_elementary_volume(im)
-        assert_allclose(sp.average(rev.porosity), im.sum()/im.size, rtol=1e-1)
+        assert_allclose(np.average(rev.porosity), im.sum()/im.size, rtol=1e-1)
 
         im = ps.generators.lattice_spheres(shape=[151, 151, 151],
                                            radius=9, offset=4)
         rev = ps.metrics.representative_elementary_volume(im)
-        assert_allclose(sp.average(rev.porosity), im.sum()/im.size, rtol=1e-1)
+        assert_allclose(np.average(rev.porosity), im.sum()/im.size, rtol=1e-1)
 
 
 if __name__ == '__main__':

--- a/test/unit/test_metrics.py
+++ b/test/unit/test_metrics.py
@@ -157,7 +157,7 @@ class MetricsTest():
         assert np.isclose(fractions.sum(), 1)
         assert np.allclose(fractions, counts/counts.sum())
         with pytest.raises(Exception):
-            ps.metrics.phase_fraction(np.rand(10, 10, 10), normed=True)
+            ps.metrics.phase_fraction(np.random.rand(10, 10, 10), normed=True)
         # The method must also work on boolean images
         counts = ps.metrics.phase_fraction(im.astype(bool))
         assert counts[0] == (im == 0).sum() / im.size

--- a/test/unit/test_tools.py
+++ b/test/unit/test_tools.py
@@ -88,11 +88,11 @@ class ToolsTest():
         assert im.shape == (60, 50, 40)
 
     def test_inhull(self):
-        X = np.rand(25, 2)
+        X = np.random.rand(25, 2)
         hull = np.spatial.ConvexHull(X)
         assert not ps.tools.in_hull([[0, 0]], hull)
         assert ps.tools.in_hull([np.mean(X, axis=0)], hull)
-        X = np.rand(25, 3)
+        X = np.random.rand(25, 3)
         hull = np.spatial.ConvexHull(X)
         assert not ps.tools.in_hull([[0, 0, 0]], hull)
         assert ps.tools.in_hull([np.mean(X, axis=0)], hull)

--- a/test/unit/test_tools.py
+++ b/test/unit/test_tools.py
@@ -1,5 +1,5 @@
 import porespy as ps
-import scipy as sp
+import numpy as np
 import scipy.ndimage as spim
 import matplotlib.pyplot as plt
 import pytest
@@ -8,8 +8,8 @@ import pytest
 class ToolsTest():
     def setup_class(self):
         plt.close('all')
-        self.im = sp.random.randint(0, 10, 20)
-        sp.random.seed(0)
+        self.im = np.random.randint(0, 10, 20)
+        np.random.seed(0)
         self.blobs = ps.generators.blobs(shape=[101, 101])
         self.im2D = ps.generators.blobs(shape=[51, 51])
         self.im3D = ps.generators.blobs(shape=[51, 51, 51])
@@ -17,29 +17,29 @@ class ToolsTest():
 
     def test_randomize_colors(self):
         randomized_im = ps.tools.randomize_colors(im=self.im)
-        assert sp.unique(self.im).size == sp.unique(randomized_im).size
-        assert sp.all(sp.unique(self.im) == sp.unique(randomized_im))
+        assert np.unique(self.im).size == np.unique(randomized_im).size
+        assert np.all(np.unique(self.im) == np.unique(randomized_im))
 
     def test_make_contiguous_size(self):
         cont_im = ps.tools.make_contiguous(self.im)
-        assert sp.unique(self.im).size == sp.unique(cont_im).size
+        assert np.unique(self.im).size == np.unique(cont_im).size
 
     def test_make_contiguous_contiguity(self):
         cont_im = ps.tools.make_contiguous(self.im)
-        assert sp.all(sp.arange(sp.unique(self.im).size) == sp.unique(cont_im))
+        assert np.all(np.arange(np.unique(self.im).size) == np.unique(cont_im))
 
     def test_make_contiguous_negs(self):
-        im = sp.array([[0, 0, 1, 3], [-2, -4, 1, 3], [-4, 3, 5, 0]])
+        im = np.array([[0, 0, 1, 3], [-2, -4, 1, 3], [-4, 3, 5, 0]])
         a = ps.tools.make_contiguous(im, keep_zeros=True).max()
         b = ps.tools.make_contiguous(im, keep_zeros=False).max()
         assert a == b
 
     def test_extract_subsection(self):
         sec = ps.tools.extract_subsection(self.blobs, [0.5])
-        assert sp.all(sp.array(sp.shape(sec)) == 50)
+        assert np.all(np.array(np.shape(sec)) == 50)
 
     def test_extract_cylinder(self):
-        im = sp.ones([200, 300, 400], dtype=bool)
+        im = np.ones([200, 300, 400], dtype=bool)
         cx = ps.tools.extract_cylinder(im)
         assert cx.sum() == 14132200
         cy = ps.tools.extract_cylinder(im, axis=1)
@@ -51,21 +51,21 @@ class ToolsTest():
 
     def test_bbox_to_slices(self):
         s = ps.tools.bbox_to_slices([0, 0, 0, 10, 10, 10])
-        assert sp.all(self.im3D[s].shape == (10, 10, 10))
+        assert np.all(self.im3D[s].shape == (10, 10, 10))
 
     def test_get_planes(self):
         x, y, z = ps.tools.get_planes(self.im3D)
-        assert sp.all(x.shape == (51, 51))
-        assert sp.all(y.shape == (51, 51))
-        assert sp.all(z.shape == (51, 51))
+        assert np.all(x.shape == (51, 51))
+        assert np.all(y.shape == (51, 51))
+        assert np.all(z.shape == (51, 51))
         with pytest.raises(ValueError):
             ps.tools.get_planes(self.im2D)
 
     def test_get_planes_not_squeezed(self):
         x, y, z = ps.tools.get_planes(self.im3D, squeeze=False)
-        assert sp.all(x.shape == (1, 51, 51))
-        assert sp.all(y.shape == (51, 1, 51))
-        assert sp.all(z.shape == (51, 51, 1))
+        assert np.all(x.shape == (1, 51, 51))
+        assert np.all(y.shape == (51, 1, 51))
+        assert np.all(z.shape == (51, 51, 1))
 
     def test_get_border(self):
         c = ps.tools.get_border(self.im2D.shape, thickness=1, mode='corners')
@@ -82,54 +82,54 @@ class ToolsTest():
         assert c.sum() == 15002
 
     def test_align_image_w_openpnm(self):
-        im = ps.tools.align_image_with_openpnm(sp.ones([40, 50]))
+        im = ps.tools.align_image_with_openpnm(np.ones([40, 50]))
         assert im.shape == (50, 40)
-        im = ps.tools.align_image_with_openpnm(sp.ones([40, 50, 60]))
+        im = ps.tools.align_image_with_openpnm(np.ones([40, 50, 60]))
         assert im.shape == (60, 50, 40)
 
     def test_inhull(self):
-        X = sp.rand(25, 2)
-        hull = sp.spatial.ConvexHull(X)
+        X = np.rand(25, 2)
+        hull = np.spatial.ConvexHull(X)
         assert not ps.tools.in_hull([[0, 0]], hull)
-        assert ps.tools.in_hull([sp.mean(X, axis=0)], hull)
-        X = sp.rand(25, 3)
-        hull = sp.spatial.ConvexHull(X)
+        assert ps.tools.in_hull([np.mean(X, axis=0)], hull)
+        X = np.rand(25, 3)
+        hull = np.spatial.ConvexHull(X)
         assert not ps.tools.in_hull([[0, 0, 0]], hull)
-        assert ps.tools.in_hull([sp.mean(X, axis=0)], hull)
+        assert ps.tools.in_hull([np.mean(X, axis=0)], hull)
 
     def test_insert_sphere_2D(self):
-        im = sp.zeros(shape=[200, 200], dtype=bool)
+        im = np.zeros(shape=[200, 200], dtype=bool)
         im = ps.tools.insert_sphere(im, [100, 100], 50)
         im = ps.tools.insert_sphere(im, [10, 100], 50)
         im = ps.tools.insert_sphere(im, [180, 100], 50)
 
     def test_insert_sphere_3D(self):
-        im = sp.zeros(shape=[200, 200, 200], dtype=bool)
+        im = np.zeros(shape=[200, 200, 200], dtype=bool)
         im = ps.tools.insert_sphere(im, [100, 100, 100], 50)
         im = ps.tools.insert_sphere(im, [10, 100, 100], 50)
         im = ps.tools.insert_sphere(im, [180, 100, 100], 50)
 
     def test_subdivide_3D(self):
-        im = sp.ones([50, 100, 150])
+        im = np.ones([50, 100, 150])
         ims = ps.tools.subdivide(im, divs=1)
         assert ims.shape == (1, 1, 1)
-        assert sp.all(im[tuple(ims[0, 0, 0])] == im)
+        assert np.all(im[tuple(ims[0, 0, 0])] == im)
         ims = ps.tools.subdivide(im, divs=2)
         assert ims.shape == (2, 2, 2)
-        assert im[tuple(ims[0, 0, 0])].sum() == sp.prod(im.shape)/8
+        assert im[tuple(ims[0, 0, 0])].sum() == np.prod(im.shape)/8
 
     def test_subdivide_2D(self):
-        im = sp.ones([50, 100])
+        im = np.ones([50, 100])
         ims = ps.tools.subdivide(im, divs=2)
         assert ims.shape == (2, 2)
-        assert im[tuple(ims[0, 0])].sum() == sp.prod(im.shape)/4
+        assert im[tuple(ims[0, 0])].sum() == np.prod(im.shape)/4
 
     def test_size_to_seq(self):
         im = self.im2D
         sz = ps.filters.porosimetry(im)
-        nsizes = sp.size(sp.unique(sp.around(sz, decimals=0)))
+        nsizes = np.size(np.unique(np.around(sz, decimals=0)))
         sq = ps.tools.size_to_seq(sz)
-        nsteps = sp.size(sp.unique(sq))
+        nsteps = np.size(np.unique(sq))
         assert nsteps == nsizes
 
     def test_seq_to_sat_fully_filled(self):

--- a/test/unit/test_tools.py
+++ b/test/unit/test_tools.py
@@ -1,5 +1,6 @@
 import porespy as ps
 import numpy as np
+import scipy as sp
 import scipy.ndimage as spim
 import matplotlib.pyplot as plt
 import pytest
@@ -89,11 +90,11 @@ class ToolsTest():
 
     def test_inhull(self):
         X = np.random.rand(25, 2)
-        hull = np.spatial.ConvexHull(X)
+        hull = sp.spatial.ConvexHull(X)
         assert not ps.tools.in_hull([[0, 0]], hull)
         assert ps.tools.in_hull([np.mean(X, axis=0)], hull)
         X = np.random.rand(25, 3)
-        hull = np.spatial.ConvexHull(X)
+        hull = sp.spatial.ConvexHull(X)
         assert not ps.tools.in_hull([[0, 0, 0]], hull)
         assert ps.tools.in_hull([np.mean(X, axis=0)], hull)
 

--- a/test/unit/test_visualization.py
+++ b/test/unit/test_visualization.py
@@ -1,5 +1,5 @@
 import porespy as ps
-import scipy as sp
+import numpy as np
 
 
 class VisualizationTest():
@@ -12,7 +12,7 @@ class VisualizationTest():
 
     def test_xray_x(self):
         xray = ps.visualization.xray(self.im)
-        assert sp.sum(xray) == sp.sum(~self.im)
+        assert np.sum(xray) == np.sum(~self.im)
 
     def test_sem_y(self):
         sem = ps.visualization.sem(self.im, direction='Y')
@@ -20,7 +20,7 @@ class VisualizationTest():
 
     def test_xray_y(self):
         xray = ps.visualization.xray(self.im, direction='Y')
-        assert sp.sum(xray) == sp.sum(~self.im)
+        assert np.sum(xray) == np.sum(~self.im)
 
     def test_sem_z(self):
         sem = ps.visualization.sem(self.im, direction='Z')
@@ -28,7 +28,7 @@ class VisualizationTest():
 
     def test_xray_z(self):
         xray = ps.visualization.xray(self.im, direction='Z')
-        assert sp.sum(xray) == sp.sum(~self.im)
+        assert np.sum(xray) == np.sum(~self.im)
 
 if __name__ == '__main__':
     t = VisualizationTest()


### PR DESCRIPTION
Scipy V2+ will stop import all the numpy functions to the top level, so ``sp.func`` must be changed to ``np.func`` throughout the code.  Also, even now some of the scipy funcs are not working.  For instance, ``sp.minimum.accumulate`` is broken, so this change must be made now, even though scipy V2 is not ready yet.