### PR TITLE
Update snow_advanced.ipynb (an error caused by the version difference)

### DIFF
--- a/examples/networks/snow_advanced.ipynb
+++ b/examples/networks/snow_advanced.ipynb
@@ -262,7 +262,7 @@
    "source": [
     "# NBVAL_IGNORE_OUTPUT\n",
     "im = ps.tools.align_image_with_openpnm(im).astype(int)\n",
-    "ps.io.to_vtk(im, filename='extracted_network')"
+    "ps.io.to_vtk(im, path='extracted_network')"
    ]
   },
   {


### PR DESCRIPTION
Correction an error caused by the version difference.
In the version 1.3.1, the script `ps.io.to_vtk(im, filename='extracted_network')` should be changed to `ps.io.to_vtk(im, path='extracted_network')`. I test in my PC.