### PR TITLE
Scipy2 deprecation proofing

### DIFF
--- a/porespy/__init__.py
+++ b/porespy/__init__.py
@@ -52,7 +52,7 @@ Create a test image (or load one using ``skimage.io.imread``)
 .. code-block:: python
 
     >>> import porespy as ps
-    >>> import scipy as sp
+    >>> import numpy as np
     >>> import scipy.ndimage as spim
     >>> np.random.seed(0)  # Set number generator for same image each time
     >>> im = ps.generators.blobs(shape=[250, 250])

--- a/porespy/__init__.py
+++ b/porespy/__init__.py
@@ -54,7 +54,7 @@ Create a test image (or load one using ``skimage.io.imread``)
     >>> import porespy as ps
     >>> import scipy as sp
     >>> import scipy.ndimage as spim
-    >>> sp.random.seed(0)  # Set number generator for same image each time
+    >>> np.random.seed(0)  # Set number generator for same image each time
     >>> im = ps.generators.blobs(shape=[250, 250])
 
 Apply a filter to the image using tools from ``scipy.ndimage``:

--- a/porespy/filters/__funcs__.py
+++ b/porespy/filters/__funcs__.py
@@ -215,7 +215,7 @@ def snow_partitioning(im, dt=None, r_max=4, sigma=0.4, return_all=False,
         im = im > 0
     if dt is None:
         print('Peforming Distance Transform')
-        if sp.any(im_shape == 1):
+        if np.any(im_shape == 1):
             ax = np.where(im_shape == 1)[0][0]
             dt = spim.distance_transform_edt(input=im.squeeze())
             dt = sp.expand_dims(dt, ax)
@@ -1216,7 +1216,7 @@ def porosimetry(im, sizes=25, inlets=None, access_limited=True,
             if access_limited:
                 imtemp = trim_disconnected_blobs(imtemp, inlets)
             imtemp = fftmorphology(imtemp, strel(r), mode='dilation')
-            if sp.any(imtemp):
+            if np.any(imtemp):
                 imresults[(imresults == 0)*imtemp] = r
         imresults = extract_subsection(imresults, shape=im.shape)
     elif mode == 'dt':
@@ -1226,7 +1226,7 @@ def porosimetry(im, sizes=25, inlets=None, access_limited=True,
             imtemp = dt >= r
             if access_limited:
                 imtemp = trim_disconnected_blobs(imtemp, inlets)
-            if sp.any(imtemp):
+            if np.any(imtemp):
                 imtemp = spim.distance_transform_edt(~imtemp) < r
                 imresults[(imresults == 0)*imtemp] = r
     elif mode == 'hybrid':
@@ -1236,7 +1236,7 @@ def porosimetry(im, sizes=25, inlets=None, access_limited=True,
             imtemp = dt >= r
             if access_limited:
                 imtemp = trim_disconnected_blobs(imtemp, inlets)
-            if sp.any(imtemp):
+            if np.any(imtemp):
                 imtemp = fftconvolve(imtemp, strel(r), mode='same') > 0.0001
                 imresults[(imresults == 0)*imtemp] = r
     else:

--- a/porespy/filters/__funcs__.py
+++ b/porespy/filters/__funcs__.py
@@ -858,7 +858,7 @@ def flood(im, regions=None, mode='max'):
         V = np.zeros(shape=N+1, dtype=int)
         for i in range(len(L)):
             V[L[i]] += 1
-    im_flooded = sp.reshape(V[labels], newshape=im.shape)
+    im_flooded = np.reshape(V[labels], newshape=im.shape)
     im_flooded = im_flooded*mask
     return im_flooded
 
@@ -1276,7 +1276,7 @@ def trim_disconnected_blobs(im, inlets):
     keep = np.unique(labels[inlets])
     keep = keep[keep > 0]
     if len(keep) > 0:
-        im2 = sp.reshape(sp.in1d(labels, keep), newshape=im.shape)
+        im2 = np.reshape(sp.in1d(labels, keep), newshape=im.shape)
     else:
         im2 = np.zeros_like(im)
     im2 = im2*im

--- a/porespy/filters/__funcs__.py
+++ b/porespy/filters/__funcs__.py
@@ -354,7 +354,7 @@ def snow_partitioning_n(im, r_max=4, sigma=0.4, return_all=True,
             phase_ws = phase_snow.regions * phase_snow.im
             phase_ws[phase_ws == num[i - 1]] = 0
             combined_region += phase_ws
-        num.append(sp.amax(combined_region))
+        num.append(np.amax(combined_region))
     if return_all:
         tup = namedtuple('results', field_names=['im', 'dt', 'phase_max_label',
                                                  'regions'])
@@ -509,7 +509,7 @@ def trim_saddle_points(peaks, dt, max_iters=10):
             iters += 1
             peaks_dil = spim.binary_dilation(input=peaks_dil,
                                              structure=cube(3))
-            peaks_max = peaks_dil*sp.amax(dt_i*peaks_dil)
+            peaks_max = peaks_dil*np.amax(dt_i*peaks_dil)
             peaks_extended = (peaks_max == dt_i)*im_i
             if np.all(peaks_extended == peaks_i):
                 break  # Found a true peak
@@ -1195,7 +1195,7 @@ def porosimetry(im, sizes=25, inlets=None, access_limited=True,
         inlets = get_border(im.shape, mode='faces')
 
     if isinstance(sizes, int):
-        sizes = sp.logspace(start=sp.log10(sp.amax(dt)), stop=0, num=sizes)
+        sizes = sp.logspace(start=sp.log10(np.amax(dt)), stop=0, num=sizes)
     else:
         sizes = sp.unique(sizes)[-1::-1]
 

--- a/porespy/filters/__funcs__.py
+++ b/porespy/filters/__funcs__.py
@@ -45,7 +45,7 @@ def trim_small_clusters(im, size=1):
         raise Exception('Only 2D or 3D images are accepted')
     filtered_array = sp.copy(im)
     labels, N = spim.label(filtered_array, structure=strel)
-    id_sizes = sp.array(spim.sum(im, labels, range(N + 1)))
+    id_sizes = np.array(spim.sum(im, labels, range(N + 1)))
     area_mask = (id_sizes <= size)
     filtered_array[area_mask[labels]] = 0
     return filtered_array
@@ -209,14 +209,14 @@ def snow_partitioning(im, dt=None, r_max=4, sigma=0.4, return_all=False,
     tup = namedtuple('results', field_names=['im', 'dt', 'peaks', 'regions'])
     print('_'*60)
     print("Beginning SNOW Algorithm")
-    im_shape = sp.array(im.shape)
+    im_shape = np.array(im.shape)
     if im.dtype is not bool:
         print('Converting supplied image (im) to boolean')
         im = im > 0
     if dt is None:
         print('Peforming Distance Transform')
         if sp.any(im_shape == 1):
-            ax = sp.where(im_shape == 1)[0][0]
+            ax = np.where(im_shape == 1)[0][0]
             dt = spim.distance_transform_edt(input=im.squeeze())
             dt = sp.expand_dims(dt, ax)
         else:
@@ -571,7 +571,7 @@ def trim_nearby_peaks(peaks, dt):
     dist_to_neighbor = temp[0][:, 1]
     del temp, tree  # Free-up memory
     dist_to_solid = dt[tuple(crds.T)]  # Get distance to solid for each peak
-    hits = sp.where(dist_to_neighbor < dist_to_solid)[0]
+    hits = np.where(dist_to_neighbor < dist_to_solid)[0]
     # Drop peak that is closer to the solid than it's neighbor
     drop_peaks = []
     for peak in hits:
@@ -850,7 +850,7 @@ def flood(im, regions=None, mode='max'):
             if V[L[i]] < I[i]:
                 V[L[i]] = I[i]
     elif mode.startswith('min'):
-        V = sp.ones(shape=N+1, dtype=float)*sp.inf
+        V = np.ones(shape=N+1, dtype=float)*sp.inf
         for i in range(len(L)):
             if V[L[i]] > I[i]:
                 V[L[i]] = I[i]
@@ -887,9 +887,9 @@ def find_dt_artifacts(dt):
         the image.  Obviously, voxels with a value of zero have no error.
 
     """
-    temp = sp.ones(shape=dt.shape)*sp.inf
+    temp = np.ones(shape=dt.shape)*sp.inf
     for ax in range(dt.ndim):
-        dt_lin = distance_transform_lin(sp.ones_like(temp, dtype=bool),
+        dt_lin = distance_transform_lin(np.ones_like(temp, dtype=bool),
                                         axis=ax, mode='both')
         temp = sp.minimum(temp, dt_lin)
     result = sp.clip(dt - temp, a_min=0, a_max=sp.inf)
@@ -1208,7 +1208,7 @@ def porosimetry(im, sizes=25, inlets=None, access_limited=True,
         pw = int(np.floor(dt.max()))
         impad = sp.pad(im, mode='symmetric', pad_width=pw)
         inletspad = sp.pad(inlets, mode='symmetric', pad_width=pw)
-        inlets = sp.where(inletspad)
+        inlets = np.where(inletspad)
 #        sizes = sp.unique(sp.around(sizes, decimals=0).astype(int))[-1::-1]
         imresults = np.zeros(sp.shape(impad))
         for r in tqdm(sizes):
@@ -1220,7 +1220,7 @@ def porosimetry(im, sizes=25, inlets=None, access_limited=True,
                 imresults[(imresults == 0)*imtemp] = r
         imresults = extract_subsection(imresults, shape=im.shape)
     elif mode == 'dt':
-        inlets = sp.where(inlets)
+        inlets = np.where(inlets)
         imresults = np.zeros(sp.shape(im))
         for r in tqdm(sizes):
             imtemp = dt >= r
@@ -1230,7 +1230,7 @@ def porosimetry(im, sizes=25, inlets=None, access_limited=True,
                 imtemp = spim.distance_transform_edt(~imtemp) < r
                 imresults[(imresults == 0)*imtemp] = r
     elif mode == 'hybrid':
-        inlets = sp.where(inlets)
+        inlets = np.where(inlets)
         imresults = np.zeros(sp.shape(im))
         for r in tqdm(sizes):
             imtemp = dt >= r

--- a/porespy/filters/__funcs__.py
+++ b/porespy/filters/__funcs__.py
@@ -329,7 +329,7 @@ def snow_partitioning_n(im, r_max=4, sigma=0.4, return_all=True,
     # Get alias if provided by user
     al = _create_alias_map(im=im, alias=alias)
     # Perform snow on each phase and merge all segmentation and dt together
-    phases_num = sp.unique(im * 1)
+    phases_num = np.unique(im * 1)
     phases_num = sp.trim_zeros(phases_num)
     combined_dt = 0
     combined_region = 0
@@ -579,7 +579,7 @@ def trim_nearby_peaks(peaks, dt):
             drop_peaks.append(peak)
         else:
             drop_peaks.append(nearest_neighbor[peak])
-    drop_peaks = sp.unique(drop_peaks)
+    drop_peaks = np.unique(drop_peaks)
     # Remove peaks from image
     slices = spim.find_objects(input=peaks)
     for s in drop_peaks:
@@ -756,8 +756,8 @@ def trim_nonpercolating_paths(im, inlet_axis=0, outlet_axis=0):
             outlet[-1, :] = 1
         elif outlet_axis == 1:
             outlet[:, -1] = 1
-    IN = sp.unique(labels*inlet)
-    OUT = sp.unique(labels*outlet)
+    IN = np.unique(labels*inlet)
+    OUT = np.unique(labels*outlet)
     new_im = sp.isin(labels, list(set(IN) ^ set(OUT)), invert=True)
     im[new_im == 0] = True
     return ~im
@@ -1197,7 +1197,7 @@ def porosimetry(im, sizes=25, inlets=None, access_limited=True,
     if isinstance(sizes, int):
         sizes = sp.logspace(start=sp.log10(np.amax(dt)), stop=0, num=sizes)
     else:
-        sizes = sp.unique(sizes)[-1::-1]
+        sizes = np.unique(sizes)[-1::-1]
 
     if im.ndim == 2:
         strel = ps_disk
@@ -1209,7 +1209,7 @@ def porosimetry(im, sizes=25, inlets=None, access_limited=True,
         impad = np.pad(im, mode='symmetric', pad_width=pw)
         inletspad = np.pad(inlets, mode='symmetric', pad_width=pw)
         inlets = np.where(inletspad)
-#        sizes = sp.unique(np.around(sizes, decimals=0).astype(int))[-1::-1]
+#        sizes = np.unique(np.around(sizes, decimals=0).astype(int))[-1::-1]
         imresults = np.zeros(np.shape(impad))
         for r in tqdm(sizes):
             imtemp = fftmorphology(impad, strel(r), mode='erosion')
@@ -1273,7 +1273,7 @@ def trim_disconnected_blobs(im, inlets):
     else:
         raise Exception('inlets not valid, refer to docstring for info')
     labels = spim.label(inlets + (im > 0))[0]
-    keep = sp.unique(labels[inlets])
+    keep = np.unique(labels[inlets])
     keep = keep[keep > 0]
     if len(keep) > 0:
         im2 = sp.reshape(sp.in1d(labels, keep), newshape=im.shape)
@@ -1445,7 +1445,7 @@ def prune_branches(skel, branch_points=None, iterations=1):
         # Find branch point labels the overlap current arc
         hits = pts_labels[s]*(arc_labels[s] == label_num)
         # If image contains 2 branch points, then it's not a tail.
-        if len(sp.unique(hits)) == 3:
+        if len(np.unique(hits)) == 3:
             im_result[s] += arc_labels[s] == label_num
     # Add missing branch points back to arc image to make complete skeleton
     im_result += skel*pts_orig

--- a/porespy/filters/__funcs__.py
+++ b/porespy/filters/__funcs__.py
@@ -122,11 +122,11 @@ def distance_transform_lin(im, axis=0, mode='both'):
     elif mode in ['both']:
         im_f = distance_transform_lin(im=im, axis=axis, mode='forward')
         im_b = distance_transform_lin(im=im, axis=axis, mode='backward')
-        return sp.minimum(im_f, im_b)
+        return np.minimum(im_f, im_b)
     else:
         b = sp.cumsum(im > 0, axis=axis)
         c = sp.diff(b*(im == 0), axis=axis)
-        d = sp.minimum.accumulate(c, axis=axis)
+        d = np.minimum.accumulate(c, axis=axis)
         if im.ndim == 1:
             e = np.pad(d, pad_width=[1, 0], mode='constant', constant_values=0)
         elif im.ndim == 2:
@@ -330,7 +330,7 @@ def snow_partitioning_n(im, r_max=4, sigma=0.4, return_all=True,
     al = _create_alias_map(im=im, alias=alias)
     # Perform snow on each phase and merge all segmentation and dt together
     phases_num = np.unique(im * 1)
-    phases_num = sp.trim_zeros(phases_num)
+    phases_num = np.trim_zeros(phases_num)
     combined_dt = 0
     combined_region = 0
     num = [0]
@@ -891,7 +891,7 @@ def find_dt_artifacts(dt):
     for ax in range(dt.ndim):
         dt_lin = distance_transform_lin(np.ones_like(temp, dtype=bool),
                                         axis=ax, mode='both')
-        temp = sp.minimum(temp, dt_lin)
+        temp = np.minimum(temp, dt_lin)
     result = sp.clip(dt - temp, a_min=0, a_max=sp.inf)
     return result
 

--- a/porespy/filters/__funcs__.py
+++ b/porespy/filters/__funcs__.py
@@ -511,7 +511,7 @@ def trim_saddle_points(peaks, dt, max_iters=10):
                                              structure=cube(3))
             peaks_max = peaks_dil*sp.amax(dt_i*peaks_dil)
             peaks_extended = (peaks_max == dt_i)*im_i
-            if sp.all(peaks_extended == peaks_i):
+            if np.all(peaks_extended == peaks_i):
                 break  # Found a true peak
             elif np.sum(peaks_extended*peaks_i) == 0:
                 peaks_i = False
@@ -1455,6 +1455,6 @@ def prune_branches(skel, branch_points=None, iterations=1):
         im_result = prune_branches(skel=im_result,
                                    branch_points=None,
                                    iterations=iterations)
-        if sp.all(im_temp == im_result):
+        if np.all(im_temp == im_result):
             iterations = 0
     return im_result

--- a/porespy/filters/__funcs__.py
+++ b/porespy/filters/__funcs__.py
@@ -563,7 +563,7 @@ def trim_nearby_peaks(peaks, dt):
     peaks, N = spim.label(peaks, structure=cube(3))
     crds = spim.measurements.center_of_mass(peaks, labels=peaks,
                                             index=np.arange(1, N+1))
-    crds = sp.vstack(crds).astype(int)  # Convert to numpy array of ints
+    crds = np.vstack(crds).astype(int)  # Convert to numpy array of ints
     # Get distance between each peak as a distance map
     tree = sptl.cKDTree(data=crds)
     temp = tree.query(x=crds, k=2)

--- a/porespy/filters/__funcs__.py
+++ b/porespy/filters/__funcs__.py
@@ -1195,7 +1195,7 @@ def porosimetry(im, sizes=25, inlets=None, access_limited=True,
         inlets = get_border(im.shape, mode='faces')
 
     if isinstance(sizes, int):
-        sizes = sp.logspace(start=sp.log10(np.amax(dt)), stop=0, num=sizes)
+        sizes = np.logspace(start=sp.log10(np.amax(dt)), stop=0, num=sizes)
     else:
         sizes = np.unique(sizes)[-1::-1]
 

--- a/porespy/filters/__funcs__.py
+++ b/porespy/filters/__funcs__.py
@@ -451,9 +451,9 @@ def reduce_peaks(peaks):
     inds = spim.measurements.center_of_mass(input=peaks,
                                             labels=markers,
                                             index=sp.arange(1, N+1))
-    inds = sp.floor(inds).astype(int)
+    inds = np.floor(inds).astype(int)
     # Centroid may not be on old pixel, so create a new peaks image
-    peaks_new = sp.zeros_like(peaks, dtype=bool)
+    peaks_new = np.zeros_like(peaks, dtype=bool)
     peaks_new[tuple(inds.T)] = True
     return peaks_new
 
@@ -729,8 +729,8 @@ def trim_nonpercolating_paths(im, inlet_axis=0, outlet_axis=0):
                       ' unexpected behavior.')
     im = trim_floating_solid(~im)
     labels = spim.label(~im)[0]
-    inlet = sp.zeros_like(im, dtype=int)
-    outlet = sp.zeros_like(im, dtype=int)
+    inlet = np.zeros_like(im, dtype=int)
+    outlet = np.zeros_like(im, dtype=int)
     if im.ndim == 3:
         if inlet_axis == 0:
             inlet[0, :, :] = 1
@@ -845,7 +845,7 @@ def flood(im, regions=None, mode='max'):
     I = im.flatten()
     L = labels.flatten()
     if mode.startswith('max'):
-        V = sp.zeros(shape=N+1, dtype=float)
+        V = np.zeros(shape=N+1, dtype=float)
         for i in range(len(L)):
             if V[L[i]] < I[i]:
                 V[L[i]] = I[i]
@@ -855,7 +855,7 @@ def flood(im, regions=None, mode='max'):
             if V[L[i]] > I[i]:
                 V[L[i]] = I[i]
     elif mode.startswith('size'):
-        V = sp.zeros(shape=N+1, dtype=int)
+        V = np.zeros(shape=N+1, dtype=int)
         for i in range(len(L)):
             V[L[i]] += 1
     im_flooded = sp.reshape(V[labels], newshape=im.shape)
@@ -970,7 +970,7 @@ def apply_chords(im, spacing=1, axis=0, trim_edges=True, label=False):
         raise Exception('Spacing cannot be less than 0')
     if spacing == 0:
         label = True
-    result = sp.zeros(im.shape, dtype=int)  # Will receive chords at end
+    result = np.zeros(im.shape, dtype=int)  # Will receive chords at end
     slxyz = [slice(None, None, spacing*(axis != i) + 1) for i in [0, 1, 2]]
     slices = tuple(slxyz[:im.ndim])
     s = [[0, 1, 0], [0, 1, 0], [0, 1, 0]]  # Straight-line structuring element
@@ -1033,7 +1033,7 @@ def apply_chords_3D(im, spacing=0, trim_edges=True):
         raise Exception('Must be a 3D image to use this function')
     if spacing < 0:
         raise Exception('Spacing cannot be less than 0')
-    ch = sp.zeros_like(im, dtype=int)
+    ch = np.zeros_like(im, dtype=int)
     ch[:, ::4+2*spacing, ::4+2*spacing] = 1  # X-direction
     ch[::4+2*spacing, :, 2::4+2*spacing] = 2  # Y-direction
     ch[2::4+2*spacing, 2::4+2*spacing, :] = 3  # Z-direction
@@ -1205,12 +1205,12 @@ def porosimetry(im, sizes=25, inlets=None, access_limited=True,
         strel = ps_ball
 
     if mode == 'mio':
-        pw = int(sp.floor(dt.max()))
+        pw = int(np.floor(dt.max()))
         impad = sp.pad(im, mode='symmetric', pad_width=pw)
         inletspad = sp.pad(inlets, mode='symmetric', pad_width=pw)
         inlets = sp.where(inletspad)
 #        sizes = sp.unique(sp.around(sizes, decimals=0).astype(int))[-1::-1]
-        imresults = sp.zeros(sp.shape(impad))
+        imresults = np.zeros(sp.shape(impad))
         for r in tqdm(sizes):
             imtemp = fftmorphology(impad, strel(r), mode='erosion')
             if access_limited:
@@ -1221,7 +1221,7 @@ def porosimetry(im, sizes=25, inlets=None, access_limited=True,
         imresults = extract_subsection(imresults, shape=im.shape)
     elif mode == 'dt':
         inlets = sp.where(inlets)
-        imresults = sp.zeros(sp.shape(im))
+        imresults = np.zeros(sp.shape(im))
         for r in tqdm(sizes):
             imtemp = dt >= r
             if access_limited:
@@ -1231,7 +1231,7 @@ def porosimetry(im, sizes=25, inlets=None, access_limited=True,
                 imresults[(imresults == 0)*imtemp] = r
     elif mode == 'hybrid':
         inlets = sp.where(inlets)
-        imresults = sp.zeros(sp.shape(im))
+        imresults = np.zeros(sp.shape(im))
         for r in tqdm(sizes):
             imtemp = dt >= r
             if access_limited:
@@ -1266,7 +1266,7 @@ def trim_disconnected_blobs(im, inlets):
     """
     if type(inlets) == tuple:
         temp = sp.copy(inlets)
-        inlets = sp.zeros_like(im, dtype=bool)
+        inlets = np.zeros_like(im, dtype=bool)
         inlets[temp] = True
     elif (inlets.shape == im.shape) and (inlets.max() == 1):
         inlets = inlets.astype(bool)
@@ -1278,7 +1278,7 @@ def trim_disconnected_blobs(im, inlets):
     if len(keep) > 0:
         im2 = sp.reshape(sp.in1d(labels, keep), newshape=im.shape)
     else:
-        im2 = sp.zeros_like(im)
+        im2 = np.zeros_like(im)
     im2 = im2*im
     return im2
 
@@ -1423,7 +1423,7 @@ def prune_branches(skel, branch_points=None, iterations=1):
     else:
         from skimage.morphology import cube
     # Create empty image to house results
-    im_result = sp.zeros_like(skel)
+    im_result = np.zeros_like(skel)
     # If branch points are not supplied, attempt to find them
     if branch_points is None:
         branch_points = spim.convolve(skel*1.0, weights=cube(3)) > 3

--- a/porespy/filters/__funcs__.py
+++ b/porespy/filters/__funcs__.py
@@ -513,7 +513,7 @@ def trim_saddle_points(peaks, dt, max_iters=10):
             peaks_extended = (peaks_max == dt_i)*im_i
             if sp.all(peaks_extended == peaks_i):
                 break  # Found a true peak
-            elif sp.sum(peaks_extended*peaks_i) == 0:
+            elif np.sum(peaks_extended*peaks_i) == 0:
                 peaks_i = False
                 break  # Found a saddle point
         peaks[s] = peaks_i

--- a/porespy/filters/__funcs__.py
+++ b/porespy/filters/__funcs__.py
@@ -128,15 +128,15 @@ def distance_transform_lin(im, axis=0, mode='both'):
         c = sp.diff(b*(im == 0), axis=axis)
         d = sp.minimum.accumulate(c, axis=axis)
         if im.ndim == 1:
-            e = sp.pad(d, pad_width=[1, 0], mode='constant', constant_values=0)
+            e = np.pad(d, pad_width=[1, 0], mode='constant', constant_values=0)
         elif im.ndim == 2:
             ax = [[[1, 0], [0, 0]], [[0, 0], [1, 0]]]
-            e = sp.pad(d, pad_width=ax[axis], mode='constant', constant_values=0)
+            e = np.pad(d, pad_width=ax[axis], mode='constant', constant_values=0)
         elif im.ndim == 3:
             ax = [[[1, 0], [0, 0], [0, 0]],
                   [[0, 0], [1, 0], [0, 0]],
                   [[0, 0], [0, 0], [1, 0]]]
-            e = sp.pad(d, pad_width=ax[axis], mode='constant', constant_values=0)
+            e = np.pad(d, pad_width=ax[axis], mode='constant', constant_values=0)
         f = im*(b + e)
         return f
 
@@ -975,7 +975,7 @@ def apply_chords(im, spacing=1, axis=0, trim_edges=True, label=False):
     slices = tuple(slxyz[:im.ndim])
     s = [[0, 1, 0], [0, 1, 0], [0, 1, 0]]  # Straight-line structuring element
     if im.ndim == 3:  # Make structuring element 3D if necessary
-        s = sp.pad(sp.atleast_3d(s), pad_width=((0, 0), (0, 0), (1, 1)),
+        s = np.pad(sp.atleast_3d(s), pad_width=((0, 0), (0, 0), (1, 1)),
                    mode='constant', constant_values=0)
     im = im[slices]
     s = sp.swapaxes(s, 0, axis)
@@ -1206,11 +1206,11 @@ def porosimetry(im, sizes=25, inlets=None, access_limited=True,
 
     if mode == 'mio':
         pw = int(np.floor(dt.max()))
-        impad = sp.pad(im, mode='symmetric', pad_width=pw)
-        inletspad = sp.pad(inlets, mode='symmetric', pad_width=pw)
+        impad = np.pad(im, mode='symmetric', pad_width=pw)
+        inletspad = np.pad(inlets, mode='symmetric', pad_width=pw)
         inlets = np.where(inletspad)
 #        sizes = sp.unique(sp.around(sizes, decimals=0).astype(int))[-1::-1]
-        imresults = np.zeros(sp.shape(impad))
+        imresults = np.zeros(np.shape(impad))
         for r in tqdm(sizes):
             imtemp = fftmorphology(impad, strel(r), mode='erosion')
             if access_limited:
@@ -1221,7 +1221,7 @@ def porosimetry(im, sizes=25, inlets=None, access_limited=True,
         imresults = extract_subsection(imresults, shape=im.shape)
     elif mode == 'dt':
         inlets = np.where(inlets)
-        imresults = np.zeros(sp.shape(im))
+        imresults = np.zeros(np.shape(im))
         for r in tqdm(sizes):
             imtemp = dt >= r
             if access_limited:
@@ -1231,7 +1231,7 @@ def porosimetry(im, sizes=25, inlets=None, access_limited=True,
                 imresults[(imresults == 0)*imtemp] = r
     elif mode == 'hybrid':
         inlets = np.where(inlets)
-        imresults = np.zeros(sp.shape(im))
+        imresults = np.zeros(np.shape(im))
         for r in tqdm(sizes):
             imtemp = dt >= r
             if access_limited:

--- a/porespy/filters/__funcs__.py
+++ b/porespy/filters/__funcs__.py
@@ -1,5 +1,4 @@
 from collections import namedtuple
-import scipy as sp
 import numpy as np
 import operator as op
 import scipy.ndimage as spim

--- a/porespy/filters/__funcs__.py
+++ b/porespy/filters/__funcs__.py
@@ -1209,7 +1209,7 @@ def porosimetry(im, sizes=25, inlets=None, access_limited=True,
         impad = np.pad(im, mode='symmetric', pad_width=pw)
         inletspad = np.pad(inlets, mode='symmetric', pad_width=pw)
         inlets = np.where(inletspad)
-#        sizes = sp.unique(sp.around(sizes, decimals=0).astype(int))[-1::-1]
+#        sizes = sp.unique(np.around(sizes, decimals=0).astype(int))[-1::-1]
         imresults = np.zeros(np.shape(impad))
         for r in tqdm(sizes):
             imtemp = fftmorphology(impad, strel(r), mode='erosion')

--- a/porespy/filters/__funcs__.py
+++ b/porespy/filters/__funcs__.py
@@ -124,8 +124,8 @@ def distance_transform_lin(im, axis=0, mode='both'):
         im_b = distance_transform_lin(im=im, axis=axis, mode='backward')
         return np.minimum(im_f, im_b)
     else:
-        b = sp.cumsum(im > 0, axis=axis)
-        c = sp.diff(b*(im == 0), axis=axis)
+        b = np.cumsum(im > 0, axis=axis)
+        c = np.diff(b*(im == 0), axis=axis)
         d = np.minimum.accumulate(c, axis=axis)
         if im.ndim == 1:
             e = np.pad(d, pad_width=[1, 0], mode='constant', constant_values=0)
@@ -218,7 +218,7 @@ def snow_partitioning(im, dt=None, r_max=4, sigma=0.4, return_all=False,
         if np.any(im_shape == 1):
             ax = np.where(im_shape == 1)[0][0]
             dt = spim.distance_transform_edt(input=im.squeeze())
-            dt = sp.expand_dims(dt, ax)
+            dt = np.expand_dims(dt, ax)
         else:
             dt = spim.distance_transform_edt(input=im)
 
@@ -758,7 +758,7 @@ def trim_nonpercolating_paths(im, inlet_axis=0, outlet_axis=0):
             outlet[:, -1] = 1
     IN = np.unique(labels*inlet)
     OUT = np.unique(labels*outlet)
-    new_im = sp.isin(labels, list(set(IN) ^ set(OUT)), invert=True)
+    new_im = np.isin(labels, list(set(IN) ^ set(OUT)), invert=True)
     im[new_im == 0] = True
     return ~im
 
@@ -850,7 +850,7 @@ def flood(im, regions=None, mode='max'):
             if V[L[i]] < I[i]:
                 V[L[i]] = I[i]
     elif mode.startswith('min'):
-        V = np.ones(shape=N+1, dtype=float)*sp.inf
+        V = np.ones(shape=N+1, dtype=float)*np.inf
         for i in range(len(L)):
             if V[L[i]] > I[i]:
                 V[L[i]] = I[i]
@@ -887,12 +887,12 @@ def find_dt_artifacts(dt):
         the image.  Obviously, voxels with a value of zero have no error.
 
     """
-    temp = np.ones(shape=dt.shape)*sp.inf
+    temp = np.ones(shape=dt.shape)*np.inf
     for ax in range(dt.ndim):
         dt_lin = distance_transform_lin(np.ones_like(temp, dtype=bool),
                                         axis=ax, mode='both')
         temp = np.minimum(temp, dt_lin)
-    result = sp.clip(dt - temp, a_min=0, a_max=sp.inf)
+    result = np.clip(dt - temp, a_min=0, a_max=np.inf)
     return result
 
 
@@ -917,7 +917,7 @@ def region_size(im):
     """
     if im.dtype == bool:
         im = spim.label(im)[0]
-    counts = sp.bincount(im.flatten())
+    counts = np.bincount(im.flatten())
     counts[0] = 0
     chords = counts[im]
     return chords
@@ -975,10 +975,10 @@ def apply_chords(im, spacing=1, axis=0, trim_edges=True, label=False):
     slices = tuple(slxyz[:im.ndim])
     s = [[0, 1, 0], [0, 1, 0], [0, 1, 0]]  # Straight-line structuring element
     if im.ndim == 3:  # Make structuring element 3D if necessary
-        s = np.pad(sp.atleast_3d(s), pad_width=((0, 0), (0, 0), (1, 1)),
+        s = np.pad(np.atleast_3d(s), pad_width=((0, 0), (0, 0), (1, 1)),
                    mode='constant', constant_values=0)
     im = im[slices]
-    s = sp.swapaxes(s, 0, axis)
+    s = np.swapaxes(s, 0, axis)
     chords = spim.label(im, structure=s)[0]
     if trim_edges:  # Label on border chords will be set to 0
         chords = clear_border(chords)
@@ -1195,7 +1195,7 @@ def porosimetry(im, sizes=25, inlets=None, access_limited=True,
         inlets = get_border(im.shape, mode='faces')
 
     if isinstance(sizes, int):
-        sizes = np.logspace(start=sp.log10(np.amax(dt)), stop=0, num=sizes)
+        sizes = np.logspace(start=np.log10(np.amax(dt)), stop=0, num=sizes)
     else:
         sizes = np.unique(sizes)[-1::-1]
 
@@ -1276,7 +1276,7 @@ def trim_disconnected_blobs(im, inlets):
     keep = np.unique(labels[inlets])
     keep = keep[keep > 0]
     if len(keep) > 0:
-        im2 = np.reshape(sp.in1d(labels, keep), newshape=im.shape)
+        im2 = np.reshape(np.in1d(labels, keep), newshape=im.shape)
     else:
         im2 = np.zeros_like(im)
     im2 = im2*im

--- a/porespy/filters/__funcs__.py
+++ b/porespy/filters/__funcs__.py
@@ -450,7 +450,7 @@ def reduce_peaks(peaks):
     markers, N = spim.label(input=peaks, structure=strel(3))
     inds = spim.measurements.center_of_mass(input=peaks,
                                             labels=markers,
-                                            index=sp.arange(1, N+1))
+                                            index=np.arange(1, N+1))
     inds = np.floor(inds).astype(int)
     # Centroid may not be on old pixel, so create a new peaks image
     peaks_new = np.zeros_like(peaks, dtype=bool)
@@ -562,7 +562,7 @@ def trim_nearby_peaks(peaks, dt):
         from skimage.morphology import cube
     peaks, N = spim.label(peaks, structure=cube(3))
     crds = spim.measurements.center_of_mass(peaks, labels=peaks,
-                                            index=sp.arange(1, N+1))
+                                            index=np.arange(1, N+1))
     crds = sp.vstack(crds).astype(int)  # Convert to numpy array of ints
     # Get distance between each peak as a distance map
     tree = sptl.cKDTree(data=crds)

--- a/porespy/filters/__funcs__.py
+++ b/porespy/filters/__funcs__.py
@@ -43,7 +43,7 @@ def trim_small_clusters(im, size=1):
         strel = ball(1)
     else:
         raise Exception('Only 2D or 3D images are accepted')
-    filtered_array = sp.copy(im)
+    filtered_array = np.copy(im)
     labels, N = spim.label(filtered_array, structure=strel)
     id_sizes = np.array(spim.sum(im, labels, range(N + 1)))
     area_mask = (id_sizes <= size)
@@ -115,9 +115,9 @@ def distance_transform_lin(im, axis=0, mode='both'):
                       ' Reduce dimensionality with np.squeeze(im) to avoid' +
                       ' unexpected behavior.')
     if mode in ['backward', 'reverse']:
-        im = sp.flip(im, axis)
+        im = np.flip(im, axis)
         im = distance_transform_lin(im=im, axis=axis, mode='forward')
-        im = sp.flip(im, axis)
+        im = np.flip(im, axis)
         return im
     elif mode in ['both']:
         im_f = distance_transform_lin(im=im, axis=axis, mode='forward')
@@ -491,7 +491,7 @@ def trim_saddle_points(peaks, dt, max_iters=10):
     using marker-based watershed segmenation".  Physical Review E. (2017)
 
     """
-    peaks = sp.copy(peaks)
+    peaks = np.copy(peaks)
     if dt.ndim == 2:
         from skimage.morphology import square as cube
     else:
@@ -504,7 +504,7 @@ def trim_saddle_points(peaks, dt, max_iters=10):
         dt_i = dt[s]
         im_i = dt_i > 0
         iters = 0
-        peaks_dil = sp.copy(peaks_i)
+        peaks_dil = np.copy(peaks_i)
         while iters < max_iters:
             iters += 1
             peaks_dil = spim.binary_dilation(input=peaks_dil,
@@ -555,7 +555,7 @@ def trim_nearby_peaks(peaks, dt):
     [1] Gostick, J. "A versatile and efficient network extraction algorithm
     using marker-based watershed segmenation".  Physical Review E. (2017)
     """
-    peaks = sp.copy(peaks)
+    peaks = np.copy(peaks)
     if dt.ndim == 2:
         from skimage.morphology import square as cube
     else:
@@ -656,7 +656,7 @@ def fill_blind_pores(im):
     find_disconnected_voxels
 
     """
-    im = sp.copy(im)
+    im = np.copy(im)
     holes = find_disconnected_voxels(im)
     im[holes] = False
     return im
@@ -681,7 +681,7 @@ def trim_floating_solid(im):
     find_disconnected_voxels
 
     """
-    im = sp.copy(im)
+    im = np.copy(im)
     holes = find_disconnected_voxels(~im)
     im[holes] = True
     return im
@@ -840,7 +840,7 @@ def flood(im, regions=None, mode='max'):
     if regions is None:
         labels, N = spim.label(mask)
     else:
-        labels = sp.copy(regions)
+        labels = np.copy(regions)
         N = labels.max()
     I = im.flatten()
     L = labels.flatten()
@@ -1265,7 +1265,7 @@ def trim_disconnected_blobs(im, inlets):
         voxels not connected to the ``inlets`` removed.
     """
     if type(inlets) == tuple:
-        temp = sp.copy(inlets)
+        temp = np.copy(inlets)
         inlets = np.zeros_like(im, dtype=bool)
         inlets[temp] = True
     elif (inlets.shape == im.shape) and (inlets.max() == 1):
@@ -1451,7 +1451,7 @@ def prune_branches(skel, branch_points=None, iterations=1):
     im_result += skel*pts_orig
     if iterations > 1:
         iterations -= 1
-        im_temp = sp.copy(im_result)
+        im_temp = np.copy(im_result)
         im_result = prune_branches(skel=im_result,
                                    branch_points=None,
                                    iterations=iterations)

--- a/porespy/generators/__imgen__.py
+++ b/porespy/generators/__imgen__.py
@@ -764,8 +764,8 @@ def cylinders(shape: List[int], radius: int, ncylinders: int,
         # Choose a random starting point in domain
         x = sp.rand(3)*shape
         # Chose a random phi and theta within given ranges
-        phi = (sp.pi/2 - sp.pi*sp.rand())*phi_max/90
-        theta = (sp.pi/2 - sp.pi*sp.rand())*theta_max/90
+        phi = (np.pi/2 - np.pi*sp.rand())*phi_max/90
+        theta = (np.pi/2 - np.pi*sp.rand())*theta_max/90
         X0 = R*np.array([sp.cos(phi)*sp.cos(theta),
                          sp.cos(phi)*sp.sin(theta),
                          sp.sin(phi)])

--- a/porespy/generators/__imgen__.py
+++ b/porespy/generators/__imgen__.py
@@ -220,11 +220,11 @@ def bundle_of_tubes(shape: List[int], spacing: int):
     if sp.size(shape) == 2:
         shape = sp.hstack((shape, [1]))
     temp = np.zeros(shape=shape[:2])
-    Xi = sp.ceil(sp.linspace(spacing/2,
+    Xi = sp.ceil(np.linspace(spacing/2,
                              shape[0]-(spacing/2)-1,
                              int(shape[0]/spacing)))
     Xi = np.array(Xi, dtype=int)
-    Yi = sp.ceil(sp.linspace(spacing/2,
+    Yi = sp.ceil(np.linspace(spacing/2,
                              shape[1]-(spacing/2)-1,
                              int(shape[1]/spacing)))
     Yi = np.array(Yi, dtype=int)
@@ -282,7 +282,7 @@ def polydisperse_spheres(shape: List[int], porosity: float, dist,
     shape = np.array(shape)
     if sp.size(shape) == 1:
         shape = sp.full((3, ), int(shape))
-    Rs = dist.interval(sp.linspace(0.05, 0.95, nbins))
+    Rs = dist.interval(np.linspace(0.05, 0.95, nbins))
     Rs = sp.vstack(Rs).T
     Rs = (Rs[:-1] + Rs[1:])/2
     Rs = sp.clip(Rs.flatten(), a_min=r_min, a_max=None)
@@ -804,14 +804,14 @@ def line_segment(X0, X1):
     X1 = sp.around(X1).astype(int)
     if len(X0) == 3:
         L = sp.amax(sp.absolute([[X1[0]-X0[0]], [X1[1]-X0[1]], [X1[2]-X0[2]]])) + 1
-        x = sp.rint(sp.linspace(X0[0], X1[0], L)).astype(int)
-        y = sp.rint(sp.linspace(X0[1], X1[1], L)).astype(int)
-        z = sp.rint(sp.linspace(X0[2], X1[2], L)).astype(int)
+        x = sp.rint(np.linspace(X0[0], X1[0], L)).astype(int)
+        y = sp.rint(np.linspace(X0[1], X1[1], L)).astype(int)
+        z = sp.rint(np.linspace(X0[2], X1[2], L)).astype(int)
         return [x, y, z]
     else:
         L = sp.amax(sp.absolute([[X1[0]-X0[0]], [X1[1]-X0[1]]])) + 1
-        x = sp.rint(sp.linspace(X0[0], X1[0], L)).astype(int)
-        y = sp.rint(sp.linspace(X0[1], X1[1], L)).astype(int)
+        x = sp.rint(np.linspace(X0[0], X1[0], L)).astype(int)
+        y = sp.rint(np.linspace(X0[1], X1[1], L)).astype(int)
         return [x, y]
 
 

--- a/porespy/generators/__imgen__.py
+++ b/porespy/generators/__imgen__.py
@@ -59,21 +59,21 @@ def insert_shape(im, element, center=None, corner=None, value=1,
             if d == 0:
                 raise Exception('Cannot specify center point when element ' +
                                 'has one or more even dimension')
-            lower_im = sp.amax((center[dim] - r, 0))
-            upper_im = sp.amin((center[dim] + r + 1, im.shape[dim]))
+            lower_im = np.amax((center[dim] - r, 0))
+            upper_im = np.amin((center[dim] + r + 1, im.shape[dim]))
             s_im.append(slice(lower_im, upper_im))
-            lower_el = sp.amax((lower_im - center[dim] + r, 0))
-            upper_el = sp.amin((upper_im - center[dim] + r,
+            lower_el = np.amax((lower_im - center[dim] + r, 0))
+            upper_el = np.amin((upper_im - center[dim] + r,
                                 element.shape[dim]))
             s_el.append(slice(lower_el, upper_el))
     elif (corner is not None) and (center is None):
         for dim in range(im.ndim):
             L = int(element.shape[dim])
-            lower_im = sp.amax((corner[dim], 0))
-            upper_im = sp.amin((corner[dim] + L, im.shape[dim]))
+            lower_im = np.amax((corner[dim], 0))
+            upper_im = np.amin((corner[dim] + L, im.shape[dim]))
             s_im.append(slice(lower_im, upper_im))
-            lower_el = sp.amax((lower_im - corner[dim], 0))
-            upper_el = sp.amin((upper_im - corner[dim],
+            lower_el = np.amax((lower_im - corner[dim], 0))
+            upper_el = np.amin((upper_im - corner[dim],
                                 element.shape[dim]))
             s_el.append(slice(min(lower_el, upper_el), upper_el))
     else:
@@ -803,13 +803,13 @@ def line_segment(X0, X1):
     X0 = sp.around(X0).astype(int)
     X1 = sp.around(X1).astype(int)
     if len(X0) == 3:
-        L = sp.amax(sp.absolute([[X1[0]-X0[0]], [X1[1]-X0[1]], [X1[2]-X0[2]]])) + 1
+        L = np.amax(sp.absolute([[X1[0]-X0[0]], [X1[1]-X0[1]], [X1[2]-X0[2]]])) + 1
         x = sp.rint(np.linspace(X0[0], X1[0], L)).astype(int)
         y = sp.rint(np.linspace(X0[1], X1[1], L)).astype(int)
         z = sp.rint(np.linspace(X0[2], X1[2], L)).astype(int)
         return [x, y, z]
     else:
-        L = sp.amax(sp.absolute([[X1[0]-X0[0]], [X1[1]-X0[1]]])) + 1
+        L = np.amax(sp.absolute([[X1[0]-X0[0]], [X1[1]-X0[1]]])) + 1
         x = sp.rint(np.linspace(X0[0], X1[0], L)).astype(int)
         y = sp.rint(np.linspace(X0[1], X1[1], L)).astype(int)
         return [x, y]

--- a/porespy/generators/__imgen__.py
+++ b/porespy/generators/__imgen__.py
@@ -218,7 +218,7 @@ def bundle_of_tubes(shape: List[int], spacing: int):
     if sp.size(shape) == 1:
         shape = np.full((3, ), int(shape))
     if sp.size(shape) == 2:
-        shape = sp.hstack((shape, [1]))
+        shape = np.hstack((shape, [1]))
     temp = np.zeros(shape=shape[:2])
     Xi = np.ceil(np.linspace(spacing/2,
                              shape[0]-(spacing/2)-1,
@@ -283,7 +283,7 @@ def polydisperse_spheres(shape: List[int], porosity: float, dist,
     if sp.size(shape) == 1:
         shape = np.full((3, ), int(shape))
     Rs = dist.interval(np.linspace(0.05, 0.95, nbins))
-    Rs = sp.vstack(Rs).T
+    Rs = np.vstack(Rs).T
     Rs = (Rs[:-1] + Rs[1:])/2
     Rs = sp.clip(Rs.flatten(), a_min=r_min, a_max=None)
     phi_desired = 1 - (1 - porosity)/(len(Rs))
@@ -334,15 +334,15 @@ def voronoi_edges(shape: List[int], radius: int, ncells: int,
         # Reflect base points
         Nx, Ny, Nz = shape
         orig_pts = base_pts
-        base_pts = sp.vstack((base_pts,
+        base_pts = np.vstack((base_pts,
                               [-1, 1, 1] * orig_pts + [2.0*Nx, 0, 0]))
-        base_pts = sp.vstack((base_pts,
+        base_pts = np.vstack((base_pts,
                               [1, -1, 1] * orig_pts + [0, 2.0*Ny, 0]))
-        base_pts = sp.vstack((base_pts,
+        base_pts = np.vstack((base_pts,
                               [1, 1, -1] * orig_pts + [0, 0, 2.0*Nz]))
-        base_pts = sp.vstack((base_pts, [-1, 1, 1] * orig_pts))
-        base_pts = sp.vstack((base_pts, [1, -1, 1] * orig_pts))
-        base_pts = sp.vstack((base_pts, [1, 1, -1] * orig_pts))
+        base_pts = np.vstack((base_pts, [-1, 1, 1] * orig_pts))
+        base_pts = np.vstack((base_pts, [1, -1, 1] * orig_pts))
+        base_pts = np.vstack((base_pts, [1, 1, -1] * orig_pts))
     vor = sptl.Voronoi(points=base_pts)
     vor.vertices = np.around(vor.vertices)
     vor.vertices *= (np.array(im.shape)-1) / np.array(im.shape)
@@ -378,14 +378,14 @@ def _get_Voronoi_edges(vor):
         # Create a closed cycle of vertices that define the facet
         edges[0].extend(facet[:-1]+[facet[-1]])
         edges[1].extend(facet[1:]+[facet[0]])
-    edges = sp.vstack(edges).T  # Convert to scipy-friendly format
+    edges = np.vstack(edges).T  # Convert to scipy-friendly format
     mask = np.any(edges == -1, axis=1)  # Identify edges at infinity
     edges = edges[~mask]  # Remove edges at infinity
     edges = sp.sort(edges, axis=1)  # Move all points to upper triangle
     # Remove duplicate pairs
     edges = edges[:, 0] + 1j*edges[:, 1]  # Convert to imaginary
     edges = np.unique(edges)  # Remove duplicates
-    edges = sp.vstack((sp.real(edges), sp.imag(edges))).T  # Back to real
+    edges = np.vstack((sp.real(edges), sp.imag(edges))).T  # Back to real
     edges = np.array(edges, dtype=int)
     return edges
 
@@ -771,8 +771,8 @@ def cylinders(shape: List[int], radius: int, ncylinders: int,
                          np.cos(phi)])
         [X0, X1] = [x + X0, x - X0]
         crds = line_segment(X0, X1)
-        lower = ~np.any(sp.vstack(crds).T < [0, 0, 0], axis=1)
-        upper = ~np.any(sp.vstack(crds).T >= shape, axis=1)
+        lower = ~np.any(np.vstack(crds).T < [0, 0, 0], axis=1)
+        upper = ~np.any(np.vstack(crds).T >= shape, axis=1)
         valid = upper*lower
         if np.any(valid):
             im[crds[0][valid], crds[1][valid], crds[2][valid]] = 1

--- a/porespy/generators/__imgen__.py
+++ b/porespy/generators/__imgen__.py
@@ -563,7 +563,7 @@ def overlapping_spheres(shape: List[int], radius: int, porosity: float,
     # Bisection search: N is always undershoot (bc. of overlaps)
     N_low, N_high = N, 4*N
     for i in range(iter_max):
-        N = sp.mean([N_high, N_low], dtype=int)
+        N = np.mean([N_high, N_low], dtype=int)
         err = g(f(N)) - porosity
         if err > 0:
             N_low = N
@@ -695,7 +695,7 @@ def blobs(shape: List[int], porosity: float = 0.5, blobiness: int = 1):
     shape = np.array(shape)
     if sp.size(shape) == 1:
         shape = np.full((3, ), int(shape))
-    sigma = sp.mean(shape)/(40*blobiness)
+    sigma = np.mean(shape)/(40*blobiness)
     im = sp.random.random(shape)
     im = spim.gaussian_filter(im, sigma=sigma)
     im = norm_to_uniform(im, scale=[0, 1])

--- a/porespy/generators/__imgen__.py
+++ b/porespy/generators/__imgen__.py
@@ -349,7 +349,7 @@ def voronoi_edges(shape: List[int], radius: int, ncells: int,
     vor.edges = _get_Voronoi_edges(vor)
     for row in vor.edges:
         pts = vor.vertices[row].astype(int)
-        if sp.all(pts >= 0) and sp.all(pts < im.shape):
+        if np.all(pts >= 0) and np.all(pts < im.shape):
             line_pts = line_segment(pts[0], pts[1])
             im[tuple(line_pts)] = True
     im = spim.distance_transform_edt(~im) > radius

--- a/porespy/generators/__imgen__.py
+++ b/porespy/generators/__imgen__.py
@@ -158,7 +158,7 @@ def RSA(im: array, radius: int, volume_fraction: int = 1,
         mask = ps.tools.fftmorphology(im > 0, im_strel > 0, mode='dilate')
         mask = mask.astype(int)
     else:
-        mask = sp.zeros_like(im)
+        mask = np.zeros_like(im)
     if mode == 'contained':
         mask = _remove_edge(mask, radius)
     elif mode == 'extended':
@@ -218,7 +218,7 @@ def bundle_of_tubes(shape: List[int], spacing: int):
         shape = sp.full((3, ), int(shape))
     if sp.size(shape) == 2:
         shape = sp.hstack((shape, [1]))
-    temp = sp.zeros(shape=shape[:2])
+    temp = np.zeros(shape=shape[:2])
     Xi = sp.ceil(sp.linspace(spacing/2,
                              shape[0]-(spacing/2)-1,
                              int(shape[0]/spacing)))
@@ -227,7 +227,7 @@ def bundle_of_tubes(shape: List[int], spacing: int):
                              shape[1]-(spacing/2)-1,
                              int(shape[1]/spacing)))
     Yi = sp.array(Yi, dtype=int)
-    temp[tuple(sp.meshgrid(Xi, Yi))] = 1
+    temp[tuple(np.meshgrid(Xi, Yi))] = 1
     inds = sp.where(temp)
     for i in range(len(inds[0])):
         r = sp.random.randint(1, (spacing/2))
@@ -327,7 +327,7 @@ def voronoi_edges(shape: List[int], radius: int, ncells: int,
     shape = sp.array(shape)
     if sp.size(shape) == 1:
         shape = sp.full((3, ), int(shape))
-    im = sp.zeros(shape, dtype=bool)
+    im = np.zeros(shape, dtype=bool)
     base_pts = sp.rand(ncells, 3)*shape
     if flat_faces:
         # Reflect base points
@@ -429,7 +429,7 @@ def lattice_spheres(shape: List[int], radius: int, offset: int = 0,
     shape = sp.array(shape)
     if sp.size(shape) == 1:
         shape = sp.full((3, ), int(shape))
-    im = sp.zeros(shape, dtype=bool)
+    im = np.zeros(shape, dtype=bool)
     im = im.squeeze()
 
     # Parse lattice type
@@ -447,7 +447,7 @@ def lattice_spheres(shape: List[int], radius: int, offset: int = 0,
                           r:im.shape[1]-r:2*s]
         im[coords[0], coords[1]] = 1
     elif lattice in ['tri', 'triangular']:
-        spacing = 2*sp.floor(sp.sqrt(2*(r**2))).astype(int)
+        spacing = 2*np.floor(sp.sqrt(2*(r**2))).astype(int)
         s = int(spacing/2) + offset
         coords = sp.mgrid[r:im.shape[0]-r:2*s,
                           r:im.shape[1]-r:2*s]
@@ -463,7 +463,7 @@ def lattice_spheres(shape: List[int], radius: int, offset: int = 0,
                           r:im.shape[2]-r:2*s]
         im[coords[0], coords[1], coords[2]] = 1
     elif lattice in ['bcc', 'body cenetered cubic']:
-        spacing = 2*sp.floor(sp.sqrt(4/3*(r**2))).astype(int)
+        spacing = 2*np.floor(sp.sqrt(4/3*(r**2))).astype(int)
         s = int(spacing/2) + offset
         coords = sp.mgrid[r:im.shape[0]-r:2*s,
                           r:im.shape[1]-r:2*s,
@@ -474,7 +474,7 @@ def lattice_spheres(shape: List[int], radius: int, offset: int = 0,
                           s+r:im.shape[2]-r:2*s]
         im[coords[0], coords[1], coords[2]] = 1
     elif lattice in ['fcc', 'face centered cubic']:
-        spacing = 2*sp.floor(sp.sqrt(2*(r**2))).astype(int)
+        spacing = 2*np.floor(sp.sqrt(2*(r**2))).astype(int)
         s = int(spacing/2) + offset
         coords = sp.mgrid[r:im.shape[0]-r:2*s,
                           r:im.shape[1]-r:2*s,
@@ -646,7 +646,7 @@ def generate_noise(shape: List[int], porosity=None, octaves: int = 3,
         freq = sp.concatenate((frequency, [1]))
     else:
         freq = sp.array(frequency)
-    im = sp.zeros(shape=[Lx, Ly, Lz], dtype=float)
+    im = np.zeros(shape=[Lx, Ly, Lz], dtype=float)
     for x in range(Lx):
         for y in range(Ly):
             for z in range(Lz):
@@ -752,7 +752,7 @@ def cylinders(shape: List[int], radius: int, ncylinders: int,
         R = sp.sqrt(sp.sum(sp.square(shape))).astype(int)
     else:
         R = length/2
-    im = sp.zeros(shape)
+    im = np.zeros(shape)
     # Adjust max angles to be between 0 and 90
     if (phi_max > 90) or (phi_max < 0):
         raise Exception('phi_max must be betwen 0 and 90')

--- a/porespy/generators/__imgen__.py
+++ b/porespy/generators/__imgen__.py
@@ -1,6 +1,5 @@
 import porespy as ps
 import numpy as np
-import scipy as sp
 import scipy.spatial as sptl
 import scipy.ndimage as spim
 from porespy.tools import norm_to_uniform, ps_ball, ps_disk

--- a/porespy/generators/__imgen__.py
+++ b/porespy/generators/__imgen__.py
@@ -384,7 +384,7 @@ def _get_Voronoi_edges(vor):
     edges = sp.sort(edges, axis=1)  # Move all points to upper triangle
     # Remove duplicate pairs
     edges = edges[:, 0] + 1j*edges[:, 1]  # Convert to imaginary
-    edges = sp.unique(edges)  # Remove duplicates
+    edges = np.unique(edges)  # Remove duplicates
     edges = sp.vstack((sp.real(edges), sp.imag(edges))).T  # Back to real
     edges = np.array(edges, dtype=int)
     return edges

--- a/porespy/generators/__imgen__.py
+++ b/porespy/generators/__imgen__.py
@@ -444,52 +444,52 @@ def lattice_spheres(shape: List[int], radius: int, offset: int = 0,
     if lattice in ['sq', 'square']:
         spacing = 2*r
         s = int(spacing/2) + np.array(offset)
-        coords = sp.mgrid[r:im.shape[0]-r:2*s,
+        coords = np.mgrid[r:im.shape[0]-r:2*s,
                           r:im.shape[1]-r:2*s]
         im[coords[0], coords[1]] = 1
     elif lattice in ['tri', 'triangular']:
         spacing = 2*np.floor(np.sqrt(2*(r**2))).astype(int)
         s = int(spacing/2) + offset
-        coords = sp.mgrid[r:im.shape[0]-r:2*s,
+        coords = np.mgrid[r:im.shape[0]-r:2*s,
                           r:im.shape[1]-r:2*s]
         im[coords[0], coords[1]] = 1
-        coords = sp.mgrid[s+r:im.shape[0]-r:2*s,
+        coords = np.mgrid[s+r:im.shape[0]-r:2*s,
                           s+r:im.shape[1]-r:2*s]
         im[coords[0], coords[1]] = 1
     elif lattice in ['sc', 'simple cubic', 'cubic']:
         spacing = 2*r
         s = int(spacing/2) + np.array(offset)
-        coords = sp.mgrid[r:im.shape[0]-r:2*s,
+        coords = np.mgrid[r:im.shape[0]-r:2*s,
                           r:im.shape[1]-r:2*s,
                           r:im.shape[2]-r:2*s]
         im[coords[0], coords[1], coords[2]] = 1
     elif lattice in ['bcc', 'body cenetered cubic']:
         spacing = 2*np.floor(np.sqrt(4/3*(r**2))).astype(int)
         s = int(spacing/2) + offset
-        coords = sp.mgrid[r:im.shape[0]-r:2*s,
+        coords = np.mgrid[r:im.shape[0]-r:2*s,
                           r:im.shape[1]-r:2*s,
                           r:im.shape[2]-r:2*s]
         im[coords[0], coords[1], coords[2]] = 1
-        coords = sp.mgrid[s+r:im.shape[0]-r:2*s,
+        coords = np.mgrid[s+r:im.shape[0]-r:2*s,
                           s+r:im.shape[1]-r:2*s,
                           s+r:im.shape[2]-r:2*s]
         im[coords[0], coords[1], coords[2]] = 1
     elif lattice in ['fcc', 'face centered cubic']:
         spacing = 2*np.floor(np.sqrt(2*(r**2))).astype(int)
         s = int(spacing/2) + offset
-        coords = sp.mgrid[r:im.shape[0]-r:2*s,
+        coords = np.mgrid[r:im.shape[0]-r:2*s,
                           r:im.shape[1]-r:2*s,
                           r:im.shape[2]-r:2*s]
         im[coords[0], coords[1], coords[2]] = 1
-        coords = sp.mgrid[r:im.shape[0]-r:2*s,
+        coords = np.mgrid[r:im.shape[0]-r:2*s,
                           s+r:im.shape[1]-r:2*s,
                           s+r:im.shape[2]-r:2*s]
         im[coords[0], coords[1], coords[2]] = 1
-        coords = sp.mgrid[s+r:im.shape[0]-r:2*s,
+        coords = np.mgrid[s+r:im.shape[0]-r:2*s,
                           s:im.shape[1]-r:2*s,
                           s+r:im.shape[2]-r:2*s]
         im[coords[0], coords[1], coords[2]] = 1
-        coords = sp.mgrid[s+r:im.shape[0]-r:2*s,
+        coords = np.mgrid[s+r:im.shape[0]-r:2*s,
                           s+r:im.shape[1]-r:2*s,
                           s:im.shape[2]-r:2*s]
         im[coords[0], coords[1], coords[2]] = 1
@@ -766,9 +766,9 @@ def cylinders(shape: List[int], radius: int, ncylinders: int,
         # Chose a random phi and theta within given ranges
         phi = (np.pi/2 - np.pi*sp.rand())*phi_max/90
         theta = (np.pi/2 - np.pi*sp.rand())*theta_max/90
-        X0 = R*np.array([sp.cos(phi)*sp.cos(theta),
-                         sp.cos(phi)*sp.sin(theta),
-                         sp.sin(phi)])
+        X0 = R*np.array([np.cos(phi)*np.cos(theta),
+                         np.cos(phi)*np.cos(theta),
+                         np.cos(phi)])
         [X0, X1] = [x + X0, x - X0]
         crds = line_segment(X0, X1)
         lower = ~np.any(sp.vstack(crds).T < [0, 0, 0], axis=1)

--- a/porespy/generators/__imgen__.py
+++ b/porespy/generators/__imgen__.py
@@ -289,7 +289,7 @@ def polydisperse_spheres(shape: List[int], porosity: float, dist,
     phi_desired = 1 - (1 - porosity)/(len(Rs))
     im = np.ones(shape, dtype=bool)
     for r in Rs:
-        phi_im = im.sum() / sp.prod(shape)
+        phi_im = im.sum() / np.prod(shape)
         phi_corrected = 1 - (1 - phi_desired) / phi_im
         temp = overlapping_spheres(shape=shape, radius=r, porosity=phi_corrected)
         im = im * temp
@@ -539,13 +539,13 @@ def overlapping_spheres(shape: List[int], radius: int, porosity: float,
     ndim = (shape != 1).sum()
     s_vol = ps_disk(radius).sum() if ndim == 2 else ps_ball(radius).sum()
 
-    bulk_vol = sp.prod(shape)
+    bulk_vol = np.prod(shape)
     N = int(np.ceil((1 - porosity)*bulk_vol/s_vol))
     im = sp.random.random(size=shape)
 
     # Helper functions for calculating porosity: phi = g(f(N))
     f = lambda N: spim.distance_transform_edt(im > N/bulk_vol) < radius
-    g = lambda im: 1 - im.sum() / sp.prod(shape)
+    g = lambda im: 1 - im.sum() / np.prod(shape)
 
     # # Newton's method for getting image porosity match the given
     # w = 1.0                         # Damping factor

--- a/porespy/generators/__imgen__.py
+++ b/porespy/generators/__imgen__.py
@@ -750,7 +750,7 @@ def cylinders(shape: List[int], radius: int, ncylinders: int,
     elif sp.size(shape) == 2:
         raise Exception("2D cylinders don't make sense")
     if length is None:
-        R = np.sqrt(sp.sum(sp.square(shape))).astype(int)
+        R = np.sqrt(np.sum(sp.square(shape))).astype(int)
     else:
         R = length/2
     im = np.zeros(shape)

--- a/porespy/generators/__imgen__.py
+++ b/porespy/generators/__imgen__.py
@@ -344,7 +344,7 @@ def voronoi_edges(shape: List[int], radius: int, ncells: int,
         base_pts = sp.vstack((base_pts, [1, -1, 1] * orig_pts))
         base_pts = sp.vstack((base_pts, [1, 1, -1] * orig_pts))
     vor = sptl.Voronoi(points=base_pts)
-    vor.vertices = sp.around(vor.vertices)
+    vor.vertices = np.around(vor.vertices)
     vor.vertices *= (np.array(im.shape)-1) / np.array(im.shape)
     vor.edges = _get_Voronoi_edges(vor)
     for row in vor.edges:
@@ -800,8 +800,8 @@ def line_segment(X0, X1):
         that should be drawn between the start and end points to create a solid
         line.
     """
-    X0 = sp.around(X0).astype(int)
-    X1 = sp.around(X1).astype(int)
+    X0 = np.around(X0).astype(int)
+    X1 = np.around(X1).astype(int)
     if len(X0) == 3:
         L = np.amax(sp.absolute([[X1[0]-X0[0]], [X1[1]-X0[1]], [X1[2]-X0[2]]])) + 1
         x = sp.rint(np.linspace(X0[0], X1[0], L)).astype(int)

--- a/porespy/generators/__imgen__.py
+++ b/porespy/generators/__imgen__.py
@@ -220,11 +220,11 @@ def bundle_of_tubes(shape: List[int], spacing: int):
     if sp.size(shape) == 2:
         shape = sp.hstack((shape, [1]))
     temp = np.zeros(shape=shape[:2])
-    Xi = sp.ceil(np.linspace(spacing/2,
+    Xi = np.ceil(np.linspace(spacing/2,
                              shape[0]-(spacing/2)-1,
                              int(shape[0]/spacing)))
     Xi = np.array(Xi, dtype=int)
-    Yi = sp.ceil(np.linspace(spacing/2,
+    Yi = np.ceil(np.linspace(spacing/2,
                              shape[1]-(spacing/2)-1,
                              int(shape[1]/spacing)))
     Yi = np.array(Yi, dtype=int)
@@ -540,7 +540,7 @@ def overlapping_spheres(shape: List[int], radius: int, porosity: float,
     s_vol = ps_disk(radius).sum() if ndim == 2 else ps_ball(radius).sum()
 
     bulk_vol = sp.prod(shape)
-    N = int(sp.ceil((1 - porosity)*bulk_vol/s_vol))
+    N = int(np.ceil((1 - porosity)*bulk_vol/s_vol))
     im = sp.random.random(size=shape)
 
     # Helper functions for calculating porosity: phi = g(f(N))

--- a/porespy/generators/__imgen__.py
+++ b/porespy/generators/__imgen__.py
@@ -88,7 +88,7 @@ def insert_shape(im, element, center=None, corner=None, value=1,
     return im
 
 
-def RSA(im: array, radius: int, volume_fraction: int = 1,
+def RSA(im: np.array, radius: int, volume_fraction: int = 1,
         mode: str = 'extended'):
     r"""
     Generates a sphere or disk packing using Random Sequential Addition
@@ -172,7 +172,7 @@ def RSA(im: array, radius: int, volume_fraction: int = 1,
     free_spots = np.argwhere(mask == 0)
     i = 0
     while vf <= volume_fraction and len(free_spots) > 0:
-        choice = sp.random.randint(0, len(free_spots), size=1)
+        choice = np.random.randint(0, len(free_spots), size=1)
         if d2:
             [x, y] = free_spots[choice].flatten()
             im = _fit_strel_to_im_2d(im, im_strel, radius, x, y)
@@ -215,9 +215,9 @@ def bundle_of_tubes(shape: List[int], spacing: int):
         A boolean array with ``True`` values denoting the pore space
     """
     shape = np.array(shape)
-    if sp.size(shape) == 1:
+    if np.size(shape) == 1:
         shape = np.full((3, ), int(shape))
-    if sp.size(shape) == 2:
+    if np.size(shape) == 2:
         shape = np.hstack((shape, [1]))
     temp = np.zeros(shape=shape[:2])
     Xi = np.ceil(np.linspace(spacing/2,
@@ -231,7 +231,7 @@ def bundle_of_tubes(shape: List[int], spacing: int):
     temp[tuple(np.meshgrid(Xi, Yi))] = 1
     inds = np.where(temp)
     for i in range(len(inds[0])):
-        r = sp.random.randint(1, (spacing/2))
+        r = np.random.randint(1, (spacing/2))
         try:
             s1 = slice(inds[0][i]-r, inds[0][i]+r+1)
             s2 = slice(inds[1][i]-r, inds[1][i]+r+1)
@@ -280,7 +280,7 @@ def polydisperse_spheres(shape: List[int], porosity: float, dist,
         A boolean array with ``True`` values denoting the pore space
     """
     shape = np.array(shape)
-    if sp.size(shape) == 1:
+    if np.size(shape) == 1:
         shape = np.full((3, ), int(shape))
     Rs = dist.interval(np.linspace(0.05, 0.95, nbins))
     Rs = np.vstack(Rs).T
@@ -326,10 +326,10 @@ def voronoi_edges(shape: List[int], radius: int, ncells: int,
     print(78*'―')
     print('voronoi_edges: Generating', ncells, 'cells')
     shape = np.array(shape)
-    if sp.size(shape) == 1:
+    if np.size(shape) == 1:
         shape = np.full((3, ), int(shape))
     im = np.zeros(shape, dtype=bool)
-    base_pts = sp.rand(ncells, 3)*shape
+    base_pts = np.random.rand(ncells, 3)*shape
     if flat_faces:
         # Reflect base points
         Nx, Ny, Nz = shape
@@ -428,7 +428,7 @@ def lattice_spheres(shape: List[int], radius: int, offset: int = 0,
     print('lattice_spheres: Generating ' + lattice + ' lattice')
     r = radius
     shape = np.array(shape)
-    if sp.size(shape) == 1:
+    if np.size(shape) == 1:
         shape = np.full((3, ), int(shape))
     im = np.zeros(shape, dtype=bool)
     im = im.squeeze()
@@ -534,14 +534,14 @@ def overlapping_spheres(shape: List[int], radius: int, porosity: float,
 
     """
     shape = np.array(shape)
-    if sp.size(shape) == 1:
+    if np.size(shape) == 1:
         shape = np.full((3, ), int(shape))
     ndim = (shape != 1).sum()
     s_vol = ps_disk(radius).sum() if ndim == 2 else ps_ball(radius).sum()
 
     bulk_vol = np.prod(shape)
     N = int(np.ceil((1 - porosity)*bulk_vol/s_vol))
-    im = sp.random.random(size=shape)
+    im = np.random.random(size=shape)
 
     # Helper functions for calculating porosity: phi = g(f(N))
     f = lambda N: spim.distance_transform_edt(im > N/bulk_vol) < radius
@@ -629,7 +629,7 @@ def generate_noise(shape: List[int], porosity=None, octaves: int = 3,
     except ModuleNotFoundError:
         raise Exception("The noise package must be installed")
     shape = np.array(shape)
-    if sp.size(shape) == 1:
+    if np.size(shape) == 1:
         Lx, Ly, Lz = np.full((3, ), int(shape))
     elif len(shape) == 2:
         Lx, Ly = shape
@@ -693,10 +693,10 @@ def blobs(shape: List[int], porosity: float = 0.5, blobiness: int = 1):
     """
     blobiness = np.array(blobiness)
     shape = np.array(shape)
-    if sp.size(shape) == 1:
+    if np.size(shape) == 1:
         shape = np.full((3, ), int(shape))
     sigma = np.mean(shape)/(40*blobiness)
-    im = sp.random.random(shape)
+    im = np.random.random(shape)
     im = spim.gaussian_filter(im, sigma=sigma)
     im = norm_to_uniform(im, scale=[0, 1])
     if porosity:
@@ -745,12 +745,12 @@ def cylinders(shape: List[int], radius: int, ncylinders: int,
         A boolean array with ``True`` values denoting the pore space
     """
     shape = np.array(shape)
-    if sp.size(shape) == 1:
+    if np.size(shape) == 1:
         shape = np.full((3, ), int(shape))
-    elif sp.size(shape) == 2:
+    elif np.size(shape) == 2:
         raise Exception("2D cylinders don't make sense")
     if length is None:
-        R = np.sqrt(np.sum(sp.square(shape))).astype(int)
+        R = np.sqrt(np.sum(np.square(shape))).astype(int)
     else:
         R = length/2
     im = np.zeros(shape)
@@ -762,10 +762,10 @@ def cylinders(shape: List[int], radius: int, ncylinders: int,
     n = 0
     while n < ncylinders:
         # Choose a random starting point in domain
-        x = sp.rand(3)*shape
+        x = np.random.rand(3)*shape
         # Chose a random phi and theta within given ranges
-        phi = (np.pi/2 - np.pi*sp.rand())*phi_max/90
-        theta = (np.pi/2 - np.pi*sp.rand())*theta_max/90
+        phi = (np.pi/2 - np.pi*np.random.rand())*phi_max/90
+        theta = (np.pi/2 - np.pi*np.random.rand())*theta_max/90
         X0 = R*np.array([np.cos(phi)*np.cos(theta),
                          np.cos(phi)*np.cos(theta),
                          np.cos(phi)])

--- a/porespy/generators/__imgen__.py
+++ b/porespy/generators/__imgen__.py
@@ -239,7 +239,7 @@ def bundle_of_tubes(shape: List[int], spacing: int):
         except ValueError:
             odd_shape = np.shape(temp[s1, s2])
             temp[s1, s2] = ps_disk(r)[:odd_shape[0], :odd_shape[1]]
-    im = sp.broadcast_to(array=sp.atleast_3d(temp), shape=shape)
+    im = np.broadcast_to(array=sp.atleast_3d(temp), shape=shape)
     return im
 
 

--- a/porespy/generators/__imgen__.py
+++ b/porespy/generators/__imgen__.py
@@ -1,10 +1,11 @@
 import porespy as ps
+import numpy as np
 import scipy as sp
 import scipy.spatial as sptl
 import scipy.ndimage as spim
 from porespy.tools import norm_to_uniform, ps_ball, ps_disk
 from typing import List
-from numpy import array
+
 
 
 def insert_shape(im, element, center=None, corner=None, value=1,
@@ -213,7 +214,7 @@ def bundle_of_tubes(shape: List[int], spacing: int):
     image : ND-array
         A boolean array with ``True`` values denoting the pore space
     """
-    shape = sp.array(shape)
+    shape = np.array(shape)
     if sp.size(shape) == 1:
         shape = sp.full((3, ), int(shape))
     if sp.size(shape) == 2:
@@ -222,13 +223,13 @@ def bundle_of_tubes(shape: List[int], spacing: int):
     Xi = sp.ceil(sp.linspace(spacing/2,
                              shape[0]-(spacing/2)-1,
                              int(shape[0]/spacing)))
-    Xi = sp.array(Xi, dtype=int)
+    Xi = np.array(Xi, dtype=int)
     Yi = sp.ceil(sp.linspace(spacing/2,
                              shape[1]-(spacing/2)-1,
                              int(shape[1]/spacing)))
-    Yi = sp.array(Yi, dtype=int)
+    Yi = np.array(Yi, dtype=int)
     temp[tuple(np.meshgrid(Xi, Yi))] = 1
-    inds = sp.where(temp)
+    inds = np.where(temp)
     for i in range(len(inds[0])):
         r = sp.random.randint(1, (spacing/2))
         try:
@@ -278,7 +279,7 @@ def polydisperse_spheres(shape: List[int], porosity: float, dist,
     image : ND-array
         A boolean array with ``True`` values denoting the pore space
     """
-    shape = sp.array(shape)
+    shape = np.array(shape)
     if sp.size(shape) == 1:
         shape = sp.full((3, ), int(shape))
     Rs = dist.interval(sp.linspace(0.05, 0.95, nbins))
@@ -286,7 +287,7 @@ def polydisperse_spheres(shape: List[int], porosity: float, dist,
     Rs = (Rs[:-1] + Rs[1:])/2
     Rs = sp.clip(Rs.flatten(), a_min=r_min, a_max=None)
     phi_desired = 1 - (1 - porosity)/(len(Rs))
-    im = sp.ones(shape, dtype=bool)
+    im = np.ones(shape, dtype=bool)
     for r in Rs:
         phi_im = im.sum() / sp.prod(shape)
         phi_corrected = 1 - (1 - phi_desired) / phi_im
@@ -324,7 +325,7 @@ def voronoi_edges(shape: List[int], radius: int, ncells: int,
     """
     print(78*'―')
     print('voronoi_edges: Generating', ncells, 'cells')
-    shape = sp.array(shape)
+    shape = np.array(shape)
     if sp.size(shape) == 1:
         shape = sp.full((3, ), int(shape))
     im = np.zeros(shape, dtype=bool)
@@ -344,7 +345,7 @@ def voronoi_edges(shape: List[int], radius: int, ncells: int,
         base_pts = sp.vstack((base_pts, [1, 1, -1] * orig_pts))
     vor = sptl.Voronoi(points=base_pts)
     vor.vertices = sp.around(vor.vertices)
-    vor.vertices *= (sp.array(im.shape)-1) / sp.array(im.shape)
+    vor.vertices *= (np.array(im.shape)-1) / np.array(im.shape)
     vor.edges = _get_Voronoi_edges(vor)
     for row in vor.edges:
         pts = vor.vertices[row].astype(int)
@@ -385,7 +386,7 @@ def _get_Voronoi_edges(vor):
     edges = edges[:, 0] + 1j*edges[:, 1]  # Convert to imaginary
     edges = sp.unique(edges)  # Remove duplicates
     edges = sp.vstack((sp.real(edges), sp.imag(edges))).T  # Back to real
-    edges = sp.array(edges, dtype=int)
+    edges = np.array(edges, dtype=int)
     return edges
 
 
@@ -426,7 +427,7 @@ def lattice_spheres(shape: List[int], radius: int, offset: int = 0,
     print(78*'―')
     print('lattice_spheres: Generating ' + lattice + ' lattice')
     r = radius
-    shape = sp.array(shape)
+    shape = np.array(shape)
     if sp.size(shape) == 1:
         shape = sp.full((3, ), int(shape))
     im = np.zeros(shape, dtype=bool)
@@ -442,12 +443,12 @@ def lattice_spheres(shape: List[int], radius: int, offset: int = 0,
 
     if lattice in ['sq', 'square']:
         spacing = 2*r
-        s = int(spacing/2) + sp.array(offset)
+        s = int(spacing/2) + np.array(offset)
         coords = sp.mgrid[r:im.shape[0]-r:2*s,
                           r:im.shape[1]-r:2*s]
         im[coords[0], coords[1]] = 1
     elif lattice in ['tri', 'triangular']:
-        spacing = 2*np.floor(sp.sqrt(2*(r**2))).astype(int)
+        spacing = 2*np.floor(np.sqrt(2*(r**2))).astype(int)
         s = int(spacing/2) + offset
         coords = sp.mgrid[r:im.shape[0]-r:2*s,
                           r:im.shape[1]-r:2*s]
@@ -457,13 +458,13 @@ def lattice_spheres(shape: List[int], radius: int, offset: int = 0,
         im[coords[0], coords[1]] = 1
     elif lattice in ['sc', 'simple cubic', 'cubic']:
         spacing = 2*r
-        s = int(spacing/2) + sp.array(offset)
+        s = int(spacing/2) + np.array(offset)
         coords = sp.mgrid[r:im.shape[0]-r:2*s,
                           r:im.shape[1]-r:2*s,
                           r:im.shape[2]-r:2*s]
         im[coords[0], coords[1], coords[2]] = 1
     elif lattice in ['bcc', 'body cenetered cubic']:
-        spacing = 2*np.floor(sp.sqrt(4/3*(r**2))).astype(int)
+        spacing = 2*np.floor(np.sqrt(4/3*(r**2))).astype(int)
         s = int(spacing/2) + offset
         coords = sp.mgrid[r:im.shape[0]-r:2*s,
                           r:im.shape[1]-r:2*s,
@@ -474,7 +475,7 @@ def lattice_spheres(shape: List[int], radius: int, offset: int = 0,
                           s+r:im.shape[2]-r:2*s]
         im[coords[0], coords[1], coords[2]] = 1
     elif lattice in ['fcc', 'face centered cubic']:
-        spacing = 2*np.floor(sp.sqrt(2*(r**2))).astype(int)
+        spacing = 2*np.floor(np.sqrt(2*(r**2))).astype(int)
         s = int(spacing/2) + offset
         coords = sp.mgrid[r:im.shape[0]-r:2*s,
                           r:im.shape[1]-r:2*s,
@@ -532,7 +533,7 @@ def overlapping_spheres(shape: List[int], radius: int, porosity: float,
     returned image.
 
     """
-    shape = sp.array(shape)
+    shape = np.array(shape)
     if sp.size(shape) == 1:
         shape = sp.full((3, ), int(shape))
     ndim = (shape != 1).sum()
@@ -627,7 +628,7 @@ def generate_noise(shape: List[int], porosity=None, octaves: int = 3,
         import noise
     except ModuleNotFoundError:
         raise Exception("The noise package must be installed")
-    shape = sp.array(shape)
+    shape = np.array(shape)
     if sp.size(shape) == 1:
         Lx, Ly, Lz = sp.full((3, ), int(shape))
     elif len(shape) == 2:
@@ -645,7 +646,7 @@ def generate_noise(shape: List[int], porosity=None, octaves: int = 3,
     elif frequency.size == 2:
         freq = sp.concatenate((frequency, [1]))
     else:
-        freq = sp.array(frequency)
+        freq = np.array(frequency)
     im = np.zeros(shape=[Lx, Ly, Lz], dtype=float)
     for x in range(Lx):
         for y in range(Ly):
@@ -690,8 +691,8 @@ def blobs(shape: List[int], porosity: float = 0.5, blobiness: int = 1):
     norm_to_uniform
 
     """
-    blobiness = sp.array(blobiness)
-    shape = sp.array(shape)
+    blobiness = np.array(blobiness)
+    shape = np.array(shape)
     if sp.size(shape) == 1:
         shape = sp.full((3, ), int(shape))
     sigma = sp.mean(shape)/(40*blobiness)
@@ -743,13 +744,13 @@ def cylinders(shape: List[int], radius: int, ncylinders: int,
     image : ND-array
         A boolean array with ``True`` values denoting the pore space
     """
-    shape = sp.array(shape)
+    shape = np.array(shape)
     if sp.size(shape) == 1:
         shape = sp.full((3, ), int(shape))
     elif sp.size(shape) == 2:
         raise Exception("2D cylinders don't make sense")
     if length is None:
-        R = sp.sqrt(sp.sum(sp.square(shape))).astype(int)
+        R = np.sqrt(sp.sum(sp.square(shape))).astype(int)
     else:
         R = length/2
     im = np.zeros(shape)
@@ -765,7 +766,7 @@ def cylinders(shape: List[int], radius: int, ncylinders: int,
         # Chose a random phi and theta within given ranges
         phi = (sp.pi/2 - sp.pi*sp.rand())*phi_max/90
         theta = (sp.pi/2 - sp.pi*sp.rand())*theta_max/90
-        X0 = R*sp.array([sp.cos(phi)*sp.cos(theta),
+        X0 = R*np.array([sp.cos(phi)*sp.cos(theta),
                          sp.cos(phi)*sp.sin(theta),
                          sp.sin(phi)])
         [X0, X1] = [x + X0, x - X0]
@@ -776,7 +777,7 @@ def cylinders(shape: List[int], radius: int, ncylinders: int,
         if sp.any(valid):
             im[crds[0][valid], crds[1][valid], crds[2][valid]] = 1
             n += 1
-    im = sp.array(im, dtype=bool)
+    im = np.array(im, dtype=bool)
     dt = spim.distance_transform_edt(~im) < radius
     return ~dt
 
@@ -890,7 +891,7 @@ def _remove_edge(im, r):
     Fill in the edges of the input image.
     Used by RSA to ensure that no elements are placed too close to the edge.
     '''
-    edge = sp.ones_like(im)
+    edge = np.ones_like(im)
     if len(im.shape) == 2:
         sx, sy = im.shape
         edge[r:sx-r, r:sy-r] = im[r:sx-r, r:sy-r]

--- a/porespy/generators/__imgen__.py
+++ b/porespy/generators/__imgen__.py
@@ -153,7 +153,7 @@ def RSA(im: array, radius: int, volume_fraction: int = 1,
     else:
         im_strel = ps_ball(radius)
         mask_strel = ps_ball(mrad)
-    if sp.any(im > 0):
+    if np.any(im > 0):
         # Dilate existing objects by im_strel to remove pixels near them
         # from consideration for sphere placement
         mask = ps.tools.fftmorphology(im > 0, im_strel > 0, mode='dilate')
@@ -379,7 +379,7 @@ def _get_Voronoi_edges(vor):
         edges[0].extend(facet[:-1]+[facet[-1]])
         edges[1].extend(facet[1:]+[facet[0]])
     edges = sp.vstack(edges).T  # Convert to scipy-friendly format
-    mask = sp.any(edges == -1, axis=1)  # Identify edges at infinity
+    mask = np.any(edges == -1, axis=1)  # Identify edges at infinity
     edges = edges[~mask]  # Remove edges at infinity
     edges = sp.sort(edges, axis=1)  # Move all points to upper triangle
     # Remove duplicate pairs
@@ -771,10 +771,10 @@ def cylinders(shape: List[int], radius: int, ncylinders: int,
                          sp.sin(phi)])
         [X0, X1] = [x + X0, x - X0]
         crds = line_segment(X0, X1)
-        lower = ~sp.any(sp.vstack(crds).T < [0, 0, 0], axis=1)
-        upper = ~sp.any(sp.vstack(crds).T >= shape, axis=1)
+        lower = ~np.any(sp.vstack(crds).T < [0, 0, 0], axis=1)
+        upper = ~np.any(sp.vstack(crds).T >= shape, axis=1)
         valid = upper*lower
-        if sp.any(valid):
+        if np.any(valid):
             im[crds[0][valid], crds[1][valid], crds[2][valid]] = 1
             n += 1
     im = np.array(im, dtype=bool)

--- a/porespy/generators/__imgen__.py
+++ b/porespy/generators/__imgen__.py
@@ -216,7 +216,7 @@ def bundle_of_tubes(shape: List[int], spacing: int):
     """
     shape = np.array(shape)
     if sp.size(shape) == 1:
-        shape = sp.full((3, ), int(shape))
+        shape = np.full((3, ), int(shape))
     if sp.size(shape) == 2:
         shape = sp.hstack((shape, [1]))
     temp = np.zeros(shape=shape[:2])
@@ -281,7 +281,7 @@ def polydisperse_spheres(shape: List[int], porosity: float, dist,
     """
     shape = np.array(shape)
     if sp.size(shape) == 1:
-        shape = sp.full((3, ), int(shape))
+        shape = np.full((3, ), int(shape))
     Rs = dist.interval(np.linspace(0.05, 0.95, nbins))
     Rs = sp.vstack(Rs).T
     Rs = (Rs[:-1] + Rs[1:])/2
@@ -327,7 +327,7 @@ def voronoi_edges(shape: List[int], radius: int, ncells: int,
     print('voronoi_edges: Generating', ncells, 'cells')
     shape = np.array(shape)
     if sp.size(shape) == 1:
-        shape = sp.full((3, ), int(shape))
+        shape = np.full((3, ), int(shape))
     im = np.zeros(shape, dtype=bool)
     base_pts = sp.rand(ncells, 3)*shape
     if flat_faces:
@@ -429,7 +429,7 @@ def lattice_spheres(shape: List[int], radius: int, offset: int = 0,
     r = radius
     shape = np.array(shape)
     if sp.size(shape) == 1:
-        shape = sp.full((3, ), int(shape))
+        shape = np.full((3, ), int(shape))
     im = np.zeros(shape, dtype=bool)
     im = im.squeeze()
 
@@ -535,7 +535,7 @@ def overlapping_spheres(shape: List[int], radius: int, porosity: float,
     """
     shape = np.array(shape)
     if sp.size(shape) == 1:
-        shape = sp.full((3, ), int(shape))
+        shape = np.full((3, ), int(shape))
     ndim = (shape != 1).sum()
     s_vol = ps_disk(radius).sum() if ndim == 2 else ps_ball(radius).sum()
 
@@ -630,7 +630,7 @@ def generate_noise(shape: List[int], porosity=None, octaves: int = 3,
         raise Exception("The noise package must be installed")
     shape = np.array(shape)
     if sp.size(shape) == 1:
-        Lx, Ly, Lz = sp.full((3, ), int(shape))
+        Lx, Ly, Lz = np.full((3, ), int(shape))
     elif len(shape) == 2:
         Lx, Ly = shape
         Lz = 1
@@ -642,7 +642,7 @@ def generate_noise(shape: List[int], porosity=None, octaves: int = 3,
         f = noise.pnoise3
     frequency = sp.atleast_1d(frequency)
     if frequency.size == 1:
-        freq = sp.full(shape=[3, ], fill_value=frequency[0])
+        freq = np.full(shape=[3, ], fill_value=frequency[0])
     elif frequency.size == 2:
         freq = sp.concatenate((frequency, [1]))
     else:
@@ -694,7 +694,7 @@ def blobs(shape: List[int], porosity: float = 0.5, blobiness: int = 1):
     blobiness = np.array(blobiness)
     shape = np.array(shape)
     if sp.size(shape) == 1:
-        shape = sp.full((3, ), int(shape))
+        shape = np.full((3, ), int(shape))
     sigma = sp.mean(shape)/(40*blobiness)
     im = sp.random.random(shape)
     im = spim.gaussian_filter(im, sigma=sigma)
@@ -746,7 +746,7 @@ def cylinders(shape: List[int], radius: int, ncylinders: int,
     """
     shape = np.array(shape)
     if sp.size(shape) == 1:
-        shape = sp.full((3, ), int(shape))
+        shape = np.full((3, ), int(shape))
     elif sp.size(shape) == 2:
         raise Exception("2D cylinders don't make sense")
     if length is None:

--- a/porespy/generators/__imgen__.py
+++ b/porespy/generators/__imgen__.py
@@ -804,14 +804,14 @@ def line_segment(X0, X1):
     X1 = np.around(X1).astype(int)
     if len(X0) == 3:
         L = np.amax(sp.absolute([[X1[0]-X0[0]], [X1[1]-X0[1]], [X1[2]-X0[2]]])) + 1
-        x = sp.rint(np.linspace(X0[0], X1[0], L)).astype(int)
-        y = sp.rint(np.linspace(X0[1], X1[1], L)).astype(int)
-        z = sp.rint(np.linspace(X0[2], X1[2], L)).astype(int)
+        x = np.rint(np.linspace(X0[0], X1[0], L)).astype(int)
+        y = np.rint(np.linspace(X0[1], X1[1], L)).astype(int)
+        z = np.rint(np.linspace(X0[2], X1[2], L)).astype(int)
         return [x, y, z]
     else:
         L = np.amax(sp.absolute([[X1[0]-X0[0]], [X1[1]-X0[1]]])) + 1
-        x = sp.rint(np.linspace(X0[0], X1[0], L)).astype(int)
-        y = sp.rint(np.linspace(X0[1], X1[1], L)).astype(int)
+        x = np.rint(np.linspace(X0[0], X1[0], L)).astype(int)
+        y = np.rint(np.linspace(X0[1], X1[1], L)).astype(int)
         return [x, y]
 
 

--- a/porespy/generators/__imgen__.py
+++ b/porespy/generators/__imgen__.py
@@ -237,7 +237,7 @@ def bundle_of_tubes(shape: List[int], spacing: int):
             s2 = slice(inds[1][i]-r, inds[1][i]+r+1)
             temp[s1, s2] = ps_disk(r)
         except ValueError:
-            odd_shape = sp.shape(temp[s1, s2])
+            odd_shape = np.shape(temp[s1, s2])
             temp[s1, s2] = ps_disk(r)[:odd_shape[0], :odd_shape[1]]
     im = sp.broadcast_to(array=sp.atleast_3d(temp), shape=shape)
     return im

--- a/porespy/generators/__imgen__.py
+++ b/porespy/generators/__imgen__.py
@@ -55,7 +55,7 @@ def insert_shape(im, element, center=None, corner=None, value=1,
     s_el = []
     if (center is not None) and (corner is None):
         for dim in range(im.ndim):
-            r, d = sp.divmod(element.shape[dim], 2)
+            r, d = np.divmod(element.shape[dim], 2)
             if d == 0:
                 raise Exception('Cannot specify center point when element ' +
                                 'has one or more even dimension')
@@ -169,7 +169,7 @@ def RSA(im: array, radius: int, volume_fraction: int = 1,
     else:
         raise Exception('Unrecognized mode: ' + mode)
     vf = im.sum()/im.size
-    free_spots = sp.argwhere(mask == 0)
+    free_spots = np.argwhere(mask == 0)
     i = 0
     while vf <= volume_fraction and len(free_spots) > 0:
         choice = sp.random.randint(0, len(free_spots), size=1)
@@ -183,7 +183,7 @@ def RSA(im: array, radius: int, volume_fraction: int = 1,
             im = _fit_strel_to_im_3d(im, im_strel, radius, x, y, z)
             mask = _fit_strel_to_im_3d(mask, mask_strel, mrad, x, y, z)
             im[x, y, z] = 2
-        free_spots = sp.argwhere(mask == 0)
+        free_spots = np.argwhere(mask == 0)
         vf = im.sum()/im.size
         i += 1
     if vf > volume_fraction:
@@ -239,7 +239,7 @@ def bundle_of_tubes(shape: List[int], spacing: int):
         except ValueError:
             odd_shape = np.shape(temp[s1, s2])
             temp[s1, s2] = ps_disk(r)[:odd_shape[0], :odd_shape[1]]
-    im = np.broadcast_to(array=sp.atleast_3d(temp), shape=shape)
+    im = np.broadcast_to(array=np.atleast_3d(temp), shape=shape)
     return im
 
 
@@ -285,7 +285,7 @@ def polydisperse_spheres(shape: List[int], porosity: float, dist,
     Rs = dist.interval(np.linspace(0.05, 0.95, nbins))
     Rs = np.vstack(Rs).T
     Rs = (Rs[:-1] + Rs[1:])/2
-    Rs = sp.clip(Rs.flatten(), a_min=r_min, a_max=None)
+    Rs = np.clip(Rs.flatten(), a_min=r_min, a_max=None)
     phi_desired = 1 - (1 - porosity)/(len(Rs))
     im = np.ones(shape, dtype=bool)
     for r in Rs:
@@ -381,11 +381,11 @@ def _get_Voronoi_edges(vor):
     edges = np.vstack(edges).T  # Convert to scipy-friendly format
     mask = np.any(edges == -1, axis=1)  # Identify edges at infinity
     edges = edges[~mask]  # Remove edges at infinity
-    edges = sp.sort(edges, axis=1)  # Move all points to upper triangle
+    edges = np.sort(edges, axis=1)  # Move all points to upper triangle
     # Remove duplicate pairs
     edges = edges[:, 0] + 1j*edges[:, 1]  # Convert to imaginary
     edges = np.unique(edges)  # Remove duplicates
-    edges = np.vstack((sp.real(edges), sp.imag(edges))).T  # Back to real
+    edges = np.vstack((np.real(edges), np.imag(edges))).T  # Back to real
     edges = np.array(edges, dtype=int)
     return edges
 
@@ -640,11 +640,11 @@ def generate_noise(shape: List[int], porosity=None, octaves: int = 3,
         f = noise.snoise3
     else:
         f = noise.pnoise3
-    frequency = sp.atleast_1d(frequency)
+    frequency = np.atleast_1d(frequency)
     if frequency.size == 1:
         freq = np.full(shape=[3, ], fill_value=frequency[0])
     elif frequency.size == 2:
-        freq = sp.concatenate((frequency, [1]))
+        freq = np.concatenate((frequency, [1]))
     else:
         freq = np.array(frequency)
     im = np.zeros(shape=[Lx, Ly, Lz], dtype=float)
@@ -803,13 +803,13 @@ def line_segment(X0, X1):
     X0 = np.around(X0).astype(int)
     X1 = np.around(X1).astype(int)
     if len(X0) == 3:
-        L = np.amax(sp.absolute([[X1[0]-X0[0]], [X1[1]-X0[1]], [X1[2]-X0[2]]])) + 1
+        L = np.amax(np.absolute([[X1[0]-X0[0]], [X1[1]-X0[1]], [X1[2]-X0[2]]])) + 1
         x = np.rint(np.linspace(X0[0], X1[0], L)).astype(int)
         y = np.rint(np.linspace(X0[1], X1[1], L)).astype(int)
         z = np.rint(np.linspace(X0[2], X1[2], L)).astype(int)
         return [x, y, z]
     else:
-        L = np.amax(sp.absolute([[X1[0]-X0[0]], [X1[1]-X0[1]]])) + 1
+        L = np.amax(np.absolute([[X1[0]-X0[0]], [X1[1]-X0[1]]])) + 1
         x = np.rint(np.linspace(X0[0], X1[0], L)).astype(int)
         y = np.rint(np.linspace(X0[1], X1[1], L)).astype(int)
         return [x, y]

--- a/porespy/metrics/__funcs__.py
+++ b/porespy/metrics/__funcs__.py
@@ -53,8 +53,8 @@ def representative_elementary_volume(im, npoints=1000):
 
     """
     im_temp = np.zeros_like(im)
-    crds = sp.array(sp.rand(npoints, im.ndim)*im.shape, dtype=int)
-    pads = sp.array(sp.rand(npoints)*sp.amin(im.shape)/2+10, dtype=int)
+    crds = np.array(sp.rand(npoints, im.ndim)*im.shape, dtype=int)
+    pads = np.array(sp.rand(npoints)*sp.amin(im.shape)/2+10, dtype=int)
     im_temp[tuple(crds.T)] = True
     labels, N = spim.label(input=im_temp)
     slices = spim.find_objects(input=labels)
@@ -226,7 +226,7 @@ def porosity(im):
     calculation of accessible porosity, rather than overall porosity.
 
     """
-    im = sp.array(im, dtype=int)
+    im = np.array(im, dtype=int)
     Vp = sp.sum(im == 1)
     Vs = sp.sum(im == 0)
     e = Vp/(Vs + Vp)
@@ -313,11 +313,11 @@ def _radial_profile(autocorr, r_max, nbins=100):
     if len(autocorr.shape) == 2:
         adj = sp.reshape(autocorr.shape, [2, 1, 1])
         inds = sp.indices(autocorr.shape) - adj/2
-        dt = sp.sqrt(inds[0]**2 + inds[1]**2)
+        dt = np.sqrt(inds[0]**2 + inds[1]**2)
     elif len(autocorr.shape) == 3:
         adj = sp.reshape(autocorr.shape, [3, 1, 1, 1])
         inds = sp.indices(autocorr.shape) - adj/2
-        dt = sp.sqrt(inds[0]**2 + inds[1]**2 + inds[2]**2)
+        dt = np.sqrt(inds[0]**2 + inds[1]**2 + inds[2]**2)
     else:
         raise Exception('Image dimensions must be 2 or 3')
     bin_size = np.int(np.ceil(r_max/nbins))
@@ -475,7 +475,7 @@ def chord_counts(im):
     """
     labels, N = spim.label(im > 0)
     props = regionprops(labels, coordinates='xy')
-    chord_lens = sp.array([i.filled_area for i in props])
+    chord_lens = np.array([i.filled_area for i in props])
     return chord_lens
 
 
@@ -595,7 +595,7 @@ def chord_length_distribution(im, bins=None, log=False, voxel_size=1,
     """
     x = chord_counts(im)
     if bins is None:
-        bins = sp.array(range(0, x.max()+2))*voxel_size
+        bins = np.array(range(0, x.max()+2))*voxel_size
     x = x*voxel_size
     if log:
         x = sp.log10(x)
@@ -697,7 +697,7 @@ def region_interface_areas(regions, areas, voxel_size=1, strel=None):
                     mesh = mesh_region(region=merged_region, strel=strel)
                     sa_combined.append(mesh_surface_area(mesh))
     # Interfacial area calculation
-    cn = sp.array(cn)
+    cn = np.array(cn)
     ia = 0.5 * (sa[cn[:, 0]] + sa[cn[:, 1]] - sa_combined)
     ia[ia <= 0] = 1
     result = namedtuple('interfacial_areas', ('conns', 'area'))

--- a/porespy/metrics/__funcs__.py
+++ b/porespy/metrics/__funcs__.py
@@ -65,7 +65,7 @@ def representative_elementary_volume(im, npoints=1000):
         p = pads[i]
         new_s = extend_slice(s, shape=im.shape, pad=p)
         temp = im[new_s]
-        Vp = sp.sum(temp)
+        Vp = np.sum(temp)
         Vt = sp.size(temp)
         porosity[i] = Vp/Vt
         volume[i] = Vt
@@ -227,8 +227,8 @@ def porosity(im):
 
     """
     im = np.array(im, dtype=int)
-    Vp = sp.sum(im == 1)
-    Vs = sp.sum(im == 0)
+    Vp = np.sum(im == 1)
+    Vs = np.sum(im == 0)
     e = Vp/(Vs + Vp)
     return e
 
@@ -824,7 +824,7 @@ def phase_fraction(im, normed=True):
     labels = sp.arange(0, sp.amax(im)+1)
     results = np.zeros_like(labels)
     for i in labels:
-        results[i] = sp.sum(im == i)
+        results[i] = np.sum(im == i)
     if normed:
         results = results/im.size
     return results

--- a/porespy/metrics/__funcs__.py
+++ b/porespy/metrics/__funcs__.py
@@ -680,7 +680,7 @@ def region_interface_areas(regions, areas, voxel_size=1, strel=None):
             im_w_throats = spim.binary_dilation(input=mask_im,
                                                 structure=ball(1))
             im_w_throats = im_w_throats*sub_im
-            Pn = sp.unique(im_w_throats)[1:] - 1
+            Pn = np.unique(im_w_throats)[1:] - 1
             for j in Pn:
                 if j > reg:
                     cn.append([reg, j])

--- a/porespy/metrics/__funcs__.py
+++ b/porespy/metrics/__funcs__.py
@@ -52,14 +52,14 @@ def representative_elementary_volume(im, npoints=1000):
     (1987)
 
     """
-    im_temp = sp.zeros_like(im)
+    im_temp = np.zeros_like(im)
     crds = sp.array(sp.rand(npoints, im.ndim)*im.shape, dtype=int)
     pads = sp.array(sp.rand(npoints)*sp.amin(im.shape)/2+10, dtype=int)
     im_temp[tuple(crds.T)] = True
     labels, N = spim.label(input=im_temp)
     slices = spim.find_objects(input=labels)
-    porosity = sp.zeros(shape=(N,), dtype=float)
-    volume = sp.zeros(shape=(N,), dtype=int)
+    porosity = np.zeros(shape=(N,), dtype=float)
+    volume = np.zeros(shape=(N,), dtype=int)
     for i in tqdm(sp.arange(0, N)):
         s = slices[i]
         p = pads[i]
@@ -269,12 +269,12 @@ def two_point_correlation_bf(im, spacing=10):
                       ' Reduce dimensionality with np.squeeze(im) to avoid' +
                       ' unexpected behavior.')
     if im.ndim == 2:
-        pts = sp.meshgrid(range(0, im.shape[0], spacing),
+        pts = np.meshgrid(range(0, im.shape[0], spacing),
                           range(0, im.shape[1], spacing))
         crds = sp.vstack([pts[0].flatten(),
                           pts[1].flatten()]).T
     elif im.ndim == 3:
-        pts = sp.meshgrid(range(0, im.shape[0], spacing),
+        pts = np.meshgrid(range(0, im.shape[0], spacing),
                           range(0, im.shape[1], spacing),
                           range(0, im.shape[2], spacing))
         crds = sp.vstack([pts[0].flatten(),
@@ -666,7 +666,7 @@ def region_interface_areas(regions, areas, voxel_size=1, strel=None):
     slices = spim.find_objects(im)
     # Initialize arrays
     Ps = sp.arange(1, sp.amax(im)+1)
-    sa = sp.zeros_like(Ps, dtype=float)
+    sa = np.zeros_like(Ps, dtype=float)
     sa_combined = []  # Difficult to preallocate since number of conns unknown
     cn = []
     # Start extracting area from im
@@ -743,7 +743,7 @@ def region_surface_areas(regions, voxel_size=1, strel=None):
     slices = spim.find_objects(im)
     # Initialize arrays
     Ps = sp.arange(1, sp.amax(im)+1)
-    sa = sp.zeros_like(Ps, dtype=float)
+    sa = np.zeros_like(Ps, dtype=float)
     # Start extracting marching cube area from im
     for i in tqdm(Ps):
         reg = i - 1
@@ -822,7 +822,7 @@ def phase_fraction(im, normed=True):
     elif im.dtype != int:
         raise Exception('Image must contain integer values for each phase')
     labels = sp.arange(0, sp.amax(im)+1)
-    results = sp.zeros_like(labels)
+    results = np.zeros_like(labels)
     for i in labels:
         results[i] = sp.sum(im == i)
     if normed:

--- a/porespy/metrics/__funcs__.py
+++ b/porespy/metrics/__funcs__.py
@@ -311,11 +311,11 @@ def _radial_profile(autocorr, r_max, nbins=100):
         and an array of ``counts`` in each bin.
     """
     if len(autocorr.shape) == 2:
-        adj = sp.reshape(autocorr.shape, [2, 1, 1])
+        adj = np.reshape(autocorr.shape, [2, 1, 1])
         inds = sp.indices(autocorr.shape) - adj/2
         dt = np.sqrt(inds[0]**2 + inds[1]**2)
     elif len(autocorr.shape) == 3:
-        adj = sp.reshape(autocorr.shape, [3, 1, 1, 1])
+        adj = np.reshape(autocorr.shape, [3, 1, 1, 1])
         inds = sp.indices(autocorr.shape) - adj/2
         dt = np.sqrt(inds[0]**2 + inds[1]**2 + inds[2]**2)
     else:

--- a/porespy/metrics/__funcs__.py
+++ b/porespy/metrics/__funcs__.py
@@ -1,4 +1,3 @@
-import scipy as sp
 import numpy as np
 import warnings
 from skimage.measure import regionprops

--- a/porespy/metrics/__funcs__.py
+++ b/porespy/metrics/__funcs__.py
@@ -53,8 +53,8 @@ def representative_elementary_volume(im, npoints=1000):
 
     """
     im_temp = np.zeros_like(im)
-    crds = np.array(sp.rand(npoints, im.ndim)*im.shape, dtype=int)
-    pads = np.array(sp.rand(npoints)*np.amin(im.shape)/2+10, dtype=int)
+    crds = np.array(np.random.rand(npoints, im.ndim)*im.shape, dtype=int)
+    pads = np.array(np.random.rand(npoints)*np.amin(im.shape)/2+10, dtype=int)
     im_temp[tuple(crds.T)] = True
     labels, N = spim.label(input=im_temp)
     slices = spim.find_objects(input=labels)
@@ -66,7 +66,7 @@ def representative_elementary_volume(im, npoints=1000):
         new_s = extend_slice(s, shape=im.shape, pad=p)
         temp = im[new_s]
         Vp = np.sum(temp)
-        Vt = sp.size(temp)
+        Vt = np.size(temp)
         porosity[i] = Vp/Vt
         volume[i] = Vt
     profile = namedtuple('profile', ('volume', 'porosity'))

--- a/porespy/metrics/__funcs__.py
+++ b/porespy/metrics/__funcs__.py
@@ -271,13 +271,13 @@ def two_point_correlation_bf(im, spacing=10):
     if im.ndim == 2:
         pts = np.meshgrid(range(0, im.shape[0], spacing),
                           range(0, im.shape[1], spacing))
-        crds = sp.vstack([pts[0].flatten(),
+        crds = np.vstack([pts[0].flatten(),
                           pts[1].flatten()]).T
     elif im.ndim == 3:
         pts = np.meshgrid(range(0, im.shape[0], spacing),
                           range(0, im.shape[1], spacing),
                           range(0, im.shape[2], spacing))
-        crds = sp.vstack([pts[0].flatten(),
+        crds = np.vstack([pts[0].flatten(),
                           pts[1].flatten(),
                           pts[2].flatten()]).T
     dmat = sptl.distance.cdist(XA=crds, XB=crds)

--- a/porespy/metrics/__funcs__.py
+++ b/porespy/metrics/__funcs__.py
@@ -60,7 +60,7 @@ def representative_elementary_volume(im, npoints=1000):
     slices = spim.find_objects(input=labels)
     porosity = np.zeros(shape=(N,), dtype=float)
     volume = np.zeros(shape=(N,), dtype=int)
-    for i in tqdm(sp.arange(0, N)):
+    for i in tqdm(np.arange(0, N)):
         s = slices[i]
         p = pads[i]
         new_s = extend_slice(s, shape=im.shape, pad=p)
@@ -665,7 +665,7 @@ def region_interface_areas(regions, areas, voxel_size=1, strel=None):
     # Get 'slices' into im for each region
     slices = spim.find_objects(im)
     # Initialize arrays
-    Ps = sp.arange(1, np.amax(im)+1)
+    Ps = np.arange(1, np.amax(im)+1)
     sa = np.zeros_like(Ps, dtype=float)
     sa_combined = []  # Difficult to preallocate since number of conns unknown
     cn = []
@@ -742,7 +742,7 @@ def region_surface_areas(regions, voxel_size=1, strel=None):
     # Get 'slices' into im for each pore region
     slices = spim.find_objects(im)
     # Initialize arrays
-    Ps = sp.arange(1, np.amax(im)+1)
+    Ps = np.arange(1, np.amax(im)+1)
     sa = np.zeros_like(Ps, dtype=float)
     # Start extracting marching cube area from im
     for i in tqdm(Ps):
@@ -821,7 +821,7 @@ def phase_fraction(im, normed=True):
         im = im.astype(int)
     elif im.dtype != int:
         raise Exception('Image must contain integer values for each phase')
-    labels = sp.arange(0, np.amax(im)+1)
+    labels = np.arange(0, np.amax(im)+1)
     results = np.zeros_like(labels)
     for i in labels:
         results[i] = np.sum(im == i)

--- a/porespy/metrics/__funcs__.py
+++ b/porespy/metrics/__funcs__.py
@@ -54,7 +54,7 @@ def representative_elementary_volume(im, npoints=1000):
     """
     im_temp = np.zeros_like(im)
     crds = np.array(sp.rand(npoints, im.ndim)*im.shape, dtype=int)
-    pads = np.array(sp.rand(npoints)*sp.amin(im.shape)/2+10, dtype=int)
+    pads = np.array(sp.rand(npoints)*np.amin(im.shape)/2+10, dtype=int)
     im_temp[tuple(crds.T)] = True
     labels, N = spim.label(input=im_temp)
     slices = spim.find_objects(input=labels)
@@ -253,7 +253,7 @@ def two_point_correlation_bf(im, spacing=10):
         function.  The x array is the distances between points and the y array
         is corresponding probabilities that points of a given distance both
         lie in the void space. The distance values are binned as follows:
-        ``bins = range(start=0, stop=sp.amin(im.shape)/2, stride=spacing)``
+        ``bins = range(start=0, stop=np.amin(im.shape)/2, stride=spacing)``
 
     Notes
     -----
@@ -283,7 +283,7 @@ def two_point_correlation_bf(im, spacing=10):
     dmat = sptl.distance.cdist(XA=crds, XB=crds)
     hits = im[tuple(pts)].flatten()
     dmat = dmat[hits, :]
-    h1 = sp.histogram(dmat, bins=range(0, int(sp.amin(im.shape)/2), spacing))
+    h1 = sp.histogram(dmat, bins=range(0, int(np.amin(im.shape)/2), spacing))
     dmat = dmat[:, hits]
     h2 = sp.histogram(dmat, bins=h1[1])
     tpcf = namedtuple('two_point_correlation_function',
@@ -665,7 +665,7 @@ def region_interface_areas(regions, areas, voxel_size=1, strel=None):
     # Get 'slices' into im for each region
     slices = spim.find_objects(im)
     # Initialize arrays
-    Ps = sp.arange(1, sp.amax(im)+1)
+    Ps = sp.arange(1, np.amax(im)+1)
     sa = np.zeros_like(Ps, dtype=float)
     sa_combined = []  # Difficult to preallocate since number of conns unknown
     cn = []
@@ -742,7 +742,7 @@ def region_surface_areas(regions, voxel_size=1, strel=None):
     # Get 'slices' into im for each pore region
     slices = spim.find_objects(im)
     # Initialize arrays
-    Ps = sp.arange(1, sp.amax(im)+1)
+    Ps = sp.arange(1, np.amax(im)+1)
     sa = np.zeros_like(Ps, dtype=float)
     # Start extracting marching cube area from im
     for i in tqdm(Ps):
@@ -821,7 +821,7 @@ def phase_fraction(im, normed=True):
         im = im.astype(int)
     elif im.dtype != int:
         raise Exception('Image must contain integer values for each phase')
-    labels = sp.arange(0, sp.amax(im)+1)
+    labels = sp.arange(0, np.amax(im)+1)
     results = np.zeros_like(labels)
     for i in labels:
         results[i] = np.sum(im == i)

--- a/porespy/metrics/__regionprops__.py
+++ b/porespy/metrics/__regionprops__.py
@@ -1,3 +1,4 @@
+import numpy as np
 import scipy as sp
 import scipy.ndimage as spim
 from tqdm import tqdm
@@ -90,7 +91,7 @@ def props_to_image(regionprops, shape, prop):
     regionprops_3d
 
     """
-    im = sp.zeros(shape=shape)
+    im = np.zeros(shape=shape)
     for r in regionprops:
         if prop == 'convex':
             mask = r.convex_image

--- a/porespy/metrics/__regionprops__.py
+++ b/porespy/metrics/__regionprops__.py
@@ -194,7 +194,7 @@ def regionprops_3D(im):
         results[i].volume = results[i].area
         # ---------------------------------------------------------------------
         # Volume of bounding box, in voxels
-        results[i].bbox_volume = sp.prod(mask.shape)
+        results[i].bbox_volume = np.prod(mask.shape)
         # ---------------------------------------------------------------------
         # Create an image of the border
         results[i].border = dt == 1

--- a/porespy/metrics/__regionprops__.py
+++ b/porespy/metrics/__regionprops__.py
@@ -1,5 +1,4 @@
 import numpy as np
-import scipy as sp
 import scipy.ndimage as spim
 from tqdm import tqdm
 from porespy.tools import extract_subsection, bbox_to_slices

--- a/porespy/metrics/__regionprops__.py
+++ b/porespy/metrics/__regionprops__.py
@@ -205,7 +205,7 @@ def regionprops_3D(im):
         results[i].inscribed_sphere = inv_dt < r
         # ---------------------------------------------------------------------
         # Find surface area using marching cubes and analyze the mesh
-        tmp = np.pad(sp.atleast_3d(mask), pad_width=1, mode='constant')
+        tmp = np.pad(np.atleast_3d(mask), pad_width=1, mode='constant')
         tmp = spim.convolve(tmp, weights=ball(1))/5
         verts, faces, norms, vals = marching_cubes_lewiner(volume=tmp, level=0)
         results[i].surface_mesh_vertices = verts

--- a/porespy/metrics/__regionprops__.py
+++ b/porespy/metrics/__regionprops__.py
@@ -215,8 +215,8 @@ def regionprops_3D(im):
         # ---------------------------------------------------------------------
         # Find sphericity
         vol = results[i].volume
-        r = (3/4/sp.pi*vol)**(1/3)
-        a_equiv = 4*sp.pi*(r)**2
+        r = (3/4/np.pi*vol)**(1/3)
+        a_equiv = 4*np.pi*(r)**2
         a_region = results[i].surface_area
         results[i].sphericity = a_equiv/a_region
         # ---------------------------------------------------------------------

--- a/porespy/metrics/__regionprops__.py
+++ b/porespy/metrics/__regionprops__.py
@@ -43,7 +43,7 @@ def props_to_DataFrame(regionprops):
     for item in reg.__dir__():
         if not item.startswith('_'):
             try:
-                if sp.shape(getattr(reg, item)) == ():
+                if np.shape(getattr(reg, item)) == ():
                     metrics.append(item)
             except (TypeError, NotImplementedError, AttributeError):
                 pass
@@ -183,7 +183,7 @@ def regionprops_3D(im):
     results = regionprops(im, coordinates='xy')
     for i in tqdm(range(len(results))):
         mask = results[i].image
-        mask_padded = sp.pad(mask, pad_width=1, mode='constant')
+        mask_padded = np.pad(mask, pad_width=1, mode='constant')
         temp = spim.distance_transform_edt(mask_padded)
         dt = extract_subsection(temp, shape=mask.shape)
         # ---------------------------------------------------------------------
@@ -205,7 +205,7 @@ def regionprops_3D(im):
         results[i].inscribed_sphere = inv_dt < r
         # ---------------------------------------------------------------------
         # Find surface area using marching cubes and analyze the mesh
-        tmp = sp.pad(sp.atleast_3d(mask), pad_width=1, mode='constant')
+        tmp = np.pad(sp.atleast_3d(mask), pad_width=1, mode='constant')
         tmp = spim.convolve(tmp, weights=ball(1))/5
         verts, faces, norms, vals = marching_cubes_lewiner(volume=tmp, level=0)
         results[i].surface_mesh_vertices = verts

--- a/porespy/metrics/__regionprops__.py
+++ b/porespy/metrics/__regionprops__.py
@@ -51,7 +51,7 @@ def props_to_DataFrame(regionprops):
     d = {}
     for k in metrics:
         try:
-            d[k] = sp.array([r[k] for r in regionprops])
+            d[k] = np.array([r[k] for r in regionprops])
         except ValueError:
             print('Error encountered evaluating ' + k + ' so skipping it')
     # Create pandas data frame an return

--- a/porespy/networks/__funcs__.py
+++ b/porespy/networks/__funcs__.py
@@ -390,7 +390,7 @@ def add_phase_interconnections(net, snow_partitioning_n, voxel_size=1,
 
     num = snow_partitioning_n.phase_max_label
     num = [0, *num]
-    phases_num = sp.unique(im * 1)
+    phases_num = np.unique(im * 1)
     phases_num = sp.trim_zeros(phases_num)
     for i in phases_num:
         loc1 = np.logical_and(conns1 >= num[i - 1], conns1 < num[i])

--- a/porespy/networks/__funcs__.py
+++ b/porespy/networks/__funcs__.py
@@ -391,7 +391,7 @@ def add_phase_interconnections(net, snow_partitioning_n, voxel_size=1,
     num = snow_partitioning_n.phase_max_label
     num = [0, *num]
     phases_num = np.unique(im * 1)
-    phases_num = sp.trim_zeros(phases_num)
+    phases_num = np.trim_zeros(phases_num)
     for i in phases_num:
         loc1 = np.logical_and(conns1 >= num[i - 1], conns1 < num[i])
         loc2 = np.logical_and(conns2 >= num[i - 1], conns2 < num[i])
@@ -418,11 +418,11 @@ def add_phase_interconnections(net, snow_partitioning_n, voxel_size=1,
                     ps = net['throat.area'][pi_pj_conns]
                     p_sa = sp.bincount(p_conns, ps)
                     # trim zeros at head/tail position to avoid extra bins
-                    p_sa = sp.trim_zeros(p_sa)
+                    p_sa = np.trim_zeros(p_sa)
                     i_index = np.arange(min(p_conns), max(p_conns) + 1)
                     j_index = np.arange(min(s_conns), max(s_conns) + 1)
                     s_pa = sp.bincount(s_conns, ps)
-                    s_pa = sp.trim_zeros(s_pa)
+                    s_pa = np.trim_zeros(s_pa)
                     pi_pj_sa[i_index] = p_sa
                     pi_pj_sa[j_index] = s_pa
                     # ---------------------------------------------------------
@@ -430,9 +430,9 @@ def add_phase_interconnections(net, snow_partitioning_n, voxel_size=1,
                     if marching_cubes_area:
                         ps_c = net['throat.area'][pi_pj_conns]
                         p_sa_c = sp.bincount(p_conns, ps_c)
-                        p_sa_c = sp.trim_zeros(p_sa_c)
+                        p_sa_c = np.trim_zeros(p_sa_c)
                         s_pa_c = sp.bincount(s_conns, ps_c)
-                        s_pa_c = sp.trim_zeros(s_pa_c)
+                        s_pa_c = np.trim_zeros(s_pa_c)
                         pi_pj_sa[i_index] = p_sa_c
                         pi_pj_sa[j_index] = s_pa_c
                     net['pore.{}_{}_area'.format(al[i],

--- a/porespy/networks/__funcs__.py
+++ b/porespy/networks/__funcs__.py
@@ -36,7 +36,7 @@ def map_to_regions(regions, values):
 
     """
     values = np.array(values).flatten()
-    if sp.size(values) != regions.max() + 1:
+    if np.size(values) != regions.max() + 1:
         raise Exception('Number of values does not match number of regions')
     im = np.zeros_like(regions)
     im = values[regions]

--- a/porespy/networks/__funcs__.py
+++ b/porespy/networks/__funcs__.py
@@ -81,7 +81,7 @@ def add_boundary_regions(regions=None, faces=['front', 'back', 'left',
     # -------------------------------------------------------------------------
     # Edge pad segmentation and distance transform
     if faces is not None:
-        regions = sp.pad(regions, 1, 'edge')
+        regions = np.pad(regions, 1, 'edge')
         # ---------------------------------------------------------------------
         if regions.ndim == 3:
             # Remove boundary nodes interconnection
@@ -104,7 +104,7 @@ def add_boundary_regions(regions=None, faces=['front', 'back', 'left',
             regions[:, -1, :] = (~find_boundaries(regions[:, -1, :],
                                                   mode='outer')) * regions[:, -1, :]
             # -----------------------------------------------------------------
-            regions = sp.pad(regions, 2, 'edge')
+            regions = np.pad(regions, 2, 'edge')
 
             # Remove unselected faces
             if 'front' not in faces:
@@ -135,7 +135,7 @@ def add_boundary_regions(regions=None, faces=['front', 'back', 'left',
             regions[:, -1] = (~find_boundaries(regions[:, -1],
                                                mode='outer')) * regions[:, -1]
             # -----------------------------------------------------------------
-            regions = sp.pad(regions, 2, 'edge')
+            regions = np.pad(regions, 2, 'edge')
 
             # Remove unselected faces
             if 'left' not in faces:

--- a/porespy/networks/__funcs__.py
+++ b/porespy/networks/__funcs__.py
@@ -35,7 +35,7 @@ def map_to_regions(regions, values):
     the region indexing starts at 1.  That is, region 1 corresponds to pore 0.
 
     """
-    values = sp.array(values).flatten()
+    values = np.array(values).flatten()
     if sp.size(values) != regions.max() + 1:
         raise Exception('Number of values does not match number of regions')
     im = np.zeros_like(regions)

--- a/porespy/networks/__funcs__.py
+++ b/porespy/networks/__funcs__.py
@@ -318,7 +318,7 @@ def generate_voxel_image(network, pore_shape="sphere", throat_shape="cylinder",
     while err > rtol:
         im = _generate_voxel_image(network, pore_shape, throat_shape,
                                    max_dim=max_dim, verbose=verbose)
-        eps = im.astype(bool).sum() / sp.prod(im.shape)
+        eps = im.astype(bool).sum() / np.prod(im.shape)
 
         err = abs(1 - eps / eps_old)
         eps_old = eps

--- a/porespy/networks/__funcs__.py
+++ b/porespy/networks/__funcs__.py
@@ -252,7 +252,7 @@ def _generate_voxel_image(network, pore_shape, throat_shape, max_dim=200,
 
     # Subtract pore-throat overlap from throats
     im_throats = (im_throats.astype(bool) * ~im_pores.astype(bool)).astype(
-        sp.uint8)
+        np.uint8)
     im = im_pores * 1 + im_throats * 2
 
     return im[extra_clearance:-extra_clearance,
@@ -416,12 +416,12 @@ def add_phase_interconnections(net, snow_partitioning_n, voxel_size=1,
                     p_conns = net['throat.conns'][:, 0][pi_pj_conns]
                     s_conns = net['throat.conns'][:, 1][pi_pj_conns]
                     ps = net['throat.area'][pi_pj_conns]
-                    p_sa = sp.bincount(p_conns, ps)
+                    p_sa = np.bincount(p_conns, ps)
                     # trim zeros at head/tail position to avoid extra bins
                     p_sa = np.trim_zeros(p_sa)
                     i_index = np.arange(min(p_conns), max(p_conns) + 1)
                     j_index = np.arange(min(s_conns), max(s_conns) + 1)
-                    s_pa = sp.bincount(s_conns, ps)
+                    s_pa = np.bincount(s_conns, ps)
                     s_pa = np.trim_zeros(s_pa)
                     pi_pj_sa[i_index] = p_sa
                     pi_pj_sa[j_index] = s_pa
@@ -429,9 +429,9 @@ def add_phase_interconnections(net, snow_partitioning_n, voxel_size=1,
                     # Calculates interfacial area using marching cube method
                     if marching_cubes_area:
                         ps_c = net['throat.area'][pi_pj_conns]
-                        p_sa_c = sp.bincount(p_conns, ps_c)
+                        p_sa_c = np.bincount(p_conns, ps_c)
                         p_sa_c = np.trim_zeros(p_sa_c)
-                        s_pa_c = sp.bincount(s_conns, ps_c)
+                        s_pa_c = np.bincount(s_conns, ps_c)
                         s_pa_c = np.trim_zeros(s_pa_c)
                         pi_pj_sa[i_index] = p_sa_c
                         pi_pj_sa[j_index] = s_pa_c

--- a/porespy/networks/__funcs__.py
+++ b/porespy/networks/__funcs__.py
@@ -419,8 +419,8 @@ def add_phase_interconnections(net, snow_partitioning_n, voxel_size=1,
                     p_sa = sp.bincount(p_conns, ps)
                     # trim zeros at head/tail position to avoid extra bins
                     p_sa = sp.trim_zeros(p_sa)
-                    i_index = sp.arange(min(p_conns), max(p_conns) + 1)
-                    j_index = sp.arange(min(s_conns), max(s_conns) + 1)
+                    i_index = np.arange(min(p_conns), max(p_conns) + 1)
+                    j_index = np.arange(min(s_conns), max(s_conns) + 1)
                     s_pa = sp.bincount(s_conns, ps)
                     s_pa = sp.trim_zeros(s_pa)
                     pi_pj_sa[i_index] = p_sa

--- a/porespy/networks/__funcs__.py
+++ b/porespy/networks/__funcs__.py
@@ -393,20 +393,20 @@ def add_phase_interconnections(net, snow_partitioning_n, voxel_size=1,
     phases_num = sp.unique(im * 1)
     phases_num = sp.trim_zeros(phases_num)
     for i in phases_num:
-        loc1 = sp.logical_and(conns1 >= num[i - 1], conns1 < num[i])
-        loc2 = sp.logical_and(conns2 >= num[i - 1], conns2 < num[i])
-        loc3 = sp.logical_and(label >= num[i - 1], label < num[i])
+        loc1 = np.logical_and(conns1 >= num[i - 1], conns1 < num[i])
+        loc2 = np.logical_and(conns2 >= num[i - 1], conns2 < num[i])
+        loc3 = np.logical_and(label >= num[i - 1], label < num[i])
         net['throat.{}'.format(al[i])] = loc1 * loc2
         net['pore.{}'.format(al[i])] = loc3
         if i == phases_num[-1]:
-            loc4 = sp.logical_and(conns1 < num[-1], conns2 >= num[-1])
+            loc4 = np.logical_and(conns1 < num[-1], conns2 >= num[-1])
             loc5 = label >= num[-1]
             net['throat.boundary'] = loc4
             net['pore.boundary'] = loc5
         for j in phases_num:
             if j > i:
                 pi_pj_sa = np.zeros_like(label)
-                loc6 = sp.logical_and(conns2 >= num[j - 1], conns2 < num[j])
+                loc6 = np.logical_and(conns2 >= num[j - 1], conns2 < num[j])
                 pi_pj_conns = loc1 * loc6
                 net['throat.{}_{}'.format(al[i], al[j])] = pi_pj_conns
                 if any(pi_pj_conns):

--- a/porespy/networks/__funcs__.py
+++ b/porespy/networks/__funcs__.py
@@ -1,4 +1,3 @@
-import scipy as sp
 import numpy as np
 import openpnm as op
 from porespy.tools import make_contiguous

--- a/porespy/networks/__funcs__.py
+++ b/porespy/networks/__funcs__.py
@@ -38,7 +38,7 @@ def map_to_regions(regions, values):
     values = sp.array(values).flatten()
     if sp.size(values) != regions.max() + 1:
         raise Exception('Number of values does not match number of regions')
-    im = sp.zeros_like(regions)
+    im = np.zeros_like(regions)
     im = values[regions]
     return im
 
@@ -405,7 +405,7 @@ def add_phase_interconnections(net, snow_partitioning_n, voxel_size=1,
             net['pore.boundary'] = loc5
         for j in phases_num:
             if j > i:
-                pi_pj_sa = sp.zeros_like(label)
+                pi_pj_sa = np.zeros_like(label)
                 loc6 = sp.logical_and(conns2 >= num[j - 1], conns2 < num[j])
                 pi_pj_conns = loc1 * loc6
                 net['throat.{}_{}'.format(al[i], al[j])] = pi_pj_conns

--- a/porespy/networks/__getnet__.py
+++ b/porespy/networks/__getnet__.py
@@ -53,12 +53,12 @@ def regions_to_network(im, dt=None, voxel_size=1):
     # Initialize arrays
     Ps = sp.arange(1, sp.amax(im)+1)
     Np = sp.size(Ps)
-    p_coords = sp.zeros((Np, im.ndim), dtype=float)
-    p_volume = sp.zeros((Np, ), dtype=float)
-    p_dia_local = sp.zeros((Np, ), dtype=float)
-    p_dia_global = sp.zeros((Np, ), dtype=float)
-    p_label = sp.zeros((Np, ), dtype=int)
-    p_area_surf = sp.zeros((Np, ), dtype=int)
+    p_coords = np.zeros((Np, im.ndim), dtype=float)
+    p_volume = np.zeros((Np, ), dtype=float)
+    p_dia_local = np.zeros((Np, ), dtype=float)
+    p_dia_global = np.zeros((Np, ), dtype=float)
+    p_label = np.zeros((Np, ), dtype=int)
+    p_area_surf = np.zeros((Np, ), dtype=int)
     t_conns = []
     t_dia_inscribed = []
     t_area = []
@@ -106,8 +106,8 @@ def regions_to_network(im, dt=None, voxel_size=1):
     # Clean up values
     Nt = len(t_dia_inscribed)  # Get number of throats
     if im.ndim == 2:  # If 2D, add 0's in 3rd dimension
-        p_coords = sp.vstack((p_coords.T, sp.zeros((Np, )))).T
-        t_coords = sp.vstack((sp.array(t_coords).T, sp.zeros((Nt, )))).T
+        p_coords = sp.vstack((p_coords.T, np.zeros((Np, )))).T
+        t_coords = sp.vstack((sp.array(t_coords).T, np.zeros((Nt, )))).T
 
     net = {}
     net['pore.all'] = sp.ones((Np, ), dtype=bool)
@@ -118,7 +118,7 @@ def regions_to_network(im, dt=None, voxel_size=1):
     net['throat.conns'] = sp.array(t_conns)
     net['pore.label'] = sp.array(p_label)
     net['pore.volume'] = sp.copy(p_volume)*(voxel_size**3)
-    net['throat.volume'] = sp.zeros((Nt, ), dtype=float)
+    net['throat.volume'] = np.zeros((Nt, ), dtype=float)
     net['pore.diameter'] = sp.copy(p_dia_local)*voxel_size
     net['pore.inscribed_diameter'] = sp.copy(p_dia_local)*voxel_size
     net['pore.equivalent_diameter'] = 2*((3/4*net['pore.volume']/sp.pi)**(1/3))

--- a/porespy/networks/__getnet__.py
+++ b/porespy/networks/__getnet__.py
@@ -80,10 +80,10 @@ def regions_to_network(im, dt=None, voxel_size=1):
         s_offset = np.array([i.start for i in s])
         p_label[pore] = i
         p_coords[pore, :] = spim.center_of_mass(pore_im) + s_offset
-        p_volume[pore] = sp.sum(pore_im)
+        p_volume[pore] = np.sum(pore_im)
         p_dia_local[pore] = (2*sp.amax(pore_dt)) - np.sqrt(3)
         p_dia_global[pore] = 2*sp.amax(sub_dt)
-        p_area_surf[pore] = sp.sum(pore_dt == 1)
+        p_area_surf[pore] = np.sum(pore_dt == 1)
         im_w_throats = spim.binary_dilation(input=pore_im, structure=struc_elem(1))
         im_w_throats = im_w_throats*sub_im
         Pn = sp.unique(im_w_throats)[1:] - 1
@@ -92,7 +92,7 @@ def regions_to_network(im, dt=None, voxel_size=1):
                 t_conns.append([pore, j])
                 vx = np.where(im_w_throats == (j + 1))
                 t_dia_inscribed.append(2*sp.amax(sub_dt[vx]))
-                t_perimeter.append(sp.sum(sub_dt[vx] < 2))
+                t_perimeter.append(np.sum(sub_dt[vx] < 2))
                 t_area.append(sp.size(vx[0]))
                 t_inds = tuple([i+j for i, j in zip(vx, s_offset)])
                 temp = np.where(dt[t_inds] == sp.amax(dt[t_inds]))[0][0]
@@ -130,14 +130,14 @@ def regions_to_network(im, dt=None, voxel_size=1):
     net['throat.perimeter'] = np.array(t_perimeter)*voxel_size
     net['throat.equivalent_diameter'] = (np.array(t_area) * (voxel_size**2))**0.5
     P12 = net['throat.conns']
-    PT1 = np.sqrt(sp.sum(((p_coords[P12[:, 0]]-t_coords) * voxel_size)**2, axis=1))
-    PT2 = np.sqrt(sp.sum(((p_coords[P12[:, 1]]-t_coords) * voxel_size)**2, axis=1))
+    PT1 = np.sqrt(np.sum(((p_coords[P12[:, 0]]-t_coords) * voxel_size)**2, axis=1))
+    PT2 = np.sqrt(np.sum(((p_coords[P12[:, 1]]-t_coords) * voxel_size)**2, axis=1))
     net['throat.total_length'] = PT1 + PT2
     PT1 = PT1-p_dia_local[P12[:, 0]]/2*voxel_size
     PT2 = PT2-p_dia_local[P12[:, 1]]/2*voxel_size
     net['throat.length'] = PT1 + PT2
     dist = (p_coords[P12[:, 0]]-p_coords[P12[:, 1]])*voxel_size
-    net['throat.direct_length'] = np.sqrt(sp.sum(dist**2, axis=1))
+    net['throat.direct_length'] = np.sqrt(np.sum(dist**2, axis=1))
     # Make a dummy openpnm network to get the conduit lengths
     pn = op.network.GenericNetwork()
     pn.update(net)

--- a/porespy/networks/__getnet__.py
+++ b/porespy/networks/__getnet__.py
@@ -1,4 +1,3 @@
-import scipy as sp
 import numpy as np
 import openpnm as op
 from tqdm import tqdm

--- a/porespy/networks/__getnet__.py
+++ b/porespy/networks/__getnet__.py
@@ -87,7 +87,7 @@ def regions_to_network(im, dt=None, voxel_size=1):
         p_area_surf[pore] = np.sum(pore_dt == 1)
         im_w_throats = spim.binary_dilation(input=pore_im, structure=struc_elem(1))
         im_w_throats = im_w_throats*sub_im
-        Pn = sp.unique(im_w_throats)[1:] - 1
+        Pn = np.unique(im_w_throats)[1:] - 1
         for j in Pn:
             if j > pore:
                 t_conns.append([pore, j])

--- a/porespy/networks/__getnet__.py
+++ b/porespy/networks/__getnet__.py
@@ -76,7 +76,7 @@ def regions_to_network(im, dt=None, voxel_size=1):
         sub_im = im[s]
         sub_dt = dt[s]
         pore_im = sub_im == i
-        padded_mask = sp.pad(pore_im, pad_width=1, mode='constant')
+        padded_mask = np.pad(pore_im, pad_width=1, mode='constant')
         pore_dt = spim.distance_transform_edt(padded_mask)
         s_offset = np.array([i.start for i in s])
         p_label[pore] = i

--- a/porespy/networks/__getnet__.py
+++ b/porespy/networks/__getnet__.py
@@ -51,7 +51,7 @@ def regions_to_network(im, dt=None, voxel_size=1):
     slices = spim.find_objects(im)
 
     # Initialize arrays
-    Ps = sp.arange(1, sp.amax(im)+1)
+    Ps = sp.arange(1, np.amax(im)+1)
     Np = sp.size(Ps)
     p_coords = np.zeros((Np, im.ndim), dtype=float)
     p_volume = np.zeros((Np, ), dtype=float)
@@ -81,8 +81,8 @@ def regions_to_network(im, dt=None, voxel_size=1):
         p_label[pore] = i
         p_coords[pore, :] = spim.center_of_mass(pore_im) + s_offset
         p_volume[pore] = np.sum(pore_im)
-        p_dia_local[pore] = (2*sp.amax(pore_dt)) - np.sqrt(3)
-        p_dia_global[pore] = 2*sp.amax(sub_dt)
+        p_dia_local[pore] = (2*np.amax(pore_dt)) - np.sqrt(3)
+        p_dia_global[pore] = 2*np.amax(sub_dt)
         p_area_surf[pore] = np.sum(pore_dt == 1)
         im_w_throats = spim.binary_dilation(input=pore_im, structure=struc_elem(1))
         im_w_throats = im_w_throats*sub_im
@@ -91,11 +91,11 @@ def regions_to_network(im, dt=None, voxel_size=1):
             if j > pore:
                 t_conns.append([pore, j])
                 vx = np.where(im_w_throats == (j + 1))
-                t_dia_inscribed.append(2*sp.amax(sub_dt[vx]))
+                t_dia_inscribed.append(2*np.amax(sub_dt[vx]))
                 t_perimeter.append(np.sum(sub_dt[vx] < 2))
                 t_area.append(sp.size(vx[0]))
                 t_inds = tuple([i+j for i, j in zip(vx, s_offset)])
-                temp = np.where(dt[t_inds] == sp.amax(dt[t_inds]))[0][0]
+                temp = np.where(dt[t_inds] == np.amax(dt[t_inds]))[0][0]
                 if im.ndim == 2:
                     t_coords.append(tuple((t_inds[0][temp],
                                            t_inds[1][temp])))

--- a/porespy/networks/__getnet__.py
+++ b/porespy/networks/__getnet__.py
@@ -64,7 +64,7 @@ def regions_to_network(im, dt=None, voxel_size=1):
     t_area = []
     t_perimeter = []
     t_coords = []
-    # dt_shape = sp.array(dt.shape)
+    # dt_shape = np.array(dt.shape)
 
     # Start extracting size information for pores and throats
     for i in tqdm(Ps):
@@ -77,11 +77,11 @@ def regions_to_network(im, dt=None, voxel_size=1):
         pore_im = sub_im == i
         padded_mask = sp.pad(pore_im, pad_width=1, mode='constant')
         pore_dt = spim.distance_transform_edt(padded_mask)
-        s_offset = sp.array([i.start for i in s])
+        s_offset = np.array([i.start for i in s])
         p_label[pore] = i
         p_coords[pore, :] = spim.center_of_mass(pore_im) + s_offset
         p_volume[pore] = sp.sum(pore_im)
-        p_dia_local[pore] = (2*sp.amax(pore_dt)) - sp.sqrt(3)
+        p_dia_local[pore] = (2*sp.amax(pore_dt)) - np.sqrt(3)
         p_dia_global[pore] = 2*sp.amax(sub_dt)
         p_area_surf[pore] = sp.sum(pore_dt == 1)
         im_w_throats = spim.binary_dilation(input=pore_im, structure=struc_elem(1))
@@ -90,12 +90,12 @@ def regions_to_network(im, dt=None, voxel_size=1):
         for j in Pn:
             if j > pore:
                 t_conns.append([pore, j])
-                vx = sp.where(im_w_throats == (j + 1))
+                vx = np.where(im_w_throats == (j + 1))
                 t_dia_inscribed.append(2*sp.amax(sub_dt[vx]))
                 t_perimeter.append(sp.sum(sub_dt[vx] < 2))
                 t_area.append(sp.size(vx[0]))
                 t_inds = tuple([i+j for i, j in zip(vx, s_offset)])
-                temp = sp.where(dt[t_inds] == sp.amax(dt[t_inds]))[0][0]
+                temp = np.where(dt[t_inds] == sp.amax(dt[t_inds]))[0][0]
                 if im.ndim == 2:
                     t_coords.append(tuple((t_inds[0][temp],
                                            t_inds[1][temp])))
@@ -107,16 +107,16 @@ def regions_to_network(im, dt=None, voxel_size=1):
     Nt = len(t_dia_inscribed)  # Get number of throats
     if im.ndim == 2:  # If 2D, add 0's in 3rd dimension
         p_coords = sp.vstack((p_coords.T, np.zeros((Np, )))).T
-        t_coords = sp.vstack((sp.array(t_coords).T, np.zeros((Nt, )))).T
+        t_coords = sp.vstack((np.array(t_coords).T, np.zeros((Nt, )))).T
 
     net = {}
-    net['pore.all'] = sp.ones((Np, ), dtype=bool)
-    net['throat.all'] = sp.ones((Nt, ), dtype=bool)
+    net['pore.all'] = np.ones((Np, ), dtype=bool)
+    net['throat.all'] = np.ones((Nt, ), dtype=bool)
     net['pore.coords'] = sp.copy(p_coords)*voxel_size
     net['pore.centroid'] = sp.copy(p_coords)*voxel_size
-    net['throat.centroid'] = sp.array(t_coords)*voxel_size
-    net['throat.conns'] = sp.array(t_conns)
-    net['pore.label'] = sp.array(p_label)
+    net['throat.centroid'] = np.array(t_coords)*voxel_size
+    net['throat.conns'] = np.array(t_conns)
+    net['pore.label'] = np.array(p_label)
     net['pore.volume'] = sp.copy(p_volume)*(voxel_size**3)
     net['throat.volume'] = np.zeros((Nt, ), dtype=float)
     net['pore.diameter'] = sp.copy(p_dia_local)*voxel_size
@@ -124,20 +124,20 @@ def regions_to_network(im, dt=None, voxel_size=1):
     net['pore.equivalent_diameter'] = 2*((3/4*net['pore.volume']/sp.pi)**(1/3))
     net['pore.extended_diameter'] = sp.copy(p_dia_global)*voxel_size
     net['pore.surface_area'] = sp.copy(p_area_surf)*(voxel_size)**2
-    net['throat.diameter'] = sp.array(t_dia_inscribed)*voxel_size
-    net['throat.inscribed_diameter'] = sp.array(t_dia_inscribed)*voxel_size
-    net['throat.area'] = sp.array(t_area)*(voxel_size**2)
-    net['throat.perimeter'] = sp.array(t_perimeter)*voxel_size
-    net['throat.equivalent_diameter'] = (sp.array(t_area) * (voxel_size**2))**0.5
+    net['throat.diameter'] = np.array(t_dia_inscribed)*voxel_size
+    net['throat.inscribed_diameter'] = np.array(t_dia_inscribed)*voxel_size
+    net['throat.area'] = np.array(t_area)*(voxel_size**2)
+    net['throat.perimeter'] = np.array(t_perimeter)*voxel_size
+    net['throat.equivalent_diameter'] = (np.array(t_area) * (voxel_size**2))**0.5
     P12 = net['throat.conns']
-    PT1 = sp.sqrt(sp.sum(((p_coords[P12[:, 0]]-t_coords) * voxel_size)**2, axis=1))
-    PT2 = sp.sqrt(sp.sum(((p_coords[P12[:, 1]]-t_coords) * voxel_size)**2, axis=1))
+    PT1 = np.sqrt(sp.sum(((p_coords[P12[:, 0]]-t_coords) * voxel_size)**2, axis=1))
+    PT2 = np.sqrt(sp.sum(((p_coords[P12[:, 1]]-t_coords) * voxel_size)**2, axis=1))
     net['throat.total_length'] = PT1 + PT2
     PT1 = PT1-p_dia_local[P12[:, 0]]/2*voxel_size
     PT2 = PT2-p_dia_local[P12[:, 1]]/2*voxel_size
     net['throat.length'] = PT1 + PT2
     dist = (p_coords[P12[:, 0]]-p_coords[P12[:, 1]])*voxel_size
-    net['throat.direct_length'] = sp.sqrt(sp.sum(dist**2, axis=1))
+    net['throat.direct_length'] = np.sqrt(sp.sum(dist**2, axis=1))
     # Make a dummy openpnm network to get the conduit lengths
     pn = op.network.GenericNetwork()
     pn.update(net)

--- a/porespy/networks/__getnet__.py
+++ b/porespy/networks/__getnet__.py
@@ -1,4 +1,5 @@
 import scipy as sp
+import numpy as np
 import openpnm as op
 from tqdm import tqdm
 import scipy.ndimage as spim
@@ -121,7 +122,7 @@ def regions_to_network(im, dt=None, voxel_size=1):
     net['throat.volume'] = np.zeros((Nt, ), dtype=float)
     net['pore.diameter'] = sp.copy(p_dia_local)*voxel_size
     net['pore.inscribed_diameter'] = sp.copy(p_dia_local)*voxel_size
-    net['pore.equivalent_diameter'] = 2*((3/4*net['pore.volume']/sp.pi)**(1/3))
+    net['pore.equivalent_diameter'] = 2*((3/4*net['pore.volume']/np.pi)**(1/3))
     net['pore.extended_diameter'] = sp.copy(p_dia_global)*voxel_size
     net['pore.surface_area'] = sp.copy(p_area_surf)*(voxel_size)**2
     net['throat.diameter'] = np.array(t_dia_inscribed)*voxel_size

--- a/porespy/networks/__getnet__.py
+++ b/porespy/networks/__getnet__.py
@@ -107,8 +107,8 @@ def regions_to_network(im, dt=None, voxel_size=1):
     # Clean up values
     Nt = len(t_dia_inscribed)  # Get number of throats
     if im.ndim == 2:  # If 2D, add 0's in 3rd dimension
-        p_coords = sp.vstack((p_coords.T, np.zeros((Np, )))).T
-        t_coords = sp.vstack((np.array(t_coords).T, np.zeros((Nt, )))).T
+        p_coords = np.vstack((p_coords.T, np.zeros((Np, )))).T
+        t_coords = np.vstack((np.array(t_coords).T, np.zeros((Nt, )))).T
 
     net = {}
     net['pore.all'] = np.ones((Np, ), dtype=bool)

--- a/porespy/networks/__getnet__.py
+++ b/porespy/networks/__getnet__.py
@@ -40,7 +40,7 @@ def regions_to_network(im, dt=None, voxel_size=1):
     from skimage.morphology import disk, ball
     struc_elem = disk if im.ndim == 2 else ball
 
-    # if ~sp.any(im == 0):
+    # if ~np.any(im == 0):
     #     raise Exception('The received image has no solid phase (0\'s)')
 
     if dt is None:

--- a/porespy/networks/__getnet__.py
+++ b/porespy/networks/__getnet__.py
@@ -113,18 +113,18 @@ def regions_to_network(im, dt=None, voxel_size=1):
     net = {}
     net['pore.all'] = np.ones((Np, ), dtype=bool)
     net['throat.all'] = np.ones((Nt, ), dtype=bool)
-    net['pore.coords'] = sp.copy(p_coords)*voxel_size
-    net['pore.centroid'] = sp.copy(p_coords)*voxel_size
+    net['pore.coords'] = np.copy(p_coords)*voxel_size
+    net['pore.centroid'] = np.copy(p_coords)*voxel_size
     net['throat.centroid'] = np.array(t_coords)*voxel_size
     net['throat.conns'] = np.array(t_conns)
     net['pore.label'] = np.array(p_label)
-    net['pore.volume'] = sp.copy(p_volume)*(voxel_size**3)
+    net['pore.volume'] = np.copy(p_volume)*(voxel_size**3)
     net['throat.volume'] = np.zeros((Nt, ), dtype=float)
-    net['pore.diameter'] = sp.copy(p_dia_local)*voxel_size
-    net['pore.inscribed_diameter'] = sp.copy(p_dia_local)*voxel_size
+    net['pore.diameter'] = np.copy(p_dia_local)*voxel_size
+    net['pore.inscribed_diameter'] = np.copy(p_dia_local)*voxel_size
     net['pore.equivalent_diameter'] = 2*((3/4*net['pore.volume']/np.pi)**(1/3))
-    net['pore.extended_diameter'] = sp.copy(p_dia_global)*voxel_size
-    net['pore.surface_area'] = sp.copy(p_area_surf)*(voxel_size)**2
+    net['pore.extended_diameter'] = np.copy(p_dia_global)*voxel_size
+    net['pore.surface_area'] = np.copy(p_area_surf)*(voxel_size)**2
     net['throat.diameter'] = np.array(t_dia_inscribed)*voxel_size
     net['throat.inscribed_diameter'] = np.array(t_dia_inscribed)*voxel_size
     net['throat.area'] = np.array(t_area)*(voxel_size**2)

--- a/porespy/networks/__getnet__.py
+++ b/porespy/networks/__getnet__.py
@@ -53,7 +53,7 @@ def regions_to_network(im, dt=None, voxel_size=1):
 
     # Initialize arrays
     Ps = np.arange(1, np.amax(im)+1)
-    Np = sp.size(Ps)
+    Np = np.size(Ps)
     p_coords = np.zeros((Np, im.ndim), dtype=float)
     p_volume = np.zeros((Np, ), dtype=float)
     p_dia_local = np.zeros((Np, ), dtype=float)
@@ -94,7 +94,7 @@ def regions_to_network(im, dt=None, voxel_size=1):
                 vx = np.where(im_w_throats == (j + 1))
                 t_dia_inscribed.append(2*np.amax(sub_dt[vx]))
                 t_perimeter.append(np.sum(sub_dt[vx] < 2))
-                t_area.append(sp.size(vx[0]))
+                t_area.append(np.size(vx[0]))
                 t_inds = tuple([i+j for i, j in zip(vx, s_offset)])
                 temp = np.where(dt[t_inds] == np.amax(dt[t_inds]))[0][0]
                 if im.ndim == 2:

--- a/porespy/networks/__getnet__.py
+++ b/porespy/networks/__getnet__.py
@@ -52,7 +52,7 @@ def regions_to_network(im, dt=None, voxel_size=1):
     slices = spim.find_objects(im)
 
     # Initialize arrays
-    Ps = sp.arange(1, np.amax(im)+1)
+    Ps = np.arange(1, np.amax(im)+1)
     Np = sp.size(Ps)
     p_coords = np.zeros((Np, im.ndim), dtype=float)
     p_volume = np.zeros((Np, ), dtype=float)

--- a/porespy/networks/__snow__.py
+++ b/porespy/networks/__snow__.py
@@ -1,3 +1,4 @@
+import numpy as np
 from porespy.networks import regions_to_network, add_boundary_regions
 from porespy.networks import _net_dict
 from porespy.networks import label_boundary_cells
@@ -5,8 +6,6 @@ from porespy.tools import pad_faces
 from porespy.filters import snow_partitioning
 from porespy.tools import make_contiguous
 from porespy.metrics import region_surface_areas, region_interface_areas
-import scipy as sp
-import numpy as np
 
 
 def snow(im, voxel_size=1,

--- a/porespy/networks/__snow__.py
+++ b/porespy/networks/__snow__.py
@@ -6,6 +6,7 @@ from porespy.filters import snow_partitioning
 from porespy.tools import make_contiguous
 from porespy.metrics import region_surface_areas, region_interface_areas
 import scipy as sp
+import numpy as np
 
 
 def snow(im, voxel_size=1,

--- a/porespy/networks/__snow__.py
+++ b/porespy/networks/__snow__.py
@@ -64,7 +64,7 @@ def snow(im, voxel_size=1,
     im = regions.im
     dt = regions.dt
     regions = regions.regions
-    b_num = sp.amax(regions)
+    b_num = np.amax(regions)
     # -------------------------------------------------------------------------
     # Boundary Conditions
     regions = add_boundary_regions(regions=regions, faces=boundary_faces)

--- a/porespy/networks/__snow_dual__.py
+++ b/porespy/networks/__snow_dual__.py
@@ -139,7 +139,7 @@ def snow_dual(im,
     p_sa = sp.bincount(p_conns, ps)
     s_conns = net['throat.conns'][:, 1][pore_solid_labels]
     s_pa = sp.bincount(s_conns, ps)
-    s_pa = sp.trim_zeros(s_pa)  # remove pore surface area labels
+    s_pa = np.trim_zeros(s_pa)  # remove pore surface area labels
     p_solid_surf = sp.concatenate((p_sa, s_pa, b_sa))
     # -------------------------------------------------------------------------
     # Calculates interfacial area using marching cube method
@@ -147,7 +147,7 @@ def snow_dual(im,
         ps_c = net['throat.area'][pore_solid_labels]
         p_sa_c = sp.bincount(p_conns, ps_c)
         s_pa_c = sp.bincount(s_conns, ps_c)
-        s_pa_c = sp.trim_zeros(s_pa_c)  # remove pore surface area labels
+        s_pa_c = np.trim_zeros(s_pa_c)  # remove pore surface area labels
         p_solid_surf = sp.concatenate((p_sa_c, s_pa_c, b_sa))
     # -------------------------------------------------------------------------
     # Adding additional information of dual network

--- a/porespy/networks/__snow_dual__.py
+++ b/porespy/networks/__snow_dual__.py
@@ -1,5 +1,4 @@
 import numpy as np
-import scipy as sp
 from porespy.networks import regions_to_network
 from porespy.networks import add_boundary_regions
 from porespy.networks import label_boundary_cells

--- a/porespy/networks/__snow_dual__.py
+++ b/porespy/networks/__snow_dual__.py
@@ -1,3 +1,4 @@
+import numpy as np
 import scipy as sp
 from porespy.networks import regions_to_network
 from porespy.networks import add_boundary_regions
@@ -130,7 +131,7 @@ def snow_dual(im,
     solid_labels = ((net['pore.label'] > solid_num) * ~
                     (net['pore.label'] > b_num))
     boundary_labels = net['pore.label'] > b_num
-    b_sa = sp.zeros(len(boundary_labels[boundary_labels == 1.0]))
+    b_sa = np.zeros(len(boundary_labels[boundary_labels == 1.0]))
     # -------------------------------------------------------------------------
     # Calculates void interfacial area that connects with solid and vice versa
     p_conns = net['throat.conns'][:, 0][pore_solid_labels]

--- a/porespy/networks/__snow_dual__.py
+++ b/porespy/networks/__snow_dual__.py
@@ -89,11 +89,11 @@ def snow_dual(im,
     solid_regions = solid_regions.regions
     pore_region = pore_regions*im
     solid_region = solid_regions*~im
-    solid_num = sp.amax(pore_regions)
+    solid_num = np.amax(pore_regions)
     solid_region = solid_region + solid_num
     solid_region = solid_region * ~im
     regions = pore_region + solid_region
-    b_num = sp.amax(regions)
+    b_num = np.amax(regions)
     # -------------------------------------------------------------------------
     # Boundary Conditions
     regions = add_boundary_regions(regions=regions, faces=boundary_faces)

--- a/porespy/networks/__snow_dual__.py
+++ b/porespy/networks/__snow_dual__.py
@@ -136,19 +136,19 @@ def snow_dual(im,
     # Calculates void interfacial area that connects with solid and vice versa
     p_conns = net['throat.conns'][:, 0][pore_solid_labels]
     ps = net['throat.area'][pore_solid_labels]
-    p_sa = sp.bincount(p_conns, ps)
+    p_sa = np.bincount(p_conns, ps)
     s_conns = net['throat.conns'][:, 1][pore_solid_labels]
-    s_pa = sp.bincount(s_conns, ps)
+    s_pa = np.bincount(s_conns, ps)
     s_pa = np.trim_zeros(s_pa)  # remove pore surface area labels
-    p_solid_surf = sp.concatenate((p_sa, s_pa, b_sa))
+    p_solid_surf = np.concatenate((p_sa, s_pa, b_sa))
     # -------------------------------------------------------------------------
     # Calculates interfacial area using marching cube method
     if marching_cubes_area:
         ps_c = net['throat.area'][pore_solid_labels]
-        p_sa_c = sp.bincount(p_conns, ps_c)
-        s_pa_c = sp.bincount(s_conns, ps_c)
+        p_sa_c = np.bincount(p_conns, ps_c)
+        s_pa_c = np.bincount(s_conns, ps_c)
         s_pa_c = np.trim_zeros(s_pa_c)  # remove pore surface area labels
-        p_solid_surf = sp.concatenate((p_sa_c, s_pa_c, b_sa))
+        p_solid_surf = np.concatenate((p_sa_c, s_pa_c, b_sa))
     # -------------------------------------------------------------------------
     # Adding additional information of dual network
     net['pore.solid_void_area'] = (p_solid_surf * voxel_size**2)

--- a/porespy/networks/__snow_n__.py
+++ b/porespy/networks/__snow_n__.py
@@ -78,7 +78,7 @@ def snow_n(im,
     # -------------------------------------------------------------------------
     # For only one phase extraction with boundary regions
     phases_num = np.unique(im).astype(int)
-    phases_num = sp.trim_zeros(phases_num)
+    phases_num = np.trim_zeros(phases_num)
     if len(phases_num) == 1:
         if f is not None:
             snow.im = pad_faces(im=snow.im, faces=f)

--- a/porespy/networks/__snow_n__.py
+++ b/porespy/networks/__snow_n__.py
@@ -1,5 +1,4 @@
 import numpy as np
-import scipy as sp
 from porespy.networks import regions_to_network
 from porespy.networks import label_boundary_cells
 from porespy.networks import add_boundary_regions

--- a/porespy/networks/__snow_n__.py
+++ b/porespy/networks/__snow_n__.py
@@ -77,7 +77,7 @@ def snow_n(im,
     dt = pad_faces(im=snow.dt, faces=f)
     # -------------------------------------------------------------------------
     # For only one phase extraction with boundary regions
-    phases_num = sp.unique(im).astype(int)
+    phases_num = np.unique(im).astype(int)
     phases_num = sp.trim_zeros(phases_num)
     if len(phases_num) == 1:
         if f is not None:

--- a/porespy/networks/__snow_n__.py
+++ b/porespy/networks/__snow_n__.py
@@ -1,3 +1,4 @@
+import numpy as np
 import scipy as sp
 from porespy.networks import regions_to_network
 from porespy.networks import label_boundary_cells

--- a/porespy/tools/__funcs__.py
+++ b/porespy/tools/__funcs__.py
@@ -314,7 +314,7 @@ def extract_cylinder(im, r=None, axis=0):
     dim = [range(int(-s / 2), int(s / 2) + s % 2) for s in im.shape]
     inds = np.meshgrid(*dim, indexing='ij')
     inds[axis] = inds[axis] * 0
-    d = sp.sqrt(sp.sum(sp.square(inds), axis=0))
+    d = np.sqrt(sp.sum(sp.square(inds), axis=0))
     mask = d < r
     im_temp = im*mask
     return im_temp
@@ -343,7 +343,7 @@ def extract_subsection(im, shape):
     --------
     >>> import scipy as sp
     >>> from porespy.tools import extract_subsection
-    >>> im = sp.array([[1, 1, 1, 1], [1, 2, 2, 2], [1, 2, 3, 3], [1, 2, 3, 4]])
+    >>> im = np.array([[1, 1, 1, 1], [1, 2, 2, 2], [1, 2, 3, 3], [1, 2, 3, 4]])
     >>> print(im)
     [[1 1 1 1]
      [1 2 2 2]
@@ -356,10 +356,10 @@ def extract_subsection(im, shape):
 
     """
     # Check if shape was given as a fraction
-    shape = sp.array(shape)
+    shape = np.array(shape)
     if shape[0] < 1:
-        shape = sp.array(im.shape) * shape
-    center = sp.array(im.shape) / 2
+        shape = np.array(im.shape) * shape
+    center = np.array(im.shape) / 2
     s_im = []
     for dim in range(im.ndim):
         r = shape[dim] / 2
@@ -389,7 +389,7 @@ def get_planes(im, squeeze=True):
     planes : list
         A list of 2D-images
     """
-    x, y, z = (sp.array(im.shape) / 2).astype(int)
+    x, y, z = (np.array(im.shape) / 2).astype(int)
     planes = [im[x, :, :], im[:, y, :], im[:, :, z]]
     if not squeeze:
         imx = planes[0]
@@ -432,7 +432,7 @@ def extend_slice(s, shape, pad=1):
     --------
     >>> from scipy.ndimage import label, find_objects
     >>> from porespy.tools import extend_slice
-    >>> im = sp.array([[1, 0, 0], [1, 0, 0], [0, 0, 1]])
+    >>> im = np.array([[1, 0, 0], [1, 0, 0], [0, 0, 1]])
     >>> labels = label(im)[0]
     >>> s = find_objects(labels)
 
@@ -526,7 +526,7 @@ def randomize_colors(im, keep_vals=[0]):
 
     '''
     im_flat = im.flatten()
-    keep_vals = sp.array(keep_vals)
+    keep_vals = np.array(keep_vals)
     swap_vals = ~sp.in1d(im_flat, keep_vals)
     im_vals = sp.unique(im_flat[swap_vals])
     new_vals = sp.random.permutation(im_vals)
@@ -567,7 +567,7 @@ def make_contiguous(im, keep_zeros=True):
     -------
     >>> import porespy as ps
     >>> import scipy as sp
-    >>> im = sp.array([[0, 2, 9], [6, 8, 3]])
+    >>> im = np.array([[0, 2, 9], [6, 8, 3]])
     >>> im = ps.tools.make_contiguous(im)
     >>> print(im)
     [[0 1 5]
@@ -585,7 +585,7 @@ def make_contiguous(im, keep_zeros=True):
     im_map[im_vals] = sp.arange(0, sp.size(sp.unique(im_flat)))
     im_new = im_map[im_flat]
     im_new = sp.reshape(im_new, newshape=sp.shape(im))
-    im_new = sp.array(im_new, dtype=im_flat.dtype)
+    im_new = np.array(im_new, dtype=im_flat.dtype)
     return im_new
 
 
@@ -647,7 +647,7 @@ def get_border(shape, thickness=1, mode='edges', return_indices=False):
     """
     ndims = len(shape)
     t = thickness
-    border = sp.ones(shape, dtype=bool)
+    border = np.ones(shape, dtype=bool)
     if mode == 'faces':
         if ndims == 2:
             border[t:-t, t:-t] = False
@@ -669,7 +669,7 @@ def get_border(shape, thickness=1, mode='edges', return_indices=False):
             border[0::, t:-t, 0::] = False
             border[0::, 0::, t:-t] = False
     if return_indices:
-        border = sp.where(border)
+        border = np.where(border)
     return border
 
 
@@ -726,7 +726,7 @@ def norm_to_uniform(im, scale=None):
     if scale is None:
         scale = [im.min(), im.max()]
     im = (im - sp.mean(im)) / sp.std(im)
-    im = 1 / 2 * sp.special.erfc(-im / sp.sqrt(2))
+    im = 1 / 2 * sp.special.erfc(-im / np.sqrt(2))
     im = (im - im.min()) / (im.max() - im.min())
     im = im * (scale[1] - scale[0]) + scale[0]
     return im
@@ -840,7 +840,7 @@ def ps_disk(radius):
         A 2D numpy bool array of the structring element
     """
     rad = int(sp.ceil(radius))
-    other = sp.ones((2 * rad + 1, 2 * rad + 1), dtype=bool)
+    other = np.ones((2 * rad + 1, 2 * rad + 1), dtype=bool)
     other[rad, rad] = False
     disk = spim.distance_transform_edt(other) < radius
     return disk
@@ -861,7 +861,7 @@ def ps_ball(radius):
         A 3D numpy array of the structuring element
     """
     rad = int(sp.ceil(radius))
-    other = sp.ones((2 * rad + 1, 2 * rad + 1, 2 * rad + 1), dtype=bool)
+    other = np.ones((2 * rad + 1, 2 * rad + 1, 2 * rad + 1), dtype=bool)
     other[rad, rad, rad] = False
     ball = spim.distance_transform_edt(other) < radius
     return ball
@@ -919,7 +919,7 @@ def insert_sphere(im, c, r):
     image : ND-array
         The original image with a sphere inerted at the specified location
     """
-    c = sp.array(c, dtype=int)
+    c = np.array(c, dtype=int)
     if c.size != im.ndim:
         raise Exception('Coordinates do not match dimensionality of image')
 
@@ -929,7 +929,7 @@ def insert_sphere(im, c, r):
     bbox = sp.ravel(bbox)
     s = bbox_to_slices(bbox)
     temp = im[s]
-    blank = sp.ones_like(temp)
+    blank = np.ones_like(temp)
     blank[tuple(c - bbox[0:im.ndim])] = 0
     blank = spim.distance_transform_edt(blank) < r
     im[s] = blank
@@ -962,7 +962,7 @@ def insert_cylinder(im, xyz0, xyz1, r):
     if im.ndim != 3:
         raise Exception('This function is only implemented for 3D images')
     # Converting coordinates to numpy array
-    xyz0, xyz1 = [sp.array(xyz).astype(int) for xyz in (xyz0, xyz1)]
+    xyz0, xyz1 = [np.array(xyz).astype(int) for xyz in (xyz0, xyz1)]
     r = int(r)
     L = sp.absolute(xyz0 - xyz1).max() + 1
     xyz_line = [np.linspace(xyz0[i], xyz1[i], L).astype(int) for i in range(3)]
@@ -1077,7 +1077,7 @@ def _create_alias_map(im, alias=None):
         al[values] = 'phase{}'.format(values)
     if alias is not None:
         alias_sort = dict(sorted(alias.items()))
-        phase_labels = sp.array([*alias_sort])
+        phase_labels = np.array([*alias_sort])
         al = alias
         if set(phase_labels) != set(phases_num):
             raise Exception('Alias labels does not match with image labels '

--- a/porespy/tools/__funcs__.py
+++ b/porespy/tools/__funcs__.py
@@ -32,10 +32,10 @@ def align_image_with_openpnm(im):
                       ' unexpected behavior.')
     im = np.copy(im)
     if im.ndim == 2:
-        im = (sp.swapaxes(im, 1, 0))
+        im = (np.swapaxes(im, 1, 0))
         im = im[-1::-1, :]
     elif im.ndim == 3:
-        im = (sp.swapaxes(im, 2, 0))
+        im = (np.swapaxes(im, 2, 0))
         im = im[:, -1::-1, :]
     return im
 
@@ -527,7 +527,7 @@ def randomize_colors(im, keep_vals=[0]):
     '''
     im_flat = im.flatten()
     keep_vals = np.array(keep_vals)
-    swap_vals = ~sp.in1d(im_flat, keep_vals)
+    swap_vals = ~np.in1d(im_flat, keep_vals)
     im_vals = np.unique(im_flat[swap_vals])
     new_vals = sp.random.permutation(im_vals)
     im_map = np.zeros(shape=[np.amax(im_vals) + 1, ], dtype=int)
@@ -725,7 +725,7 @@ def norm_to_uniform(im, scale=None):
     """
     if scale is None:
         scale = [im.min(), im.max()]
-    im = (im - np.mean(im)) / sp.std(im)
+    im = (im - np.mean(im)) / np.std(im)
     im = 1 / 2 * sp.special.erfc(-im / np.sqrt(2))
     im = (im - im.min()) / (im.max() - im.min())
     im = im * (scale[1] - scale[0]) + scale[0]
@@ -924,9 +924,9 @@ def insert_sphere(im, c, r):
         raise Exception('Coordinates do not match dimensionality of image')
 
     bbox = []
-    [bbox.append(sp.clip(c[i] - r, 0, im.shape[i])) for i in range(im.ndim)]
-    [bbox.append(sp.clip(c[i] + r, 0, im.shape[i])) for i in range(im.ndim)]
-    bbox = sp.ravel(bbox)
+    [bbox.append(np.clip(c[i] - r, 0, im.shape[i])) for i in range(im.ndim)]
+    [bbox.append(np.clip(c[i] + r, 0, im.shape[i])) for i in range(im.ndim)]
+    bbox = np.ravel(bbox)
     s = bbox_to_slices(bbox)
     temp = im[s]
     blank = np.ones_like(temp)
@@ -964,7 +964,7 @@ def insert_cylinder(im, xyz0, xyz1, r):
     # Converting coordinates to numpy array
     xyz0, xyz1 = [np.array(xyz).astype(int) for xyz in (xyz0, xyz1)]
     r = int(r)
-    L = sp.absolute(xyz0 - xyz1).max() + 1
+    L = np.absolute(xyz0 - xyz1).max() + 1
     xyz_line = [np.linspace(xyz0[i], xyz1[i], L).astype(int) for i in range(3)]
 
     xyz_min = np.amin(xyz_line, axis=1) - r
@@ -977,7 +977,7 @@ def insert_cylinder(im, xyz0, xyz1, r):
         unique_dim = [xyz0[i] != xyz1[i] for i in range(3)].index(True)
         shape_template[unique_dim] = 1
         template_2D = disk(radius=r).reshape(shape_template)
-        template = sp.repeat(template_2D, repeats=L, axis=unique_dim)
+        template = np.repeat(template_2D, repeats=L, axis=unique_dim)
         xyz_min[unique_dim] += r
         xyz_max[unique_dim] += -r
     else:
@@ -1110,7 +1110,7 @@ def extract_regions(regions, labels: list, trim=True):
         labels = [labels]
     s = spim.find_objects(regions)
     im_new = np.zeros_like(regions)
-    x_min, y_min, z_min = sp.inf, sp.inf, sp.inf
+    x_min, y_min, z_min = np.inf, np.inf, np.inf
     x_max, y_max, z_max = 0, 0, 0
     for i in labels:
         im_new[s[i-1]] = regions[s[i-1]] == i

--- a/porespy/tools/__funcs__.py
+++ b/porespy/tools/__funcs__.py
@@ -314,7 +314,7 @@ def extract_cylinder(im, r=None, axis=0):
     dim = [range(int(-s / 2), int(s / 2) + s % 2) for s in im.shape]
     inds = np.meshgrid(*dim, indexing='ij')
     inds[axis] = inds[axis] * 0
-    d = np.sqrt(np.sum(sp.square(inds), axis=0))
+    d = np.sqrt(np.sum(np.square(inds), axis=0))
     mask = d < r
     im_temp = im*mask
     return im_temp
@@ -507,7 +507,7 @@ def randomize_colors(im, keep_vals=[0]):
     >>> import porespy as ps
     >>> import scipy as sp
     >>> np.random.seed(0)
-    >>> im = sp.random.randint(low=0, high=5, size=[4, 4])
+    >>> im = np.random.randint(low=0, high=5, size=[4, 4])
     >>> print(im)
     [[4 0 3 3]
      [3 1 3 2]
@@ -529,7 +529,7 @@ def randomize_colors(im, keep_vals=[0]):
     keep_vals = np.array(keep_vals)
     swap_vals = ~np.in1d(im_flat, keep_vals)
     im_vals = np.unique(im_flat[swap_vals])
-    new_vals = sp.random.permutation(im_vals)
+    new_vals = np.random.permutation(im_vals)
     im_map = np.zeros(shape=[np.amax(im_vals) + 1, ], dtype=int)
     im_map[im_vals] = new_vals
     im_new = im_map[im_flat]
@@ -582,7 +582,7 @@ def make_contiguous(im, keep_zeros=True):
     im_flat = im.flatten()
     im_vals = np.unique(im_flat)
     im_map = np.zeros(shape=np.amax(im_flat) + 1)
-    im_map[im_vals] = np.arange(0, sp.size(np.unique(im_flat)))
+    im_map[im_vals] = np.arange(0, np.size(np.unique(im_flat)))
     im_new = im_map[im_flat]
     im_new = np.reshape(im_new, newshape=np.shape(im))
     im_new = np.array(im_new, dtype=im_flat.dtype)

--- a/porespy/tools/__funcs__.py
+++ b/porespy/tools/__funcs__.py
@@ -582,7 +582,7 @@ def make_contiguous(im, keep_zeros=True):
     im_flat = im.flatten()
     im_vals = sp.unique(im_flat)
     im_map = np.zeros(shape=np.amax(im_flat) + 1)
-    im_map[im_vals] = sp.arange(0, sp.size(sp.unique(im_flat)))
+    im_map[im_vals] = np.arange(0, sp.size(sp.unique(im_flat)))
     im_new = im_map[im_flat]
     im_new = sp.reshape(im_new, newshape=sp.shape(im))
     im_new = np.array(im_new, dtype=im_flat.dtype)

--- a/porespy/tools/__funcs__.py
+++ b/porespy/tools/__funcs__.py
@@ -506,7 +506,7 @@ def randomize_colors(im, keep_vals=[0]):
     --------
     >>> import porespy as ps
     >>> import scipy as sp
-    >>> sp.random.seed(0)
+    >>> np.random.seed(0)
     >>> im = sp.random.randint(low=0, high=5, size=[4, 4])
     >>> print(im)
     [[4 0 3 3]

--- a/porespy/tools/__funcs__.py
+++ b/porespy/tools/__funcs__.py
@@ -118,7 +118,7 @@ def fftmorphology(im, strel, mode='opening'):
 
     # Perform erosion and dilation
     # The array must be padded with 0's so it works correctly at edges
-    temp = sp.pad(array=im, pad_width=1, mode='constant', constant_values=0)
+    temp = np.pad(array=im, pad_width=1, mode='constant', constant_values=0)
     if mode.startswith('ero'):
         temp = erode(temp, strel)
     if mode.startswith('dila'):
@@ -267,7 +267,7 @@ def find_outer_region(im, r=0):
     if r == 0:
         dt = spim.distance_transform_edt(input=im)
         r = int(np.amax(dt)) * 2
-    im_padded = sp.pad(array=im, pad_width=r, mode='constant',
+    im_padded = np.pad(array=im, pad_width=r, mode='constant',
                        constant_values=True)
     dt = spim.distance_transform_edt(input=im_padded)
     seeds = (dt >= r) + get_border(shape=im_padded.shape)
@@ -533,7 +533,7 @@ def randomize_colors(im, keep_vals=[0]):
     im_map = np.zeros(shape=[np.amax(im_vals) + 1, ], dtype=int)
     im_map[im_vals] = new_vals
     im_new = im_map[im_flat]
-    im_new = sp.reshape(im_new, newshape=sp.shape(im))
+    im_new = sp.reshape(im_new, newshape=np.shape(im))
     return im_new
 
 
@@ -584,7 +584,7 @@ def make_contiguous(im, keep_zeros=True):
     im_map = np.zeros(shape=np.amax(im_flat) + 1)
     im_map[im_vals] = np.arange(0, sp.size(sp.unique(im_flat)))
     im_new = im_map[im_flat]
-    im_new = sp.reshape(im_new, newshape=sp.shape(im))
+    im_new = sp.reshape(im_new, newshape=np.shape(im))
     im_new = np.array(im_new, dtype=im_flat.dtype)
     return im_new
 
@@ -810,12 +810,12 @@ def mesh_region(region: bool, strel=None):
             strel = disk(1)
     pad_width = np.amax(strel.shape)
     if im.ndim == 3:
-        padded_mask = sp.pad(im, pad_width=pad_width, mode='constant')
+        padded_mask = np.pad(im, pad_width=pad_width, mode='constant')
         padded_mask = spim.convolve(padded_mask * 1.0,
                                     weights=strel) / np.sum(strel)
     else:
         padded_mask = sp.reshape(im, (1,) + im.shape)
-        padded_mask = sp.pad(padded_mask, pad_width=pad_width, mode='constant')
+        padded_mask = np.pad(padded_mask, pad_width=pad_width, mode='constant')
     verts, faces, norm, val = marching_cubes_lewiner(padded_mask)
     result = namedtuple('mesh', ('verts', 'faces', 'norm', 'val'))
     result.verts = verts - pad_width
@@ -1037,7 +1037,7 @@ def pad_faces(im, faces):
             faces = [(int('left' in f) * 3, int('right' in f) * 3),
                      (int('front' in f) * 3, int('back' in f) * 3),
                      (int('top' in f) * 3, int('bottom' in f) * 3)]
-        im = sp.pad(im, pad_width=faces, mode='edge')
+        im = np.pad(im, pad_width=faces, mode='edge')
     else:
         im = im
     return im

--- a/porespy/tools/__funcs__.py
+++ b/porespy/tools/__funcs__.py
@@ -725,7 +725,7 @@ def norm_to_uniform(im, scale=None):
     """
     if scale is None:
         scale = [im.min(), im.max()]
-    im = (im - sp.mean(im)) / sp.std(im)
+    im = (im - np.mean(im)) / sp.std(im)
     im = 1 / 2 * sp.special.erfc(-im / np.sqrt(2))
     im = (im - im.min()) / (im.max() - im.min())
     im = im * (scale[1] - scale[0]) + scale[0]

--- a/porespy/tools/__funcs__.py
+++ b/porespy/tools/__funcs__.py
@@ -341,7 +341,7 @@ def extract_subsection(im, shape):
 
     Examples
     --------
-    >>> import scipy as sp
+    >>> import numpy as np
     >>> from porespy.tools import extract_subsection
     >>> im = np.array([[1, 1, 1, 1], [1, 2, 2, 2], [1, 2, 3, 3], [1, 2, 3, 4]])
     >>> print(im)
@@ -505,7 +505,7 @@ def randomize_colors(im, keep_vals=[0]):
     Examples
     --------
     >>> import porespy as ps
-    >>> import scipy as sp
+    >>> import numpy as np
     >>> np.random.seed(0)
     >>> im = np.random.randint(low=0, high=5, size=[4, 4])
     >>> print(im)
@@ -566,7 +566,7 @@ def make_contiguous(im, keep_zeros=True):
     Example
     -------
     >>> import porespy as ps
-    >>> import scipy as sp
+    >>> import numpy as np
     >>> im = np.array([[0, 2, 9], [6, 8, 3]])
     >>> im = ps.tools.make_contiguous(im)
     >>> print(im)
@@ -632,7 +632,7 @@ def get_border(shape, thickness=1, mode='edges', return_indices=False):
     Examples
     --------
     >>> import porespy as ps
-    >>> import scipy as sp
+    >>> import numpy as np
     >>> mask = ps.tools.get_border(shape=[3, 3], mode='corners')
     >>> print(mask)
     [[ True False  True]

--- a/porespy/tools/__funcs__.py
+++ b/porespy/tools/__funcs__.py
@@ -30,7 +30,7 @@ def align_image_with_openpnm(im):
         warnings.warn('Input image conains a singleton axis:' + str(im.shape) +
                       ' Reduce dimensionality with np.squeeze(im) to avoid' +
                       ' unexpected behavior.')
-    im = sp.copy(im)
+    im = np.copy(im)
     if im.ndim == 2:
         im = (sp.swapaxes(im, 1, 0))
         im = im[-1::-1, :]
@@ -574,7 +574,7 @@ def make_contiguous(im, keep_zeros=True):
      [3 4 2]]
 
     """
-    im = sp.copy(im)
+    im = np.copy(im)
     if keep_zeros:
         mask = (im == 0)
         im[mask] = im.min() - 1

--- a/porespy/tools/__funcs__.py
+++ b/porespy/tools/__funcs__.py
@@ -1071,7 +1071,7 @@ def _create_alias_map(im, alias=None):
     # -------------------------------------------------------------------------
     # Get alias if provided by user
     phases_num = np.unique(im * 1)
-    phases_num = sp.trim_zeros(phases_num)
+    phases_num = np.trim_zeros(phases_num)
     al = {}
     for values in phases_num:
         al[values] = 'phase{}'.format(values)

--- a/porespy/tools/__funcs__.py
+++ b/porespy/tools/__funcs__.py
@@ -528,7 +528,7 @@ def randomize_colors(im, keep_vals=[0]):
     im_flat = im.flatten()
     keep_vals = np.array(keep_vals)
     swap_vals = ~sp.in1d(im_flat, keep_vals)
-    im_vals = sp.unique(im_flat[swap_vals])
+    im_vals = np.unique(im_flat[swap_vals])
     new_vals = sp.random.permutation(im_vals)
     im_map = np.zeros(shape=[np.amax(im_vals) + 1, ], dtype=int)
     im_map[im_vals] = new_vals
@@ -580,9 +580,9 @@ def make_contiguous(im, keep_zeros=True):
         im[mask] = im.min() - 1
     im = im - im.min()
     im_flat = im.flatten()
-    im_vals = sp.unique(im_flat)
+    im_vals = np.unique(im_flat)
     im_map = np.zeros(shape=np.amax(im_flat) + 1)
-    im_map[im_vals] = np.arange(0, sp.size(sp.unique(im_flat)))
+    im_map[im_vals] = np.arange(0, sp.size(np.unique(im_flat)))
     im_new = im_map[im_flat]
     im_new = sp.reshape(im_new, newshape=np.shape(im))
     im_new = np.array(im_new, dtype=im_flat.dtype)
@@ -1070,7 +1070,7 @@ def _create_alias_map(im, alias=None):
     """
     # -------------------------------------------------------------------------
     # Get alias if provided by user
-    phases_num = sp.unique(im * 1)
+    phases_num = np.unique(im * 1)
     phases_num = sp.trim_zeros(phases_num)
     al = {}
     for values in phases_num:

--- a/porespy/tools/__funcs__.py
+++ b/porespy/tools/__funcs__.py
@@ -314,7 +314,7 @@ def extract_cylinder(im, r=None, axis=0):
     dim = [range(int(-s / 2), int(s / 2) + s % 2) for s in im.shape]
     inds = np.meshgrid(*dim, indexing='ij')
     inds[axis] = inds[axis] * 0
-    d = np.sqrt(sp.sum(sp.square(inds), axis=0))
+    d = np.sqrt(np.sum(sp.square(inds), axis=0))
     mask = d < r
     im_temp = im*mask
     return im_temp
@@ -812,7 +812,7 @@ def mesh_region(region: bool, strel=None):
     if im.ndim == 3:
         padded_mask = sp.pad(im, pad_width=pad_width, mode='constant')
         padded_mask = spim.convolve(padded_mask * 1.0,
-                                    weights=strel) / sp.sum(strel)
+                                    weights=strel) / np.sum(strel)
     else:
         padded_mask = sp.reshape(im, (1,) + im.shape)
         padded_mask = sp.pad(padded_mask, pad_width=pad_width, mode='constant')

--- a/porespy/tools/__funcs__.py
+++ b/porespy/tools/__funcs__.py
@@ -266,7 +266,7 @@ def find_outer_region(im, r=0):
     """
     if r == 0:
         dt = spim.distance_transform_edt(input=im)
-        r = int(sp.amax(dt)) * 2
+        r = int(np.amax(dt)) * 2
     im_padded = sp.pad(array=im, pad_width=r, mode='constant',
                        constant_values=True)
     dt = spim.distance_transform_edt(input=im_padded)
@@ -310,7 +310,7 @@ def extract_cylinder(im, r=None, axis=0):
     if r is None:
         a = list(im.shape)
         a.pop(axis)
-        r = np.floor(sp.amin(a) / 2)
+        r = np.floor(np.amin(a) / 2)
     dim = [range(int(-s / 2), int(s / 2) + s % 2) for s in im.shape]
     inds = np.meshgrid(*dim, indexing='ij')
     inds[axis] = inds[axis] * 0
@@ -363,8 +363,8 @@ def extract_subsection(im, shape):
     s_im = []
     for dim in range(im.ndim):
         r = shape[dim] / 2
-        lower_im = sp.amax((center[dim] - r, 0))
-        upper_im = sp.amin((center[dim] + r, im.shape[dim]))
+        lower_im = np.amax((center[dim] - r, 0))
+        upper_im = np.amin((center[dim] + r, im.shape[dim]))
         s_im.append(slice(int(lower_im), int(upper_im)))
     return im[tuple(s_im)]
 
@@ -530,7 +530,7 @@ def randomize_colors(im, keep_vals=[0]):
     swap_vals = ~sp.in1d(im_flat, keep_vals)
     im_vals = sp.unique(im_flat[swap_vals])
     new_vals = sp.random.permutation(im_vals)
-    im_map = np.zeros(shape=[sp.amax(im_vals) + 1, ], dtype=int)
+    im_map = np.zeros(shape=[np.amax(im_vals) + 1, ], dtype=int)
     im_map[im_vals] = new_vals
     im_new = im_map[im_flat]
     im_new = sp.reshape(im_new, newshape=sp.shape(im))
@@ -581,7 +581,7 @@ def make_contiguous(im, keep_zeros=True):
     im = im - im.min()
     im_flat = im.flatten()
     im_vals = sp.unique(im_flat)
-    im_map = np.zeros(shape=sp.amax(im_flat) + 1)
+    im_map = np.zeros(shape=np.amax(im_flat) + 1)
     im_map[im_vals] = sp.arange(0, sp.size(sp.unique(im_flat)))
     im_new = im_map[im_flat]
     im_new = sp.reshape(im_new, newshape=sp.shape(im))
@@ -808,7 +808,7 @@ def mesh_region(region: bool, strel=None):
             strel = ball(1)
         if region.ndim == 2:
             strel = disk(1)
-    pad_width = sp.amax(strel.shape)
+    pad_width = np.amax(strel.shape)
     if im.ndim == 3:
         padded_mask = sp.pad(im, pad_width=pad_width, mode='constant')
         padded_mask = spim.convolve(padded_mask * 1.0,
@@ -967,8 +967,8 @@ def insert_cylinder(im, xyz0, xyz1, r):
     L = sp.absolute(xyz0 - xyz1).max() + 1
     xyz_line = [np.linspace(xyz0[i], xyz1[i], L).astype(int) for i in range(3)]
 
-    xyz_min = sp.amin(xyz_line, axis=1) - r
-    xyz_max = sp.amax(xyz_line, axis=1) + r
+    xyz_min = np.amin(xyz_line, axis=1) - r
+    xyz_max = np.amax(xyz_line, axis=1) + r
     shape_template = xyz_max - xyz_min + 1
     template = np.zeros(shape=shape_template)
 

--- a/porespy/tools/__funcs__.py
+++ b/porespy/tools/__funcs__.py
@@ -1,3 +1,4 @@
+import numpy as np
 import scipy as sp
 import scipy.ndimage as spim
 import warnings
@@ -309,9 +310,9 @@ def extract_cylinder(im, r=None, axis=0):
     if r is None:
         a = list(im.shape)
         a.pop(axis)
-        r = sp.floor(sp.amin(a) / 2)
+        r = np.floor(sp.amin(a) / 2)
     dim = [range(int(-s / 2), int(s / 2) + s % 2) for s in im.shape]
-    inds = sp.meshgrid(*dim, indexing='ij')
+    inds = np.meshgrid(*dim, indexing='ij')
     inds[axis] = inds[axis] * 0
     d = sp.sqrt(sp.sum(sp.square(inds), axis=0))
     mask = d < r
@@ -529,7 +530,7 @@ def randomize_colors(im, keep_vals=[0]):
     swap_vals = ~sp.in1d(im_flat, keep_vals)
     im_vals = sp.unique(im_flat[swap_vals])
     new_vals = sp.random.permutation(im_vals)
-    im_map = sp.zeros(shape=[sp.amax(im_vals) + 1, ], dtype=int)
+    im_map = np.zeros(shape=[sp.amax(im_vals) + 1, ], dtype=int)
     im_map[im_vals] = new_vals
     im_new = im_map[im_flat]
     im_new = sp.reshape(im_new, newshape=sp.shape(im))
@@ -580,7 +581,7 @@ def make_contiguous(im, keep_zeros=True):
     im = im - im.min()
     im_flat = im.flatten()
     im_vals = sp.unique(im_flat)
-    im_map = sp.zeros(shape=sp.amax(im_flat) + 1)
+    im_map = np.zeros(shape=sp.amax(im_flat) + 1)
     im_map[im_vals] = sp.arange(0, sp.size(sp.unique(im_flat)))
     im_new = im_map[im_flat]
     im_new = sp.reshape(im_new, newshape=sp.shape(im))
@@ -964,12 +965,12 @@ def insert_cylinder(im, xyz0, xyz1, r):
     xyz0, xyz1 = [sp.array(xyz).astype(int) for xyz in (xyz0, xyz1)]
     r = int(r)
     L = sp.absolute(xyz0 - xyz1).max() + 1
-    xyz_line = [sp.linspace(xyz0[i], xyz1[i], L).astype(int) for i in range(3)]
+    xyz_line = [np.linspace(xyz0[i], xyz1[i], L).astype(int) for i in range(3)]
 
     xyz_min = sp.amin(xyz_line, axis=1) - r
     xyz_max = sp.amax(xyz_line, axis=1) + r
     shape_template = xyz_max - xyz_min + 1
-    template = sp.zeros(shape=shape_template)
+    template = np.zeros(shape=shape_template)
 
     # Shortcut for orthogonal cylinders
     if (xyz0 == xyz1).sum() == 2:
@@ -1108,7 +1109,7 @@ def extract_regions(regions, labels: list, trim=True):
     if type(labels) is int:
         labels = [labels]
     s = spim.find_objects(regions)
-    im_new = sp.zeros_like(regions)
+    im_new = np.zeros_like(regions)
     x_min, y_min, z_min = sp.inf, sp.inf, sp.inf
     x_max, y_max, z_max = 0, 0, 0
     for i in labels:

--- a/porespy/tools/__funcs__.py
+++ b/porespy/tools/__funcs__.py
@@ -393,11 +393,11 @@ def get_planes(im, squeeze=True):
     planes = [im[x, :, :], im[:, y, :], im[:, :, z]]
     if not squeeze:
         imx = planes[0]
-        planes[0] = sp.reshape(imx, [1, imx.shape[0], imx.shape[1]])
+        planes[0] = np.reshape(imx, [1, imx.shape[0], imx.shape[1]])
         imy = planes[1]
-        planes[1] = sp.reshape(imy, [imy.shape[0], 1, imy.shape[1]])
+        planes[1] = np.reshape(imy, [imy.shape[0], 1, imy.shape[1]])
         imz = planes[2]
-        planes[2] = sp.reshape(imz, [imz.shape[0], imz.shape[1], 1])
+        planes[2] = np.reshape(imz, [imz.shape[0], imz.shape[1], 1])
     return planes
 
 
@@ -533,7 +533,7 @@ def randomize_colors(im, keep_vals=[0]):
     im_map = np.zeros(shape=[np.amax(im_vals) + 1, ], dtype=int)
     im_map[im_vals] = new_vals
     im_new = im_map[im_flat]
-    im_new = sp.reshape(im_new, newshape=np.shape(im))
+    im_new = np.reshape(im_new, newshape=np.shape(im))
     return im_new
 
 
@@ -584,7 +584,7 @@ def make_contiguous(im, keep_zeros=True):
     im_map = np.zeros(shape=np.amax(im_flat) + 1)
     im_map[im_vals] = np.arange(0, sp.size(np.unique(im_flat)))
     im_new = im_map[im_flat]
-    im_new = sp.reshape(im_new, newshape=np.shape(im))
+    im_new = np.reshape(im_new, newshape=np.shape(im))
     im_new = np.array(im_new, dtype=im_flat.dtype)
     return im_new
 
@@ -814,7 +814,7 @@ def mesh_region(region: bool, strel=None):
         padded_mask = spim.convolve(padded_mask * 1.0,
                                     weights=strel) / np.sum(strel)
     else:
-        padded_mask = sp.reshape(im, (1,) + im.shape)
+        padded_mask = np.reshape(im, (1,) + im.shape)
         padded_mask = np.pad(padded_mask, pad_width=pad_width, mode='constant')
     verts, faces, norm, val = marching_cubes_lewiner(padded_mask)
     result = namedtuple('mesh', ('verts', 'faces', 'norm', 'val'))

--- a/porespy/tools/__funcs__.py
+++ b/porespy/tools/__funcs__.py
@@ -839,7 +839,7 @@ def ps_disk(radius):
     strel : 2D-array
         A 2D numpy bool array of the structring element
     """
-    rad = int(sp.ceil(radius))
+    rad = int(np.ceil(radius))
     other = np.ones((2 * rad + 1, 2 * rad + 1), dtype=bool)
     other[rad, rad] = False
     disk = spim.distance_transform_edt(other) < radius
@@ -860,7 +860,7 @@ def ps_ball(radius):
     strel : 3D-array
         A 3D numpy array of the structuring element
     """
-    rad = int(sp.ceil(radius))
+    rad = int(np.ceil(radius))
     other = np.ones((2 * rad + 1, 2 * rad + 1, 2 * rad + 1), dtype=bool)
     other[rad, rad, rad] = False
     ball = spim.distance_transform_edt(other) < radius

--- a/porespy/visualization/__plots__.py
+++ b/porespy/visualization/__plots__.py
@@ -1,5 +1,4 @@
 import numpy as np
-import scipy as sp
 import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d.art3d import Poly3DCollection
 

--- a/porespy/visualization/__plots__.py
+++ b/porespy/visualization/__plots__.py
@@ -1,3 +1,4 @@
+import numpy as np
 import scipy as sp
 import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d.art3d import Poly3DCollection
@@ -18,8 +19,8 @@ def show_mesh(mesh):
     fig : Matplotlib figure
         A handle to a matplotlib 3D axis
     """
-    lim_max = sp.amax(mesh.verts, axis=0)
-    lim_min = sp.amin(mesh.verts, axis=0)
+    lim_max = np.amax(mesh.verts, axis=0)
+    lim_min = np.amin(mesh.verts, axis=0)
 
     # Display resulting triangular mesh using Matplotlib.
     fig = plt.figure()

--- a/porespy/visualization/__views__.py
+++ b/porespy/visualization/__views__.py
@@ -28,7 +28,7 @@ def show_3D(im):
     so inverts the image to show the solid material.
 
     """
-    im = ~sp.copy(im)
+    im = ~np.copy(im)
     if im.ndim < 3:
         raise Exception('show_3D only applies to 3D images')
     im = spim.rotate(input=im, angle=22.5, axes=[0, 1], order=0)

--- a/porespy/visualization/__views__.py
+++ b/porespy/visualization/__views__.py
@@ -148,5 +148,5 @@ def xray(im, direction='X'):
         im = sp.transpose(im, axes=[1, 0, 2])
     if direction in ['Z', 'z']:
         im = sp.transpose(im, axes=[2, 1, 0])
-    im = sp.sum(im, axis=0)
+    im = np.sum(im, axis=0)
     return im

--- a/porespy/visualization/__views__.py
+++ b/porespy/visualization/__views__.py
@@ -1,3 +1,4 @@
+import numpy as np
 import scipy as sp
 import scipy.ndimage as spim
 # import matplotlib.pyplot as plt
@@ -69,7 +70,7 @@ def show_planes(im):
 
     new_y = im_xy.shape[1] + im_xz.shape[1] + 10
 
-    new_im = sp.zeros([new_x + 20, new_y + 20], dtype=im.dtype)
+    new_im = np.zeros([new_x + 20, new_y + 20], dtype=im.dtype)
 
     # Add xy image to upper left corner
     new_im[10:im_xy.shape[0]+10,

--- a/porespy/visualization/__views__.py
+++ b/porespy/visualization/__views__.py
@@ -114,7 +114,7 @@ def sem(im, direction='X'):
     if direction in ['Z', 'z']:
         im = sp.transpose(im, axes=[2, 1, 0])
     t = im.shape[0]
-    depth = sp.reshape(np.arange(0, t), [t, 1, 1])
+    depth = np.reshape(np.arange(0, t), [t, 1, 1])
     im = im*depth
     im = np.amax(im, axis=0)
     return im

--- a/porespy/visualization/__views__.py
+++ b/porespy/visualization/__views__.py
@@ -59,12 +59,12 @@ def show_planes(im):
         ``matplotlib.pyplot.imshow``.
 
     """
-    if sp.squeeze(im.ndim) < 3:
+    if np.squeeze(im.ndim) < 3:
         raise Exception('This view is only necessary for 3D images')
     x, y, z = (np.array(im.shape)/2).astype(int)
     im_xy = im[:, :, z]
     im_xz = im[:, y, :]
-    im_yz = sp.rot90(im[x, :, :])
+    im_yz = np.rot90(im[x, :, :])
 
     new_x = im_xy.shape[0] + im_yz.shape[0] + 10
 
@@ -110,9 +110,9 @@ def sem(im, direction='X'):
     """
     im = np.array(~im, dtype=int)
     if direction in ['Y', 'y']:
-        im = sp.transpose(im, axes=[1, 0, 2])
+        im = np.transpose(im, axes=[1, 0, 2])
     if direction in ['Z', 'z']:
-        im = sp.transpose(im, axes=[2, 1, 0])
+        im = np.transpose(im, axes=[2, 1, 0])
     t = im.shape[0]
     depth = np.reshape(np.arange(0, t), [t, 1, 1])
     im = im*depth
@@ -145,8 +145,8 @@ def xray(im, direction='X'):
     """
     im = np.array(~im, dtype=int)
     if direction in ['Y', 'y']:
-        im = sp.transpose(im, axes=[1, 0, 2])
+        im = np.transpose(im, axes=[1, 0, 2])
     if direction in ['Z', 'z']:
-        im = sp.transpose(im, axes=[2, 1, 0])
+        im = np.transpose(im, axes=[2, 1, 0])
     im = np.sum(im, axis=0)
     return im

--- a/porespy/visualization/__views__.py
+++ b/porespy/visualization/__views__.py
@@ -114,7 +114,7 @@ def sem(im, direction='X'):
     if direction in ['Z', 'z']:
         im = sp.transpose(im, axes=[2, 1, 0])
     t = im.shape[0]
-    depth = sp.reshape(sp.arange(0, t), [t, 1, 1])
+    depth = sp.reshape(np.arange(0, t), [t, 1, 1])
     im = im*depth
     im = np.amax(im, axis=0)
     return im

--- a/porespy/visualization/__views__.py
+++ b/porespy/visualization/__views__.py
@@ -116,7 +116,7 @@ def sem(im, direction='X'):
     t = im.shape[0]
     depth = sp.reshape(sp.arange(0, t), [t, 1, 1])
     im = im*depth
-    im = sp.amax(im, axis=0)
+    im = np.amax(im, axis=0)
     return im
 
 

--- a/porespy/visualization/__views__.py
+++ b/porespy/visualization/__views__.py
@@ -35,7 +35,7 @@ def show_3D(im):
     im = spim.rotate(input=im, angle=45, axes=[2, 1], order=0)
     im = spim.rotate(input=im, angle=-17, axes=[0, 1], order=0, reshape=False)
     mask = im != 0
-    view = sp.where(mask.any(axis=2), mask.argmax(axis=2), 0)
+    view = np.where(mask.any(axis=2), mask.argmax(axis=2), 0)
     view = view.max() - view
     f = view.max()/5
     view[view == view.max()] = -f
@@ -61,7 +61,7 @@ def show_planes(im):
     """
     if sp.squeeze(im.ndim) < 3:
         raise Exception('This view is only necessary for 3D images')
-    x, y, z = (sp.array(im.shape)/2).astype(int)
+    x, y, z = (np.array(im.shape)/2).astype(int)
     im_xy = im[:, :, z]
     im_xz = im[:, y, :]
     im_yz = sp.rot90(im[x, :, :])
@@ -108,7 +108,7 @@ def sem(im, direction='X'):
         A 2D greyscale image suitable for use in matplotlib\'s ```imshow```
         function.
     """
-    im = sp.array(~im, dtype=int)
+    im = np.array(~im, dtype=int)
     if direction in ['Y', 'y']:
         im = sp.transpose(im, axes=[1, 0, 2])
     if direction in ['Z', 'z']:
@@ -143,7 +143,7 @@ def xray(im, direction='X'):
         A 2D greyscale image suitable for use in matplotlib\'s ```imshow```
         function.
     """
-    im = sp.array(~im, dtype=int)
+    im = np.array(~im, dtype=int)
     if direction in ['Y', 'y']:
         im = sp.transpose(im, axes=[1, 0, 2])
     if direction in ['Z', 'z']:

--- a/porespy/visualization/__views__.py
+++ b/porespy/visualization/__views__.py
@@ -1,5 +1,4 @@
 import numpy as np
-import scipy as sp
 import scipy.ndimage as spim
 # import matplotlib.pyplot as plt
 # from mpl_toolkits.mplot3d.art3d import Poly3DCollection

--- a/test/unit/test_filters.py
+++ b/test/unit/test_filters.py
@@ -295,9 +295,9 @@ class FilterTest():
                                               return_all=True, mask=True,
                                               randomize=False, alias=None)
         assert sp.amax(snow.regions) == 44
-        assert not sp.any(sp.isnan(snow.regions))
-        assert not sp.any(sp.isnan(snow.dt))
-        assert not sp.any(sp.isnan(snow.im))
+        assert not np.any(sp.isnan(snow.regions))
+        assert not np.any(sp.isnan(snow.dt))
+        assert not np.any(sp.isnan(snow.im))
 
 if __name__ == '__main__':
     t = FilterTest()

--- a/test/unit/test_filters.py
+++ b/test/unit/test_filters.py
@@ -167,7 +167,7 @@ class FilterTest():
         assert lt.max() == self.im_dt.max()
 
     def test_local_thickness_known_sizes(self):
-        im = sp.zeros(shape=[300, 300])
+        im = np.zeros(shape=[300, 300])
         im = ps.generators.RSA(im=im, radius=20)
         im = ps.generators.RSA(im=im, radius=10)
         im = im > 0

--- a/test/unit/test_filters.py
+++ b/test/unit/test_filters.py
@@ -1,6 +1,5 @@
 import porespy as ps
 import pytest
-import scipy as sp
 import numpy as np
 import scipy.ndimage as spim
 from skimage.morphology import disk, ball

--- a/test/unit/test_filters.py
+++ b/test/unit/test_filters.py
@@ -27,8 +27,8 @@ class FilterTest():
         fft = ps.filters.porosimetry(im, mode='hybrid', sizes=sizes)
         mio = ps.filters.porosimetry(im, mode='mio', sizes=sizes)
         dt = ps.filters.porosimetry(im, mode='dt', sizes=sizes)
-        assert sp.all(fft == dt)
-        assert sp.all(fft == mio)
+        assert np.all(fft == dt)
+        assert np.all(fft == mio)
 
     def test_porosimetry_npts_10(self):
         mip = ps.filters.porosimetry(im=self.im, sizes=10)
@@ -36,7 +36,7 @@ class FilterTest():
         ans = np.array([0.00000000, 1.00000000, 1.37871571, 1.61887041,
                         1.90085700, 2.23196205, 2.62074139, 3.07724114,
                         3.61325732, 4.24264069])
-        assert sp.allclose(steps, ans)
+        assert np.allclose(steps, ans)
 
     def test_porosimetry_compare_modes_3D(self):
         im = self.im
@@ -44,13 +44,13 @@ class FilterTest():
         fft = ps.filters.porosimetry(im, sizes=sizes, mode='hybrid')
         mio = ps.filters.porosimetry(im, sizes=sizes, mode='mio')
         dt = ps.filters.porosimetry(im, sizes=sizes, mode='dt')
-        assert sp.all(fft == dt)
-        assert sp.all(fft == mio)
+        assert np.all(fft == dt)
+        assert np.all(fft == mio)
 
     def test_porosimetry_with_sizes(self):
         s = sp.logspace(0.01, 0.6, 5)
         mip = ps.filters.porosimetry(im=self.im, sizes=s)
-        assert sp.allclose(sp.unique(mip)[1:], s)
+        assert np.allclose(sp.unique(mip)[1:], s)
 
     def test_apply_chords_axis0(self):
         c = ps.filters.apply_chords(im=self.im, spacing=3, axis=0)
@@ -87,11 +87,11 @@ class FilterTest():
         im = ~ps.generators.lattice_spheres(shape=[100, 100], offset=3,
                                             radius=10)
         sz = ps.filters.flood(im*2.0, mode='max')
-        assert sp.all(sp.unique(sz) == [0, 2])
+        assert np.all(sp.unique(sz) == [0, 2])
         sz = ps.filters.flood(im, mode='min')
-        assert sp.all(sp.unique(sz) == [0, 1])
+        assert np.all(sp.unique(sz) == [0, 1])
         sz = ps.filters.flood(im, mode='size')
-        assert sp.all(sp.unique(sz) == [0, 305])
+        assert np.all(sp.unique(sz) == [0, 305])
 
     def test_find_disconnected_voxels_2d(self):
         h = ps.filters.find_disconnected_voxels(self.im[:, :, 0])
@@ -172,7 +172,7 @@ class FilterTest():
         im = ps.generators.RSA(im=im, radius=10)
         im = im > 0
         lt = ps.filters.local_thickness(im, sizes=[20, 10])
-        assert sp.all(sp.unique(lt) == [0, 10, 20])
+        assert np.all(sp.unique(lt) == [0, 10, 20])
 
     def test_porosimetry(self):
         im2d = self.im[:, :, 50]
@@ -187,49 +187,49 @@ class FilterTest():
         im = self.im[:, :, 50]
         truth = spim.binary_dilation(im, structure=disk(3))
         test = ps.tools.fftmorphology(im, strel=disk(3), mode='dilation')
-        assert sp.all(truth == test)
+        assert np.all(truth == test)
 
     def test_morphology_fft_erode_2D(self):
         im = self.im[:, :, 50]
         truth = spim.binary_erosion(im, structure=disk(3))
         test = ps.tools.fftmorphology(im, strel=disk(3), mode='erosion')
-        assert sp.all(truth == test)
+        assert np.all(truth == test)
 
     def test_morphology_fft_opening_2D(self):
         im = self.im[:, :, 50]
         truth = spim.binary_opening(im, structure=disk(3))
         test = ps.tools.fftmorphology(im, strel=disk(3), mode='opening')
-        assert sp.all(truth == test)
+        assert np.all(truth == test)
 
     def test_morphology_fft_closing_2D(self):
         im = self.im[:, :, 50]
         truth = spim.binary_closing(im, structure=disk(3))
         test = ps.tools.fftmorphology(im, strel=disk(3), mode='closing')
-        assert sp.all(truth == test)
+        assert np.all(truth == test)
 
     def test_morphology_fft_dilate_3D(self):
         im = self.im
         truth = spim.binary_dilation(im, structure=ball(3))
         test = ps.tools.fftmorphology(im, strel=ball(3), mode='dilation')
-        assert sp.all(truth == test)
+        assert np.all(truth == test)
 
     def test_morphology_fft_erode_3D(self):
         im = self.im
         truth = spim.binary_erosion(im, structure=ball(3))
         test = ps.tools.fftmorphology(im, strel=ball(3), mode='erosion')
-        assert sp.all(truth == test)
+        assert np.all(truth == test)
 
     def test_morphology_fft_opening_3D(self):
         im = self.im
         truth = spim.binary_opening(im, structure=ball(3))
         test = ps.tools.fftmorphology(im, strel=ball(3), mode='opening')
-        assert sp.all(truth == test)
+        assert np.all(truth == test)
 
     def test_morphology_fft_closing_3D(self):
         im = self.im
         truth = spim.binary_closing(im, structure=ball(3))
         test = ps.tools.fftmorphology(im, strel=ball(3), mode='closing')
-        assert sp.all(truth == test)
+        assert np.all(truth == test)
 
     def test_reduce_peaks(self):
         im = ~ps.generators.lattice_spheres(shape=[50, 50], radius=5, offset=3)
@@ -287,7 +287,7 @@ class FilterTest():
         dt = spim.distance_transform_edt(im)
         ar = ps.filters.find_dt_artifacts(dt)
         inds = np.where(ar == ar.max())
-        assert sp.all(dt[inds] - ar[inds] == 1)
+        assert np.all(dt[inds] - ar[inds] == 1)
 
     def test_snow_partitioning_n(self):
         im = self.im

--- a/test/unit/test_filters.py
+++ b/test/unit/test_filters.py
@@ -23,7 +23,7 @@ class FilterTest():
 
     def test_porosimetry_compare_modes_2D(self):
         im = self.im[:, :, 50]
-        sizes = sp.arange(25, 1, -1)
+        sizes = np.arange(25, 1, -1)
         fft = ps.filters.porosimetry(im, mode='hybrid', sizes=sizes)
         mio = ps.filters.porosimetry(im, mode='mio', sizes=sizes)
         dt = ps.filters.porosimetry(im, mode='dt', sizes=sizes)
@@ -40,7 +40,7 @@ class FilterTest():
 
     def test_porosimetry_compare_modes_3D(self):
         im = self.im
-        sizes = sp.arange(25, 1, -1)
+        sizes = np.arange(25, 1, -1)
         fft = ps.filters.porosimetry(im, sizes=sizes, mode='hybrid')
         mio = ps.filters.porosimetry(im, sizes=sizes, mode='mio')
         dt = ps.filters.porosimetry(im, sizes=sizes, mode='dt')

--- a/test/unit/test_filters.py
+++ b/test/unit/test_filters.py
@@ -33,7 +33,7 @@ class FilterTest():
     def test_porosimetry_npts_10(self):
         mip = ps.filters.porosimetry(im=self.im, sizes=10)
         steps = sp.unique(mip)
-        ans = sp.array([0.00000000, 1.00000000, 1.37871571, 1.61887041,
+        ans = np.array([0.00000000, 1.00000000, 1.37871571, 1.61887041,
                         1.90085700, 2.23196205, 2.62074139, 3.07724114,
                         3.61325732, 4.24264069])
         assert sp.allclose(steps, ans)
@@ -286,7 +286,7 @@ class FilterTest():
         im = ps.generators.lattice_spheres(shape=[50, 50], radius=4, offset=5)
         dt = spim.distance_transform_edt(im)
         ar = ps.filters.find_dt_artifacts(dt)
-        inds = sp.where(ar == ar.max())
+        inds = np.where(ar == ar.max())
         assert sp.all(dt[inds] - ar[inds] == 1)
 
     def test_snow_partitioning_n(self):

--- a/test/unit/test_filters.py
+++ b/test/unit/test_filters.py
@@ -8,7 +8,7 @@ from skimage.morphology import disk, ball
 
 class FilterTest():
     def setup_class(self):
-        sp.random.seed(0)
+        np.random.seed(0)
         self.im = ps.generators.blobs(shape=[100, 100, 100], blobiness=2)
         # Ensure that im was generated as expeccted
         assert ps.metrics.porosity(self.im) == 0.499829

--- a/test/unit/test_filters.py
+++ b/test/unit/test_filters.py
@@ -48,7 +48,7 @@ class FilterTest():
         assert np.all(fft == mio)
 
     def test_porosimetry_with_sizes(self):
-        s = sp.logspace(0.01, 0.6, 5)
+        s = np.logspace(0.01, 0.6, 5)
         mip = ps.filters.porosimetry(im=self.im, sizes=s)
         assert np.allclose(np.unique(mip)[1:], s)
 
@@ -295,9 +295,9 @@ class FilterTest():
                                               return_all=True, mask=True,
                                               randomize=False, alias=None)
         assert np.amax(snow.regions) == 44
-        assert not np.any(sp.isnan(snow.regions))
-        assert not np.any(sp.isnan(snow.dt))
-        assert not np.any(sp.isnan(snow.im))
+        assert not np.any(np.isnan(snow.regions))
+        assert not np.any(np.isnan(snow.dt))
+        assert not np.any(np.isnan(snow.im))
 
 if __name__ == '__main__':
     t = FilterTest()

--- a/test/unit/test_filters.py
+++ b/test/unit/test_filters.py
@@ -294,7 +294,7 @@ class FilterTest():
         snow = ps.filters.snow_partitioning_n(im + 1, r_max=4, sigma=0.4,
                                               return_all=True, mask=True,
                                               randomize=False, alias=None)
-        assert sp.amax(snow.regions) == 44
+        assert np.amax(snow.regions) == 44
         assert not np.any(sp.isnan(snow.regions))
         assert not np.any(sp.isnan(snow.dt))
         assert not np.any(sp.isnan(snow.im))

--- a/test/unit/test_filters.py
+++ b/test/unit/test_filters.py
@@ -32,7 +32,7 @@ class FilterTest():
 
     def test_porosimetry_npts_10(self):
         mip = ps.filters.porosimetry(im=self.im, sizes=10)
-        steps = sp.unique(mip)
+        steps = np.unique(mip)
         ans = np.array([0.00000000, 1.00000000, 1.37871571, 1.61887041,
                         1.90085700, 2.23196205, 2.62074139, 3.07724114,
                         3.61325732, 4.24264069])
@@ -50,7 +50,7 @@ class FilterTest():
     def test_porosimetry_with_sizes(self):
         s = sp.logspace(0.01, 0.6, 5)
         mip = ps.filters.porosimetry(im=self.im, sizes=s)
-        assert np.allclose(sp.unique(mip)[1:], s)
+        assert np.allclose(np.unique(mip)[1:], s)
 
     def test_apply_chords_axis0(self):
         c = ps.filters.apply_chords(im=self.im, spacing=3, axis=0)
@@ -87,11 +87,11 @@ class FilterTest():
         im = ~ps.generators.lattice_spheres(shape=[100, 100], offset=3,
                                             radius=10)
         sz = ps.filters.flood(im*2.0, mode='max')
-        assert np.all(sp.unique(sz) == [0, 2])
+        assert np.all(np.unique(sz) == [0, 2])
         sz = ps.filters.flood(im, mode='min')
-        assert np.all(sp.unique(sz) == [0, 1])
+        assert np.all(np.unique(sz) == [0, 1])
         sz = ps.filters.flood(im, mode='size')
-        assert np.all(sp.unique(sz) == [0, 305])
+        assert np.all(np.unique(sz) == [0, 305])
 
     def test_find_disconnected_voxels_2d(self):
         h = ps.filters.find_disconnected_voxels(self.im[:, :, 0])
@@ -172,7 +172,7 @@ class FilterTest():
         im = ps.generators.RSA(im=im, radius=10)
         im = im > 0
         lt = ps.filters.local_thickness(im, sizes=[20, 10])
-        assert np.all(sp.unique(lt) == [0, 10, 20])
+        assert np.all(np.unique(lt) == [0, 10, 20])
 
     def test_porosimetry(self):
         im2d = self.im[:, :, 50]

--- a/test/unit/test_filters.py
+++ b/test/unit/test_filters.py
@@ -95,54 +95,54 @@ class FilterTest():
 
     def test_find_disconnected_voxels_2d(self):
         h = ps.filters.find_disconnected_voxels(self.im[:, :, 0])
-        assert sp.sum(h) == 477
+        assert np.sum(h) == 477
 
     def test_find_disconnected_voxels_2d_conn4(self):
         h = ps.filters.find_disconnected_voxels(self.im[:, :, 0], conn=4)
-        assert sp.sum(h) == 652
+        assert np.sum(h) == 652
 
     def test_find_disconnected_voxels_3d(self):
         h = ps.filters.find_disconnected_voxels(self.im)
-        assert sp.sum(h) == 55
+        assert np.sum(h) == 55
 
     def test_find_disconnected_voxels_3d_conn6(self):
         h = ps.filters.find_disconnected_voxels(self.im, conn=6)
-        assert sp.sum(h) == 202
+        assert np.sum(h) == 202
 
     def test_trim_nonpercolating_paths_2d_axis0(self):
         h = ps.filters.trim_nonpercolating_paths(self.im[:, :, 0],
                                                  inlet_axis=0, outlet_axis=0)
-        assert sp.sum(h) == 3178
+        assert np.sum(h) == 3178
 
     def test_trim_nonpercolating_paths_2d_axis1(self):
         h = ps.filters.trim_nonpercolating_paths(self.im[:, :, 0],
                                                  inlet_axis=1, outlet_axis=1)
-        assert sp.sum(h) == 1067
+        assert np.sum(h) == 1067
 
     def test_trim_nonpercolating_paths_3d_axis0(self):
         h = ps.filters.trim_nonpercolating_paths(self.im,
                                                  inlet_axis=0, outlet_axis=0)
-        assert sp.sum(h) == 499733
+        assert np.sum(h) == 499733
 
     def test_trim_nonpercolating_paths_3d_axis1(self):
         h = ps.filters.trim_nonpercolating_paths(self.im,
                                                  inlet_axis=1, outlet_axis=1)
-        assert sp.sum(h) == 499693
+        assert np.sum(h) == 499693
 
     def test_trim_nonpercolating_paths_3d_axis2(self):
         h = ps.filters.trim_nonpercolating_paths(self.im,
                                                  inlet_axis=2, outlet_axis=2)
-        assert sp.sum(h) == 499611
+        assert np.sum(h) == 499611
 
     def test_fill_blind_pores(self):
         h = ps.filters.find_disconnected_voxels(self.im)
         b = ps.filters.fill_blind_pores(h)
         h = ps.filters.find_disconnected_voxels(b)
-        assert sp.sum(h) == 0
+        assert np.sum(h) == 0
 
     def test_trim_floating_solid(self):
         f = ps.filters.trim_floating_solid(~self.im)
-        assert sp.sum(f) > sp.sum(~self.im)
+        assert np.sum(f) > np.sum(~self.im)
 
     def test_trim_extrema_min(self):
         dt = self.im_dt[:, :, 45:55]

--- a/test/unit/test_generators.py
+++ b/test/unit/test_generators.py
@@ -20,10 +20,10 @@ class GeneratorTest():
         # But this works
         im = ps.generators.cylinders(shape=[1, X, Y], radius=1, ncylinders=20)
         assert im.dtype == bool
-        assert sp.shape(im.squeeze()) == (X, Y)
+        assert np.shape(im.squeeze()) == (X, Y)
         im = ps.generators.cylinders(shape=[50, 50, 50], radius=1,
                                      ncylinders=20)
-        assert sp.shape(im.squeeze()) == (50, 50, 50)
+        assert np.shape(im.squeeze()) == (50, 50, 50)
 
     def test_insert_shape_center_defaults(self):
         im = np.zeros([11, 11])

--- a/test/unit/test_generators.py
+++ b/test/unit/test_generators.py
@@ -229,7 +229,7 @@ class GeneratorTest():
         im = np.zeros([100, 100], dtype=int)
         im = ps.generators.RSA(im, radius=10, volume_fraction=0.5,
                                mode='contained')
-        coords = sp.argwhere(im == 2)
+        coords = np.argwhere(im == 2)
         assert ~np.any(coords < 10)
         assert ~np.any(coords > 90)
 
@@ -237,7 +237,7 @@ class GeneratorTest():
         im = np.zeros([50, 50, 50], dtype=int)
         im = ps.generators.RSA(im, radius=5, volume_fraction=0.5,
                                mode='contained')
-        coords = sp.argwhere(im == 2)
+        coords = np.argwhere(im == 2)
         assert ~np.any(coords < 5)
         assert ~np.any(coords > 45)
 

--- a/test/unit/test_generators.py
+++ b/test/unit/test_generators.py
@@ -230,16 +230,16 @@ class GeneratorTest():
         im = ps.generators.RSA(im, radius=10, volume_fraction=0.5,
                                mode='contained')
         coords = sp.argwhere(im == 2)
-        assert ~sp.any(coords < 10)
-        assert ~sp.any(coords > 90)
+        assert ~np.any(coords < 10)
+        assert ~np.any(coords > 90)
 
     def test_RSA_mask_edge_3d(self):
         im = np.zeros([50, 50, 50], dtype=int)
         im = ps.generators.RSA(im, radius=5, volume_fraction=0.5,
                                mode='contained')
         coords = sp.argwhere(im == 2)
-        assert ~sp.any(coords < 5)
-        assert ~sp.any(coords > 45)
+        assert ~np.any(coords < 5)
+        assert ~np.any(coords > 45)
 
     def test_line_segment(self):
         X0 = [3, 4]

--- a/test/unit/test_generators.py
+++ b/test/unit/test_generators.py
@@ -1,4 +1,5 @@
 import porespy as ps
+import numpy as np
 import scipy as sp
 import pytest
 import scipy.ndimage as spim
@@ -130,7 +131,7 @@ class GeneratorTest():
             im = ps.generators.overlapping_spheres(shape=[101, 101],
                                                    radius=5,
                                                    porosity=phi)
-            phi_actual = im.sum() / sp.size(im)
+            phi_actual = im.sum() / np.size(im)
             assert abs(phi_actual - phi) < 0.02
 
     def test_overlapping_spheres_3d(self):
@@ -138,7 +139,7 @@ class GeneratorTest():
         for phi in phis:
             im = ps.generators.overlapping_spheres(shape=[100, 100, 50],
                                                    radius=8, porosity=phi)
-            phi_actual = im.sum() / sp.size(im)
+            phi_actual = im.sum() / np.size(im)
             assert abs(phi_actual - phi) < 0.02
 
     def test_polydisperse_spheres(self):
@@ -148,7 +149,7 @@ class GeneratorTest():
             im = ps.generators.polydisperse_spheres(shape=[100, 100, 50],
                                                     porosity=phi, dist=dist,
                                                     nbins=10)
-            phi_actual = im.sum() / sp.size(im)
+            phi_actual = im.sum() / np.size(im)
             assert abs(phi_actual - phi) < 0.1
 
     def test_voronoi_edges(self):

--- a/test/unit/test_generators.py
+++ b/test/unit/test_generators.py
@@ -29,7 +29,7 @@ class GeneratorTest():
         im = np.zeros([11, 11])
         shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, center=[5, 5])
-        assert np.sum(im) == sp.prod(shape.shape)
+        assert np.sum(im) == np.prod(shape.shape)
 
         im = np.zeros([11, 11])
         shape = np.ones([4, 4])
@@ -41,14 +41,14 @@ class GeneratorTest():
         shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, center=[5, 5],
                                         value=1.0, mode='overlay')
-        assert np.sum(im) == (sp.prod(im.shape) + sp.prod(shape.shape))
+        assert np.sum(im) == (np.prod(im.shape) + np.prod(shape.shape))
 
     def test_insert_shape_corner_overwrite(self):
         im = np.ones([10, 10])
         shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, corner=[5, 5],
                                         value=1.0, mode='overlay')
-        assert np.sum(im) == (sp.prod(im.shape) + sp.prod(shape.shape))
+        assert np.sum(im) == (np.prod(im.shape) + np.prod(shape.shape))
         assert im[5, 5] == 2
         assert im[4, 5] == 1 and im[5, 4] == 1
 

--- a/test/unit/test_generators.py
+++ b/test/unit/test_generators.py
@@ -125,7 +125,7 @@ class GeneratorTest():
         assert N == 100
 
     def test_overlapping_spheres_2d(self):
-        phis = sp.arange(0.1, 0.9, 0.2)
+        phis = np.arange(0.1, 0.9, 0.2)
         for phi in phis:
             im = ps.generators.overlapping_spheres(shape=[101, 101],
                                                    radius=5,
@@ -134,7 +134,7 @@ class GeneratorTest():
             assert abs(phi_actual - phi) < 0.02
 
     def test_overlapping_spheres_3d(self):
-        phis = sp.arange(0.1, 0.9, 0.2)
+        phis = np.arange(0.1, 0.9, 0.2)
         for phi in phis:
             im = ps.generators.overlapping_spheres(shape=[100, 100, 50],
                                                    radius=8, porosity=phi)
@@ -142,7 +142,7 @@ class GeneratorTest():
             assert abs(phi_actual - phi) < 0.02
 
     def test_polydisperse_spheres(self):
-        phis = sp.arange(0.1, 0.9, 0.2)
+        phis = np.arange(0.1, 0.9, 0.2)
         dist = sp.stats.norm(loc=7, scale=2)
         for phi in phis:
             im = ps.generators.polydisperse_spheres(shape=[100, 100, 50],

--- a/test/unit/test_generators.py
+++ b/test/unit/test_generators.py
@@ -27,25 +27,25 @@ class GeneratorTest():
 
     def test_insert_shape_center_defaults(self):
         im = np.zeros([11, 11])
-        shape = sp.ones([3, 3])
+        shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, center=[5, 5])
         assert sp.sum(im) == sp.prod(shape.shape)
 
         im = np.zeros([11, 11])
-        shape = sp.ones([4, 4])
+        shape = np.ones([4, 4])
         with pytest.raises(Exception):
             im = ps.generators.insert_shape(im, element=shape, center=[5, 5])
 
     def test_insert_shape_center_overlay(self):
-        im = sp.ones([10, 10])
-        shape = sp.ones([3, 3])
+        im = np.ones([10, 10])
+        shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, center=[5, 5],
                                         value=1.0, mode='overlay')
         assert sp.sum(im) == (sp.prod(im.shape) + sp.prod(shape.shape))
 
     def test_insert_shape_corner_overwrite(self):
-        im = sp.ones([10, 10])
-        shape = sp.ones([3, 3])
+        im = np.ones([10, 10])
+        shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, corner=[5, 5],
                                         value=1.0, mode='overlay')
         assert sp.sum(im) == (sp.prod(im.shape) + sp.prod(shape.shape))
@@ -54,68 +54,68 @@ class GeneratorTest():
 
     def test_insert_shape_center_outside_im(self):
         im = np.zeros([11, 11])
-        shape = sp.ones([3, 3])
+        shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, center=[-1, -1])
         assert sp.sum(im) == 1
 
         im = np.zeros([11, 11])
-        shape = sp.ones([3, 3])
+        shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, center=[0, -1])
         assert sp.sum(im) == 2
 
         im = np.zeros([11, 11])
-        shape = sp.ones([3, 3])
+        shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, center=[10, 10])
         assert sp.sum(im) == 4
 
         im = np.zeros([11, 11])
-        shape = sp.ones([3, 3])
+        shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, center=[14, 14])
         assert sp.sum(im) == 0
 
         im = np.zeros([11, 11])
-        shape = sp.ones([4, 4])
+        shape = np.ones([4, 4])
         with pytest.raises(Exception):
             im = ps.generators.insert_shape(im, element=shape, center=[10, 10])
 
         im = np.zeros([11, 11])
-        shape = sp.ones([4, 3])
+        shape = np.ones([4, 3])
         with pytest.raises(Exception):
             im = ps.generators.insert_shape(im, element=shape, center=[10, 10])
 
     def test_insert_shape_corner_outside_im(self):
         im = np.zeros([11, 11])
-        shape = sp.ones([3, 3])
+        shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, corner=[-1, -1])
         assert sp.sum(im) == 4
 
         im = np.zeros([11, 11])
-        shape = sp.ones([3, 3])
+        shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, corner=[-1, 1])
         assert sp.sum(im) == 6
 
         im = np.zeros([11, 11])
-        shape = sp.ones([3, 3])
+        shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, corner=[-3, -3])
         assert sp.sum(im) == 0
 
         im = np.zeros([11, 11])
-        shape = sp.ones([3, 3])
+        shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, corner=[10, 9])
         assert sp.sum(im) == 2
 
         im = np.zeros([11, 11])
-        shape = sp.ones([3, 3])
+        shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, corner=[13, 13])
         assert sp.sum(im) == 0
 
         im = np.zeros([11, 11])
-        shape = sp.ones([3, 4])
+        shape = np.ones([3, 4])
         im = ps.generators.insert_shape(im, element=shape, corner=[9, 9])
         assert sp.sum(im) == 4
 
         im = np.zeros([11, 11])
-        shape = sp.ones([3, 4])
+        shape = np.ones([3, 4])
         im = ps.generators.insert_shape(im, element=shape, corner=[0, -1])
         assert sp.sum(im) == 9
 

--- a/test/unit/test_generators.py
+++ b/test/unit/test_generators.py
@@ -245,15 +245,15 @@ class GeneratorTest():
         X0 = [3, 4]
         X1 = [5, 9]
         L1, L2 = ps.generators.line_segment(X0, X1)
-        assert sp.all(L1 == [3, 3, 4, 4, 5, 5])
-        assert sp.all(L2 == [4, 5, 6, 7, 8, 9])
+        assert np.all(L1 == [3, 3, 4, 4, 5, 5])
+        assert np.all(L2 == [4, 5, 6, 7, 8, 9])
 
         X0 = [3, 4, 5]
         X1 = [5, 9, 13]
         L1, L2, L3 = ps.generators.line_segment(X0, X1)
-        assert sp.all(L1 == [3, 3, 4, 4, 4, 4, 4, 5, 5])
-        assert sp.all(L2 == [4, 5, 5, 6, 6, 7, 8, 8, 9])
-        assert sp.all(L3 == [5, 6, 7, 8, 9, 10, 11, 12, 13])
+        assert np.all(L1 == [3, 3, 4, 4, 4, 4, 4, 5, 5])
+        assert np.all(L2 == [4, 5, 5, 6, 6, 7, 8, 8, 9])
+        assert np.all(L3 == [5, 6, 7, 8, 9, 10, 11, 12, 13])
 
 
 if __name__ == '__main__':

--- a/test/unit/test_generators.py
+++ b/test/unit/test_generators.py
@@ -9,7 +9,7 @@ plt.close('all')
 class GeneratorTest():
 
     def setup_class(self):
-        sp.random.seed(10)
+        np.random.seed(10)
 
     def test_cylinders(self):
         X = 100
@@ -152,7 +152,7 @@ class GeneratorTest():
             assert abs(phi_actual - phi) < 0.1
 
     def test_voronoi_edges(self):
-        sp.random.seed(0)
+        np.random.seed(0)
         im = ps.generators.voronoi_edges(shape=[50, 50, 50],
                                          radius=2,
                                          ncells=25,
@@ -204,14 +204,14 @@ class GeneratorTest():
         assert len(list(im.shape)) == 3
 
     def test_RSA_2d_single(self):
-        sp.random.seed(0)
+        np.random.seed(0)
         im = np.zeros([100, 100], dtype=int)
         im = ps.generators.RSA(im, radius=10, volume_fraction=0.5)
         assert np.sum(im > 0) == 5095
         assert np.sum(im > 1) == 20
 
     def test_RSA_2d_multi(self):
-        sp.random.seed(0)
+        np.random.seed(0)
         im = np.zeros([100, 100], dtype=int)
         im = ps.generators.RSA(im, radius=10, volume_fraction=0.5)
         im = ps.generators.RSA(im, radius=5, volume_fraction=0.75)
@@ -219,7 +219,7 @@ class GeneratorTest():
         assert np.sum(im > 1) == 44
 
     def test_RSA_3d_single(self):
-        sp.random.seed(0)
+        np.random.seed(0)
         im = np.zeros([50, 50, 50], dtype=int)
         im = ps.generators.RSA(im, radius=5, volume_fraction=0.5)
         assert np.sum(im > 0) == 45602

--- a/test/unit/test_generators.py
+++ b/test/unit/test_generators.py
@@ -26,12 +26,12 @@ class GeneratorTest():
         assert sp.shape(im.squeeze()) == (50, 50, 50)
 
     def test_insert_shape_center_defaults(self):
-        im = sp.zeros([11, 11])
+        im = np.zeros([11, 11])
         shape = sp.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, center=[5, 5])
         assert sp.sum(im) == sp.prod(shape.shape)
 
-        im = sp.zeros([11, 11])
+        im = np.zeros([11, 11])
         shape = sp.ones([4, 4])
         with pytest.raises(Exception):
             im = ps.generators.insert_shape(im, element=shape, center=[5, 5])
@@ -53,68 +53,68 @@ class GeneratorTest():
         assert im[4, 5] == 1 and im[5, 4] == 1
 
     def test_insert_shape_center_outside_im(self):
-        im = sp.zeros([11, 11])
+        im = np.zeros([11, 11])
         shape = sp.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, center=[-1, -1])
         assert sp.sum(im) == 1
 
-        im = sp.zeros([11, 11])
+        im = np.zeros([11, 11])
         shape = sp.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, center=[0, -1])
         assert sp.sum(im) == 2
 
-        im = sp.zeros([11, 11])
+        im = np.zeros([11, 11])
         shape = sp.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, center=[10, 10])
         assert sp.sum(im) == 4
 
-        im = sp.zeros([11, 11])
+        im = np.zeros([11, 11])
         shape = sp.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, center=[14, 14])
         assert sp.sum(im) == 0
 
-        im = sp.zeros([11, 11])
+        im = np.zeros([11, 11])
         shape = sp.ones([4, 4])
         with pytest.raises(Exception):
             im = ps.generators.insert_shape(im, element=shape, center=[10, 10])
 
-        im = sp.zeros([11, 11])
+        im = np.zeros([11, 11])
         shape = sp.ones([4, 3])
         with pytest.raises(Exception):
             im = ps.generators.insert_shape(im, element=shape, center=[10, 10])
 
     def test_insert_shape_corner_outside_im(self):
-        im = sp.zeros([11, 11])
+        im = np.zeros([11, 11])
         shape = sp.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, corner=[-1, -1])
         assert sp.sum(im) == 4
 
-        im = sp.zeros([11, 11])
+        im = np.zeros([11, 11])
         shape = sp.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, corner=[-1, 1])
         assert sp.sum(im) == 6
 
-        im = sp.zeros([11, 11])
+        im = np.zeros([11, 11])
         shape = sp.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, corner=[-3, -3])
         assert sp.sum(im) == 0
 
-        im = sp.zeros([11, 11])
+        im = np.zeros([11, 11])
         shape = sp.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, corner=[10, 9])
         assert sp.sum(im) == 2
 
-        im = sp.zeros([11, 11])
+        im = np.zeros([11, 11])
         shape = sp.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, corner=[13, 13])
         assert sp.sum(im) == 0
 
-        im = sp.zeros([11, 11])
+        im = np.zeros([11, 11])
         shape = sp.ones([3, 4])
         im = ps.generators.insert_shape(im, element=shape, corner=[9, 9])
         assert sp.sum(im) == 4
 
-        im = sp.zeros([11, 11])
+        im = np.zeros([11, 11])
         shape = sp.ones([3, 4])
         im = ps.generators.insert_shape(im, element=shape, corner=[0, -1])
         assert sp.sum(im) == 9
@@ -205,14 +205,14 @@ class GeneratorTest():
 
     def test_RSA_2d_single(self):
         sp.random.seed(0)
-        im = sp.zeros([100, 100], dtype=int)
+        im = np.zeros([100, 100], dtype=int)
         im = ps.generators.RSA(im, radius=10, volume_fraction=0.5)
         assert sp.sum(im > 0) == 5095
         assert sp.sum(im > 1) == 20
 
     def test_RSA_2d_multi(self):
         sp.random.seed(0)
-        im = sp.zeros([100, 100], dtype=int)
+        im = np.zeros([100, 100], dtype=int)
         im = ps.generators.RSA(im, radius=10, volume_fraction=0.5)
         im = ps.generators.RSA(im, radius=5, volume_fraction=0.75)
         assert sp.sum(im > 0) == 6520
@@ -220,13 +220,13 @@ class GeneratorTest():
 
     def test_RSA_3d_single(self):
         sp.random.seed(0)
-        im = sp.zeros([50, 50, 50], dtype=int)
+        im = np.zeros([50, 50, 50], dtype=int)
         im = ps.generators.RSA(im, radius=5, volume_fraction=0.5)
         assert sp.sum(im > 0) == 45602
         assert sp.sum(im > 1) == 121
 
     def test_RSA_mask_edge_2d(self):
-        im = sp.zeros([100, 100], dtype=int)
+        im = np.zeros([100, 100], dtype=int)
         im = ps.generators.RSA(im, radius=10, volume_fraction=0.5,
                                mode='contained')
         coords = sp.argwhere(im == 2)
@@ -234,7 +234,7 @@ class GeneratorTest():
         assert ~sp.any(coords > 90)
 
     def test_RSA_mask_edge_3d(self):
-        im = sp.zeros([50, 50, 50], dtype=int)
+        im = np.zeros([50, 50, 50], dtype=int)
         im = ps.generators.RSA(im, radius=5, volume_fraction=0.5,
                                mode='contained')
         coords = sp.argwhere(im == 2)

--- a/test/unit/test_generators.py
+++ b/test/unit/test_generators.py
@@ -29,7 +29,7 @@ class GeneratorTest():
         im = np.zeros([11, 11])
         shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, center=[5, 5])
-        assert sp.sum(im) == sp.prod(shape.shape)
+        assert np.sum(im) == sp.prod(shape.shape)
 
         im = np.zeros([11, 11])
         shape = np.ones([4, 4])
@@ -41,14 +41,14 @@ class GeneratorTest():
         shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, center=[5, 5],
                                         value=1.0, mode='overlay')
-        assert sp.sum(im) == (sp.prod(im.shape) + sp.prod(shape.shape))
+        assert np.sum(im) == (sp.prod(im.shape) + sp.prod(shape.shape))
 
     def test_insert_shape_corner_overwrite(self):
         im = np.ones([10, 10])
         shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, corner=[5, 5],
                                         value=1.0, mode='overlay')
-        assert sp.sum(im) == (sp.prod(im.shape) + sp.prod(shape.shape))
+        assert np.sum(im) == (sp.prod(im.shape) + sp.prod(shape.shape))
         assert im[5, 5] == 2
         assert im[4, 5] == 1 and im[5, 4] == 1
 
@@ -56,22 +56,22 @@ class GeneratorTest():
         im = np.zeros([11, 11])
         shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, center=[-1, -1])
-        assert sp.sum(im) == 1
+        assert np.sum(im) == 1
 
         im = np.zeros([11, 11])
         shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, center=[0, -1])
-        assert sp.sum(im) == 2
+        assert np.sum(im) == 2
 
         im = np.zeros([11, 11])
         shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, center=[10, 10])
-        assert sp.sum(im) == 4
+        assert np.sum(im) == 4
 
         im = np.zeros([11, 11])
         shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, center=[14, 14])
-        assert sp.sum(im) == 0
+        assert np.sum(im) == 0
 
         im = np.zeros([11, 11])
         shape = np.ones([4, 4])
@@ -87,37 +87,37 @@ class GeneratorTest():
         im = np.zeros([11, 11])
         shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, corner=[-1, -1])
-        assert sp.sum(im) == 4
+        assert np.sum(im) == 4
 
         im = np.zeros([11, 11])
         shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, corner=[-1, 1])
-        assert sp.sum(im) == 6
+        assert np.sum(im) == 6
 
         im = np.zeros([11, 11])
         shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, corner=[-3, -3])
-        assert sp.sum(im) == 0
+        assert np.sum(im) == 0
 
         im = np.zeros([11, 11])
         shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, corner=[10, 9])
-        assert sp.sum(im) == 2
+        assert np.sum(im) == 2
 
         im = np.zeros([11, 11])
         shape = np.ones([3, 3])
         im = ps.generators.insert_shape(im, element=shape, corner=[13, 13])
-        assert sp.sum(im) == 0
+        assert np.sum(im) == 0
 
         im = np.zeros([11, 11])
         shape = np.ones([3, 4])
         im = ps.generators.insert_shape(im, element=shape, corner=[9, 9])
-        assert sp.sum(im) == 4
+        assert np.sum(im) == 4
 
         im = np.zeros([11, 11])
         shape = np.ones([3, 4])
         im = ps.generators.insert_shape(im, element=shape, corner=[0, -1])
-        assert sp.sum(im) == 9
+        assert np.sum(im) == 9
 
     def test_bundle_of_tubes(self):
         im = ps.generators.bundle_of_tubes(shape=[101, 101, 1], spacing=10)
@@ -158,7 +158,7 @@ class GeneratorTest():
                                          ncells=25,
                                          flat_faces=True)
         top_slice = im[:, :, 0]
-        assert sp.sum(top_slice) == 1409
+        assert np.sum(top_slice) == 1409
 
     def test_lattice_spheres_square(self):
         im = ps.generators.lattice_spheres(shape=[101, 101], radius=5,
@@ -207,23 +207,23 @@ class GeneratorTest():
         sp.random.seed(0)
         im = np.zeros([100, 100], dtype=int)
         im = ps.generators.RSA(im, radius=10, volume_fraction=0.5)
-        assert sp.sum(im > 0) == 5095
-        assert sp.sum(im > 1) == 20
+        assert np.sum(im > 0) == 5095
+        assert np.sum(im > 1) == 20
 
     def test_RSA_2d_multi(self):
         sp.random.seed(0)
         im = np.zeros([100, 100], dtype=int)
         im = ps.generators.RSA(im, radius=10, volume_fraction=0.5)
         im = ps.generators.RSA(im, radius=5, volume_fraction=0.75)
-        assert sp.sum(im > 0) == 6520
-        assert sp.sum(im > 1) == 44
+        assert np.sum(im > 0) == 6520
+        assert np.sum(im > 1) == 44
 
     def test_RSA_3d_single(self):
         sp.random.seed(0)
         im = np.zeros([50, 50, 50], dtype=int)
         im = ps.generators.RSA(im, radius=5, volume_fraction=0.5)
-        assert sp.sum(im > 0) == 45602
-        assert sp.sum(im > 1) == 121
+        assert np.sum(im > 0) == 45602
+        assert np.sum(im > 1) == 121
 
     def test_RSA_mask_edge_2d(self):
         im = np.zeros([100, 100], dtype=int)

--- a/test/unit/test_metrics.py
+++ b/test/unit/test_metrics.py
@@ -106,10 +106,10 @@ class MetricsTest():
         im = np.ones([100, 50])
         crds = ps.filters.apply_chords(im, spacing=1, trim_edges=False)
         c = ps.metrics.chord_counts(crds)
-        assert sp.all(c == 100)
+        assert np.all(c == 100)
         crds = ps.filters.apply_chords(im, spacing=1, trim_edges=False, axis=1)
         c = ps.metrics.chord_counts(crds)
-        assert sp.all(c == 50)
+        assert np.all(c == 50)
 
     def test_mesh_surface_area(self):
         region = self.regions == self.regions.max()
@@ -128,17 +128,17 @@ class MetricsTest():
         regions = self.regions
         areas = ps.metrics.region_surface_areas(regions)
         ia = ps.metrics.region_interface_areas(regions, areas)
-        assert sp.all(ia.conns[0] == [2, 19])
+        assert np.all(ia.conns[0] == [2, 19])
         assert sp.around(ia.area[0], decimals=2) == 3.59
 
     def test_phase_fraction(self):
         im = sp.reshape(sp.random.randint(0, 10, 1000), [10, 10, 10])
         labels = sp.unique(im, return_counts=True)[1]
         counts = ps.metrics.phase_fraction(im, normed=False)
-        assert sp.all(labels == counts)
+        assert np.all(labels == counts)
         fractions = ps.metrics.phase_fraction(im, normed=True)
         assert fractions.sum() == 1
-        assert sp.allclose(fractions, counts/counts.sum())
+        assert np.allclose(fractions, counts/counts.sum())
         with pytest.raises(Exception):
             ps.metrics.phase_fraction(sp.rand(10, 10, 10), normed=True)
 

--- a/test/unit/test_metrics.py
+++ b/test/unit/test_metrics.py
@@ -133,7 +133,7 @@ class MetricsTest():
         assert np.around(ia.area[0], decimals=2) == 3.59
 
     def test_phase_fraction(self):
-        im = sp.reshape(sp.random.randint(0, 10, 1000), [10, 10, 10])
+        im = np.reshape(sp.random.randint(0, 10, 1000), [10, 10, 10])
         labels = np.unique(im, return_counts=True)[1]
         counts = ps.metrics.phase_fraction(im, normed=False)
         assert np.all(labels == counts)

--- a/test/unit/test_metrics.py
+++ b/test/unit/test_metrics.py
@@ -38,15 +38,15 @@ class MetricsTest():
         # autocorrelation fn should level off at around the porosity
         t = 0.2
         phi1 = ps.metrics.porosity(im=self.im2D)
-        assert np.sqrt((sp.mean(tpcf_fft_1.probability[-5:]) - phi1)**2) < t
+        assert np.sqrt((np.mean(tpcf_fft_1.probability[-5:]) - phi1)**2) < t
         phi2 = ps.metrics.porosity(im=self.im2D_big)
-        assert np.sqrt((sp.mean(tpcf_fft_2.probability[-5:]) - phi2)**2) < t
+        assert np.sqrt((np.mean(tpcf_fft_2.probability[-5:]) - phi2)**2) < t
 
     def test_tpcf_fft_3d(self):
         tpcf_fft = ps.metrics.two_point_correlation_fft(self.im3D)
         t = 0.2
         phi1 = ps.metrics.porosity(im=self.im3D)
-        assert np.sqrt((sp.mean(tpcf_fft.probability[-5:]) - phi1)**2) < t
+        assert np.sqrt((np.mean(tpcf_fft.probability[-5:]) - phi1)**2) < t
 
     def test_pore_size_distribution(self):
         mip = ps.filters.porosimetry(self.im3D)
@@ -58,11 +58,11 @@ class MetricsTest():
         # autocorrelation fn should level off at around the porosity
         t = 0.2
         phi1 = ps.metrics.porosity(im=self.im2D)
-        assert np.sqrt((sp.mean(tpcf_bf.probability[-5:]) - phi1)**2) < t
+        assert np.sqrt((np.mean(tpcf_bf.probability[-5:]) - phi1)**2) < t
 
     def test_rev(self):
         rev = ps.metrics.representative_elementary_volume(self.blobs)
-        assert (sp.mean(rev.porosity) - 0.5)**2 < 0.05
+        assert (np.mean(rev.porosity) - 0.5)**2 < 0.05
 
     def test_radial_density(self):
         den = ps.metrics.radial_density(self.blobs)

--- a/test/unit/test_metrics.py
+++ b/test/unit/test_metrics.py
@@ -25,7 +25,7 @@ class MetricsTest():
                                          blobiness=[1, 2, 3])
         path = Path(os.path.realpath(__file__),
                     '../../../test/fixtures/partitioned_regions.tif')
-        self.regions = sp.array(io.imread(path))
+        self.regions = np.array(io.imread(path))
 
     def test_porosity(self):
         phi = ps.metrics.porosity(im=self.im2D)
@@ -37,15 +37,15 @@ class MetricsTest():
         # autocorrelation fn should level off at around the porosity
         t = 0.2
         phi1 = ps.metrics.porosity(im=self.im2D)
-        assert sp.sqrt((sp.mean(tpcf_fft_1.probability[-5:]) - phi1)**2) < t
+        assert np.sqrt((sp.mean(tpcf_fft_1.probability[-5:]) - phi1)**2) < t
         phi2 = ps.metrics.porosity(im=self.im2D_big)
-        assert sp.sqrt((sp.mean(tpcf_fft_2.probability[-5:]) - phi2)**2) < t
+        assert np.sqrt((sp.mean(tpcf_fft_2.probability[-5:]) - phi2)**2) < t
 
     def test_tpcf_fft_3d(self):
         tpcf_fft = ps.metrics.two_point_correlation_fft(self.im3D)
         t = 0.2
         phi1 = ps.metrics.porosity(im=self.im3D)
-        assert sp.sqrt((sp.mean(tpcf_fft.probability[-5:]) - phi1)**2) < t
+        assert np.sqrt((sp.mean(tpcf_fft.probability[-5:]) - phi1)**2) < t
 
     def test_pore_size_distribution(self):
         mip = ps.filters.porosimetry(self.im3D)
@@ -57,7 +57,7 @@ class MetricsTest():
         # autocorrelation fn should level off at around the porosity
         t = 0.2
         phi1 = ps.metrics.porosity(im=self.im2D)
-        assert sp.sqrt((sp.mean(tpcf_bf.probability[-5:]) - phi1)**2) < t
+        assert np.sqrt((sp.mean(tpcf_bf.probability[-5:]) - phi1)**2) < t
 
     def test_rev(self):
         rev = ps.metrics.representative_elementary_volume(self.blobs)
@@ -103,7 +103,7 @@ class MetricsTest():
         ps.metrics.chord_length_distribution(chords, normalization='length')
 
     def test_chord_counts(self):
-        im = sp.ones([100, 50])
+        im = np.ones([100, 50])
         crds = ps.filters.apply_chords(im, spacing=1, trim_edges=False)
         c = ps.metrics.chord_counts(crds)
         assert sp.all(c == 100)

--- a/test/unit/test_metrics.py
+++ b/test/unit/test_metrics.py
@@ -12,7 +12,7 @@ from numpy.testing import assert_allclose
 class MetricsTest():
 
     def setup_class(self):
-        sp.random.seed(0)
+        np.random.seed(0)
         self.im2D = ps.generators.lattice_spheres(shape=[100, 100],
                                                   radius=5, offset=2,
                                                   lattice='square')

--- a/test/unit/test_metrics.py
+++ b/test/unit/test_metrics.py
@@ -50,7 +50,7 @@ class MetricsTest():
     def test_pore_size_distribution(self):
         mip = ps.filters.porosimetry(self.im3D)
         psd = ps.metrics.pore_size_distribution(mip)
-        assert sp.sum(psd.satn) == 1.0
+        assert np.sum(psd.satn) == 1.0
 
     def test_two_point_correlation_bf(self):
         tpcf_bf = ps.metrics.two_point_correlation_bf(self.im2D)

--- a/test/unit/test_metrics.py
+++ b/test/unit/test_metrics.py
@@ -1,5 +1,6 @@
 import porespy as ps
 import scipy as sp
+import numpy as np
 import scipy.ndimage as spim
 from skimage import io
 import pytest
@@ -122,7 +123,7 @@ class MetricsTest():
     def test_region_surface_areas(self):
         regions = self.regions
         areas = ps.metrics.region_surface_areas(regions)
-        assert not sp.any(sp.isnan(areas))
+        assert not np.any(sp.isnan(areas))
 
     def test_region_interface_areas(self):
         regions = self.regions

--- a/test/unit/test_metrics.py
+++ b/test/unit/test_metrics.py
@@ -1,5 +1,4 @@
 import porespy as ps
-import scipy as sp
 import numpy as np
 import scipy.ndimage as spim
 from skimage import io

--- a/test/unit/test_metrics.py
+++ b/test/unit/test_metrics.py
@@ -147,12 +147,12 @@ class MetricsTest():
         im = ps.generators.lattice_spheres(shape=[999, 999],
                                            radius=15, offset=4)
         rev = ps.metrics.representative_elementary_volume(im)
-        assert_allclose(sp.average(rev.porosity), im.sum()/im.size, rtol=1e-1)
+        assert_allclose(np.average(rev.porosity), im.sum()/im.size, rtol=1e-1)
 
         im = ps.generators.lattice_spheres(shape=[151, 151, 151],
                                            radius=9, offset=4)
         rev = ps.metrics.representative_elementary_volume(im)
-        assert_allclose(sp.average(rev.porosity), im.sum()/im.size, rtol=1e-1)
+        assert_allclose(np.average(rev.porosity), im.sum()/im.size, rtol=1e-1)
 
 
 if __name__ == '__main__':

--- a/test/unit/test_metrics.py
+++ b/test/unit/test_metrics.py
@@ -133,7 +133,7 @@ class MetricsTest():
         assert np.around(ia.area[0], decimals=2) == 3.59
 
     def test_phase_fraction(self):
-        im = np.reshape(sp.random.randint(0, 10, 1000), [10, 10, 10])
+        im = np.reshape(np.random.randint(0, 10, 1000), [10, 10, 10])
         labels = np.unique(im, return_counts=True)[1]
         counts = ps.metrics.phase_fraction(im, normed=False)
         assert np.all(labels == counts)
@@ -141,7 +141,7 @@ class MetricsTest():
         assert fractions.sum() == 1
         assert np.allclose(fractions, counts/counts.sum())
         with pytest.raises(Exception):
-            ps.metrics.phase_fraction(sp.rand(10, 10, 10), normed=True)
+            ps.metrics.phase_fraction(numpy.random.rand(10, 10, 10), normed=True)
 
     def test_representative_elementary_volume(self):
         im = ps.generators.lattice_spheres(shape=[999, 999],

--- a/test/unit/test_metrics.py
+++ b/test/unit/test_metrics.py
@@ -123,7 +123,7 @@ class MetricsTest():
     def test_region_surface_areas(self):
         regions = self.regions
         areas = ps.metrics.region_surface_areas(regions)
-        assert not np.any(sp.isnan(areas))
+        assert not np.any(np.isnan(areas))
 
     def test_region_interface_areas(self):
         regions = self.regions

--- a/test/unit/test_metrics.py
+++ b/test/unit/test_metrics.py
@@ -134,7 +134,7 @@ class MetricsTest():
 
     def test_phase_fraction(self):
         im = sp.reshape(sp.random.randint(0, 10, 1000), [10, 10, 10])
-        labels = sp.unique(im, return_counts=True)[1]
+        labels = np.unique(im, return_counts=True)[1]
         counts = ps.metrics.phase_fraction(im, normed=False)
         assert np.all(labels == counts)
         fractions = ps.metrics.phase_fraction(im, normed=True)

--- a/test/unit/test_metrics.py
+++ b/test/unit/test_metrics.py
@@ -116,9 +116,9 @@ class MetricsTest():
         region = self.regions == self.regions.max()
         mesh = ps.tools.mesh_region(region)
         a = ps.metrics.mesh_surface_area(mesh)
-        assert sp.around(a, decimals=2) == 258.3
+        assert np.around(a, decimals=2) == 258.3
         b = ps.metrics.mesh_surface_area(verts=mesh.verts, faces=mesh.faces)
-        assert sp.around(b, decimals=2) == sp.around(a, decimals=2)
+        assert np.around(b, decimals=2) == np.around(a, decimals=2)
 
     def test_region_surface_areas(self):
         regions = self.regions
@@ -130,7 +130,7 @@ class MetricsTest():
         areas = ps.metrics.region_surface_areas(regions)
         ia = ps.metrics.region_interface_areas(regions, areas)
         assert np.all(ia.conns[0] == [2, 19])
-        assert sp.around(ia.area[0], decimals=2) == 3.59
+        assert np.around(ia.area[0], decimals=2) == 3.59
 
     def test_phase_fraction(self):
         im = sp.reshape(sp.random.randint(0, 10, 1000), [10, 10, 10])

--- a/test/unit/test_tools.py
+++ b/test/unit/test_tools.py
@@ -10,7 +10,7 @@ class ToolsTest():
     def setup_class(self):
         plt.close('all')
         self.im = sp.random.randint(0, 10, 20)
-        sp.random.seed(0)
+        np.random.seed(0)
         self.blobs = ps.generators.blobs(shape=[101, 101])
         self.im2D = ps.generators.blobs(shape=[51, 51])
         self.im3D = ps.generators.blobs(shape=[51, 51, 51])

--- a/test/unit/test_tools.py
+++ b/test/unit/test_tools.py
@@ -37,7 +37,7 @@ class ToolsTest():
 
     def test_extract_subsection(self):
         sec = ps.tools.extract_subsection(self.blobs, [0.5])
-        assert np.all(np.array(sp.shape(sec)) == 50)
+        assert np.all(np.array(np.shape(sec)) == 50)
 
     def test_extract_cylinder(self):
         im = np.ones([200, 300, 400], dtype=bool)

--- a/test/unit/test_tools.py
+++ b/test/unit/test_tools.py
@@ -98,13 +98,13 @@ class ToolsTest():
         assert ps.tools.in_hull([sp.mean(X, axis=0)], hull)
 
     def test_insert_sphere_2D(self):
-        im = sp.zeros(shape=[200, 200], dtype=bool)
+        im = np.zeros(shape=[200, 200], dtype=bool)
         im = ps.tools.insert_sphere(im, [100, 100], 50)
         im = ps.tools.insert_sphere(im, [10, 100], 50)
         im = ps.tools.insert_sphere(im, [180, 100], 50)
 
     def test_insert_sphere_3D(self):
-        im = sp.zeros(shape=[200, 200, 200], dtype=bool)
+        im = np.zeros(shape=[200, 200, 200], dtype=bool)
         im = ps.tools.insert_sphere(im, [100, 100, 100], 50)
         im = ps.tools.insert_sphere(im, [10, 100, 100], 50)
         im = ps.tools.insert_sphere(im, [180, 100, 100], 50)

--- a/test/unit/test_tools.py
+++ b/test/unit/test_tools.py
@@ -27,7 +27,7 @@ class ToolsTest():
 
     def test_make_contiguous_contiguity(self):
         cont_im = ps.tools.make_contiguous(self.im)
-        assert np.all(sp.arange(sp.unique(self.im).size) == sp.unique(cont_im))
+        assert np.all(np.arange(sp.unique(self.im).size) == sp.unique(cont_im))
 
     def test_make_contiguous_negs(self):
         im = np.array([[0, 0, 1, 3], [-2, -4, 1, 3], [-4, 3, 5, 0]])

--- a/test/unit/test_tools.py
+++ b/test/unit/test_tools.py
@@ -117,13 +117,13 @@ class ToolsTest():
         assert np.all(im[tuple(ims[0, 0, 0])] == im)
         ims = ps.tools.subdivide(im, divs=2)
         assert ims.shape == (2, 2, 2)
-        assert im[tuple(ims[0, 0, 0])].sum() == sp.prod(im.shape)/8
+        assert im[tuple(ims[0, 0, 0])].sum() == np.prod(im.shape)/8
 
     def test_subdivide_2D(self):
         im = np.ones([50, 100])
         ims = ps.tools.subdivide(im, divs=2)
         assert ims.shape == (2, 2)
-        assert im[tuple(ims[0, 0])].sum() == sp.prod(im.shape)/4
+        assert im[tuple(ims[0, 0])].sum() == np.prod(im.shape)/4
 
 
 if __name__ == '__main__':

--- a/test/unit/test_tools.py
+++ b/test/unit/test_tools.py
@@ -92,11 +92,11 @@ class ToolsTest():
         X = sp.rand(25, 2)
         hull = sp.spatial.ConvexHull(X)
         assert not ps.tools.in_hull([[0, 0]], hull)
-        assert ps.tools.in_hull([sp.mean(X, axis=0)], hull)
+        assert ps.tools.in_hull([np.mean(X, axis=0)], hull)
         X = sp.rand(25, 3)
         hull = sp.spatial.ConvexHull(X)
         assert not ps.tools.in_hull([[0, 0, 0]], hull)
-        assert ps.tools.in_hull([sp.mean(X, axis=0)], hull)
+        assert ps.tools.in_hull([np.mean(X, axis=0)], hull)
 
     def test_insert_sphere_2D(self):
         im = np.zeros(shape=[200, 200], dtype=bool)

--- a/test/unit/test_tools.py
+++ b/test/unit/test_tools.py
@@ -9,7 +9,7 @@ import pytest
 class ToolsTest():
     def setup_class(self):
         plt.close('all')
-        self.im = sp.random.randint(0, 10, 20)
+        self.im = np.random.randint(0, 10, 20)
         np.random.seed(0)
         self.blobs = ps.generators.blobs(shape=[101, 101])
         self.im2D = ps.generators.blobs(shape=[51, 51])
@@ -89,11 +89,11 @@ class ToolsTest():
         assert im.shape == (60, 50, 40)
 
     def test_inhull(self):
-        X = sp.rand(25, 2)
+        X = np.random.rand(25, 2)
         hull = sp.spatial.ConvexHull(X)
         assert not ps.tools.in_hull([[0, 0]], hull)
         assert ps.tools.in_hull([np.mean(X, axis=0)], hull)
-        X = sp.rand(25, 3)
+        X = np.random.rand(25, 3)
         hull = sp.spatial.ConvexHull(X)
         assert not ps.tools.in_hull([[0, 0, 0]], hull)
         assert ps.tools.in_hull([np.mean(X, axis=0)], hull)

--- a/test/unit/test_tools.py
+++ b/test/unit/test_tools.py
@@ -1,4 +1,5 @@
 import porespy as ps
+import numpy as np
 import scipy as sp
 import scipy.ndimage as spim
 import matplotlib.pyplot as plt
@@ -29,17 +30,17 @@ class ToolsTest():
         assert sp.all(sp.arange(sp.unique(self.im).size) == sp.unique(cont_im))
 
     def test_make_contiguous_negs(self):
-        im = sp.array([[0, 0, 1, 3], [-2, -4, 1, 3], [-4, 3, 5, 0]])
+        im = np.array([[0, 0, 1, 3], [-2, -4, 1, 3], [-4, 3, 5, 0]])
         a = ps.tools.make_contiguous(im, keep_zeros=True).max()
         b = ps.tools.make_contiguous(im, keep_zeros=False).max()
         assert a == b
 
     def test_extract_subsection(self):
         sec = ps.tools.extract_subsection(self.blobs, [0.5])
-        assert sp.all(sp.array(sp.shape(sec)) == 50)
+        assert sp.all(np.array(sp.shape(sec)) == 50)
 
     def test_extract_cylinder(self):
-        im = sp.ones([200, 300, 400], dtype=bool)
+        im = np.ones([200, 300, 400], dtype=bool)
         cx = ps.tools.extract_cylinder(im)
         assert cx.sum() == 14132200
         cy = ps.tools.extract_cylinder(im, axis=1)
@@ -82,9 +83,9 @@ class ToolsTest():
         assert c.sum() == 15002
 
     def test_align_image_w_openpnm(self):
-        im = ps.tools.align_image_with_openpnm(sp.ones([40, 50]))
+        im = ps.tools.align_image_with_openpnm(np.ones([40, 50]))
         assert im.shape == (50, 40)
-        im = ps.tools.align_image_with_openpnm(sp.ones([40, 50, 60]))
+        im = ps.tools.align_image_with_openpnm(np.ones([40, 50, 60]))
         assert im.shape == (60, 50, 40)
 
     def test_inhull(self):
@@ -110,7 +111,7 @@ class ToolsTest():
         im = ps.tools.insert_sphere(im, [180, 100, 100], 50)
 
     def test_subdivide_3D(self):
-        im = sp.ones([50, 100, 150])
+        im = np.ones([50, 100, 150])
         ims = ps.tools.subdivide(im, divs=1)
         assert ims.shape == (1, 1, 1)
         assert sp.all(im[tuple(ims[0, 0, 0])] == im)
@@ -119,7 +120,7 @@ class ToolsTest():
         assert im[tuple(ims[0, 0, 0])].sum() == sp.prod(im.shape)/8
 
     def test_subdivide_2D(self):
-        im = sp.ones([50, 100])
+        im = np.ones([50, 100])
         ims = ps.tools.subdivide(im, divs=2)
         assert ims.shape == (2, 2)
         assert im[tuple(ims[0, 0])].sum() == sp.prod(im.shape)/4

--- a/test/unit/test_tools.py
+++ b/test/unit/test_tools.py
@@ -19,7 +19,7 @@ class ToolsTest():
     def test_randomize_colors(self):
         randomized_im = ps.tools.randomize_colors(im=self.im)
         assert sp.unique(self.im).size == sp.unique(randomized_im).size
-        assert sp.all(sp.unique(self.im) == sp.unique(randomized_im))
+        assert np.all(sp.unique(self.im) == sp.unique(randomized_im))
 
     def test_make_contiguous_size(self):
         cont_im = ps.tools.make_contiguous(self.im)
@@ -27,7 +27,7 @@ class ToolsTest():
 
     def test_make_contiguous_contiguity(self):
         cont_im = ps.tools.make_contiguous(self.im)
-        assert sp.all(sp.arange(sp.unique(self.im).size) == sp.unique(cont_im))
+        assert np.all(sp.arange(sp.unique(self.im).size) == sp.unique(cont_im))
 
     def test_make_contiguous_negs(self):
         im = np.array([[0, 0, 1, 3], [-2, -4, 1, 3], [-4, 3, 5, 0]])
@@ -37,7 +37,7 @@ class ToolsTest():
 
     def test_extract_subsection(self):
         sec = ps.tools.extract_subsection(self.blobs, [0.5])
-        assert sp.all(np.array(sp.shape(sec)) == 50)
+        assert np.all(np.array(sp.shape(sec)) == 50)
 
     def test_extract_cylinder(self):
         im = np.ones([200, 300, 400], dtype=bool)
@@ -52,21 +52,21 @@ class ToolsTest():
 
     def test_bbox_to_slices(self):
         s = ps.tools.bbox_to_slices([0, 0, 0, 10, 10, 10])
-        assert sp.all(self.im3D[s].shape == (10, 10, 10))
+        assert np.all(self.im3D[s].shape == (10, 10, 10))
 
     def test_get_planes(self):
         x, y, z = ps.tools.get_planes(self.im3D)
-        assert sp.all(x.shape == (51, 51))
-        assert sp.all(y.shape == (51, 51))
-        assert sp.all(z.shape == (51, 51))
+        assert np.all(x.shape == (51, 51))
+        assert np.all(y.shape == (51, 51))
+        assert np.all(z.shape == (51, 51))
         with pytest.raises(ValueError):
             ps.tools.get_planes(self.im2D)
 
     def test_get_planes_not_squeezed(self):
         x, y, z = ps.tools.get_planes(self.im3D, squeeze=False)
-        assert sp.all(x.shape == (1, 51, 51))
-        assert sp.all(y.shape == (51, 1, 51))
-        assert sp.all(z.shape == (51, 51, 1))
+        assert np.all(x.shape == (1, 51, 51))
+        assert np.all(y.shape == (51, 1, 51))
+        assert np.all(z.shape == (51, 51, 1))
 
     def test_get_border(self):
         c = ps.tools.get_border(self.im2D.shape, thickness=1, mode='corners')
@@ -114,7 +114,7 @@ class ToolsTest():
         im = np.ones([50, 100, 150])
         ims = ps.tools.subdivide(im, divs=1)
         assert ims.shape == (1, 1, 1)
-        assert sp.all(im[tuple(ims[0, 0, 0])] == im)
+        assert np.all(im[tuple(ims[0, 0, 0])] == im)
         ims = ps.tools.subdivide(im, divs=2)
         assert ims.shape == (2, 2, 2)
         assert im[tuple(ims[0, 0, 0])].sum() == sp.prod(im.shape)/8

--- a/test/unit/test_tools.py
+++ b/test/unit/test_tools.py
@@ -18,16 +18,16 @@ class ToolsTest():
 
     def test_randomize_colors(self):
         randomized_im = ps.tools.randomize_colors(im=self.im)
-        assert sp.unique(self.im).size == sp.unique(randomized_im).size
-        assert np.all(sp.unique(self.im) == sp.unique(randomized_im))
+        assert np.unique(self.im).size == np.unique(randomized_im).size
+        assert np.all(np.unique(self.im) == np.unique(randomized_im))
 
     def test_make_contiguous_size(self):
         cont_im = ps.tools.make_contiguous(self.im)
-        assert sp.unique(self.im).size == sp.unique(cont_im).size
+        assert np.unique(self.im).size == np.unique(cont_im).size
 
     def test_make_contiguous_contiguity(self):
         cont_im = ps.tools.make_contiguous(self.im)
-        assert np.all(np.arange(sp.unique(self.im).size) == sp.unique(cont_im))
+        assert np.all(np.arange(np.unique(self.im).size) == np.unique(cont_im))
 
     def test_make_contiguous_negs(self):
         im = np.array([[0, 0, 1, 3], [-2, -4, 1, 3], [-4, 3, 5, 0]])

--- a/test/unit/test_visualization.py
+++ b/test/unit/test_visualization.py
@@ -1,5 +1,4 @@
 import porespy as ps
-import scipy as sp
 import numpy as np
 
 

--- a/test/unit/test_visualization.py
+++ b/test/unit/test_visualization.py
@@ -1,5 +1,6 @@
 import porespy as ps
 import scipy as sp
+import numpy as np
 
 
 class VisualizationTest():
@@ -12,7 +13,7 @@ class VisualizationTest():
 
     def test_xray_x(self):
         xray = ps.visualization.xray(self.im)
-        assert sp.sum(xray) == sp.sum(~self.im)
+        assert np.sum(xray) == np.sum(~self.im)
 
     def test_sem_y(self):
         sem = ps.visualization.sem(self.im, direction='Y')
@@ -20,7 +21,7 @@ class VisualizationTest():
 
     def test_xray_y(self):
         xray = ps.visualization.xray(self.im, direction='Y')
-        assert sp.sum(xray) == sp.sum(~self.im)
+        assert np.sum(xray) == np.sum(~self.im)
 
     def test_sem_z(self):
         sem = ps.visualization.sem(self.im, direction='Z')
@@ -28,7 +29,7 @@ class VisualizationTest():
 
     def test_xray_z(self):
         xray = ps.visualization.xray(self.im, direction='Z')
-        assert sp.sum(xray) == sp.sum(~self.im)
+        assert np.sum(xray) == np.sum(~self.im)
 
 if __name__ == '__main__':
     t = VisualizationTest()


### PR DESCRIPTION
This merge request addresses the deprecation of NumPy functions exposed via the root SciPy namespace. All functions now refer directly to their numpy versions. Specific functions that were changed are pi, array, sum, any, all, ceil, amin, amax, mgrid, logical_and, rint, reshape, unique, prod, zeros, and ones.

Resolves: #229 