### PR TITLE
Fixed and upgraded subdivide method, added many tests

### DIFF
--- a/porespy/tools/__funcs__.py
+++ b/porespy/tools/__funcs__.py
@@ -170,12 +170,13 @@ def subdivide(im, divs=2, overlap=0, flatten=False):
 
     Returns
     -------
-    slices : list
-        A list containing sets of slice objects for indexing into ``im`` that
-        extract subdivisions of an image.  If ``flatten`` was ``True``, then
-        this list is a flat, suitable  for iterating.  If ``flatten`` was
+    slices : ND-array
+        An ND-array containing sets of slice objects for indexing into ``im``
+        that extract subdivisions of an image.  If ``flatten`` was ``True``,
+        then this array is flat, suitable  for iterating.  If ``flatten`` was
         ``False`` then the slice objects must be accessed by row, col, layer
-        indices.
+        indices.  An ND-array is the preferred container since it's shape can
+        be easily queried.
 
     Notes
     -----
@@ -201,12 +202,9 @@ def subdivide(im, divs=2, overlap=0, flatten=False):
     divs = np.ones((im.ndim,), dtype=int) * np.array(divs)
     halo = overlap * (divs > 1)
     slices = shape_split(im.shape, axis=divs, halo=halo.tolist(),
-                         tile_bounds_policy=ARRAY_BOUNDS)
+                         tile_bounds_policy=ARRAY_BOUNDS).astype(object)
     if flatten is True:
-        temp = np.ravel(slices)
-        slices = [tuple(s) for s in temp]
-    else:
-        slices = slices.tolist()
+        slices = np.ravel(slices)
     return slices
 
 

--- a/porespy/tools/__funcs__.py
+++ b/porespy/tools/__funcs__.py
@@ -193,24 +193,10 @@ def subdivide(im, divs=2, overlap=0, flatten=False):
     >>> import porespy as ps
     >>> import matplotlib.pyplot as plt
     >>> im = ps.generators.blobs(shape=[200, 200])
-    >>> s = ps.tools.subdivide(im, divs=[2, 2])
+    >>> s = ps.tools.subdivide(im, divs=[2, 2], flatten=True)
+    >>> print(len(s))
+    4
 
-    ``s`` contains an array with the shape given by ``divs``.  To access the
-    first and last quadrants of ``im`` use:
-    >>> print(im[tuple(s[0, 0])].shape)
-    (100, 100)
-    >>> print(im[tuple(s[1, 1])].shape)
-    (100, 100)
-
-    It can be easier to index the array with the slices by applying ``flatten``
-    first:
-    >>> s_flat = s.flatten()
-    >>> for i in s_flat:
-    ...     print(im[i].shape)
-    (100, 100)
-    (100, 100)
-    (100, 100)
-    (100, 100)
     """
     divs = np.ones((im.ndim,), dtype=int) * np.array(divs)
     halo = overlap * (divs > 1)

--- a/test/unit/test_generators.py
+++ b/test/unit/test_generators.py
@@ -1,8 +1,8 @@
 import porespy as ps
 import numpy as np
-import scipy as sp
 import pytest
 import scipy.ndimage as spim
+import scipy.stats as spst
 import matplotlib.pyplot as plt
 plt.close('all')
 
@@ -144,7 +144,7 @@ class GeneratorTest():
 
     def test_polydisperse_spheres(self):
         phis = np.arange(0.1, 0.5, 0.2)
-        dist = sp.stats.norm(loc=7, scale=2)
+        dist = spst.norm(loc=7, scale=2)
         for phi in phis:
             im = ps.generators.polydisperse_spheres(shape=[100, 100, 50],
                                                     porosity=phi, dist=dist,
@@ -223,14 +223,14 @@ class GeneratorTest():
         assert len(np.unique(lt)) > 2
 
     def test_RSA_3d_contained(self):
-        im = sp.zeros([100, 100, 100], dtype=int)
+        im = np.zeros([100, 100, 100], dtype=int)
         im = ps.generators.RSA(im, radius=10, volume_fraction=0.5,
                                mode='contained')
         lt = ps.filters.local_thickness(im, sizes=[10, 9, 8, 7, 6, 5])
         assert len(np.unique(lt)) == 2
 
     def test_RSA_3d_extended(self):
-        im = sp.zeros([100, 100, 100], dtype=int)
+        im = np.zeros([100, 100, 100], dtype=int)
         im = ps.generators.RSA(im, radius=10, volume_fraction=0.5,
                                mode='extended')
         im = np.pad(im, pad_width=1, mode='constant', constant_values=False)
@@ -238,7 +238,7 @@ class GeneratorTest():
         assert len(np.unique(lt)) > 2
 
     def test_RSA_2d_seqential_additions(self):
-        im = sp.zeros([100, 100], dtype=int)
+        im = np.zeros([100, 100], dtype=int)
         im = ps.generators.RSA(im, radius=10)
         phi1 = ps.metrics.porosity(im)
         im = ps.generators.RSA(im, radius=5)

--- a/test/unit/test_tools.py
+++ b/test/unit/test_tools.py
@@ -140,21 +140,6 @@ class ToolsTest():
         assert np.all(np.unique(im) == vals)
         assert counts[1] < counts[2]
 
-    def test_subdivide_3D(self):
-        im = np.ones([50, 100, 150])
-        ims = ps.tools.subdivide(im, divs=1)
-        assert ims.shape == (1, 1, 1)
-        assert np.all(im[tuple(ims[0, 0, 0])] == im)
-        ims = ps.tools.subdivide(im, divs=2)
-        assert ims.shape == (2, 2, 2)
-        assert im[tuple(ims[0, 0, 0])].sum() == np.prod(im.shape)/8
-
-    def test_subdivide_2D(self):
-        im = np.ones([50, 100])
-        ims = ps.tools.subdivide(im, divs=2)
-        assert ims.shape == (2, 2)
-        assert im[tuple(ims[0, 0])].sum() == np.prod(im.shape)/4
-
     def test_subdivide_2D_with_scalar_overlap(self):
         im = np.ones([150, 150])
         s = ps.tools.subdivide(im, divs=3, overlap=10)

--- a/test/unit/test_tools.py
+++ b/test/unit/test_tools.py
@@ -196,6 +196,16 @@ class ToolsTest():
         assert np.all(im[s[1]].shape == (60, 70, 110))
         assert np.all(im[s[13]].shape == (70, 90, 110))
 
+    def test_subdivided_shape_flattened(self):
+        im = np.ones([150, 150, 150])
+        s = ps.tools.subdivide(im, divs=3, overlap=[10, 20, 30], flatten=True)
+        assert np.all(s.shape == (27, ))
+
+    def test_subdivided_shape_not_flattened(self):
+        im = np.ones([150, 150, 150])
+        s = ps.tools.subdivide(im, divs=3, overlap=[10, 20, 30], flatten=False)
+        assert np.all(s.shape == (3, 3, 3))
+
     def test_size_to_seq(self):
         im = self.im2D
         sz = ps.filters.porosimetry(im)


### PR DESCRIPTION
Now returns list of tuples, instead of ND-arrays of ND-array, so numpy won't complain anymore...also added overlap and flatten args.