### PR TITLE
Change direction to axis

### DIFF
--- a/porespy/visualization/__views__.py
+++ b/porespy/visualization/__views__.py
@@ -85,32 +85,32 @@ def show_planes(im):
     return new_im
 
 
-def sem(im, direction='X'):
+def sem(im, axis=0):
     r"""
-    Simulates an SEM photograph looking into the porous material in the
-    specified direction.  Features are colored according to their depth into
-    the image, so darker features are further away.
+    Simulates an SEM photograph looking into the porous material.
+
+    Features are colored according to their depth into the image, so
+    darker features are further away.
 
     Parameters
     ----------
     im : array_like
         ND-image of the porous material with the solid phase marked as 1 or
         True
-
-    direction : string
-        Specify the axis along which the camera will point.  Options are
-        'X', 'Y', and 'Z'.
+    axis : int
+        Specifes the axis along which the camera will point.
 
     Returns
     -------
     image : 2D-array
-        A 2D greyscale image suitable for use in matplotlib\'s ```imshow```
+        A 2D greyscale image suitable for use in matplotlib's ``imshow``
         function.
+
     """
     im = np.array(~im, dtype=int)
-    if direction in ['Y', 'y']:
+    if axis == 1:
         im = np.transpose(im, axes=[1, 0, 2])
-    if direction in ['Z', 'z']:
+    if axis == 2:
         im = np.transpose(im, axes=[2, 1, 0])
     t = im.shape[0]
     depth = np.reshape(np.arange(0, t), [t, 1, 1])
@@ -119,12 +119,12 @@ def sem(im, direction='X'):
     return im
 
 
-def xray(im, direction='X'):
+def xray(im, axis=0):
     r"""
-    Simulates an X-ray radiograph looking through the porouls material in the
-    specfied direction.  The resulting image is colored according to the amount
-    of attenuation an X-ray would experience, so regions with more solid will
-    appear darker.
+    Simulates an X-ray radiograph looking through the porous material.
+
+    The resulting image is colored according to the amount of attenuation an
+    X-ray would experience, so regions with more solid will appear darker.
 
     Parameters
     ----------
@@ -132,9 +132,8 @@ def xray(im, direction='X'):
         ND-image of the porous material with the solid phase marked as 1 or
         True
 
-    direction : string
-        Specify the axis along which the camera will point.  Options are
-        'X', 'Y', and 'Z'.
+    axis : int
+        Specifes the axis along which the camera will point.
 
     Returns
     -------
@@ -143,9 +142,9 @@ def xray(im, direction='X'):
         function.
     """
     im = np.array(~im, dtype=int)
-    if direction in ['Y', 'y']:
+    if axis == 1:
         im = np.transpose(im, axes=[1, 0, 2])
-    if direction in ['Z', 'z']:
+    if axis == 2:
         im = np.transpose(im, axes=[2, 1, 0])
     im = np.sum(im, axis=0)
     return im

--- a/test/unit/test_visualization.py
+++ b/test/unit/test_visualization.py
@@ -15,19 +15,19 @@ class VisualizationTest():
         assert np.sum(xray) == np.sum(~self.im)
 
     def test_sem_y(self):
-        sem = ps.visualization.sem(self.im, direction='Y')
+        sem = ps.visualization.sem(self.im, axis=1)
         assert sem.ndim == 2
 
     def test_xray_y(self):
-        xray = ps.visualization.xray(self.im, direction='Y')
+        xray = ps.visualization.xray(self.im, axis=1)
         assert np.sum(xray) == np.sum(~self.im)
 
     def test_sem_z(self):
-        sem = ps.visualization.sem(self.im, direction='Z')
+        sem = ps.visualization.sem(self.im, axis=2)
         assert sem.ndim == 2
 
     def test_xray_z(self):
-        xray = ps.visualization.xray(self.im, direction='Z')
+        xray = ps.visualization.xray(self.im, axis=2)
         assert np.sum(xray) == np.sum(~self.im)
 
     def test_imshow_single(self):


### PR DESCRIPTION
This PR attempts to make the arg ``axis`` consistent through, rather than ``direction`` that pops up in some places.  

This is a breaking change since it's very hard to support both arguments properly.  