### PR TITLE
Only accept "hashtaged" keywords + exclude commit messages via webapp

### DIFF
--- a/.github/workflows/logger.sh
+++ b/.github/workflows/logger.sh
@@ -27,15 +27,32 @@ function filter_commits_by_label {
     local temp
     local commits=$1    # fetch the first argument
     shift               # removes first arg from list of input args
-    temp=$(echo "$commits" | grep -E --ignore-case $(parse_args "$@"))
-    temp=$(echo "${temp}" | sed 's/^[ \t]*//; s/[ \t]*$//')
+    temp=$(echo "${commits}" | grep -E --ignore-case "$@")
+    # Strip empty lines (that might include tabs, spaces, etc.)
+    temp=$(echo "${temp}" | sed -r '/^\s*$/d')
+    # Make each line a bullet point by appending "- " to lines
+    temp=$(echo "${temp}" | sed -e 's/^/- /')
+    echo "$temp"
+}
+
+function filter_commits_exclude_label {
+    local temp
+    local commits=$1    # fetch the first argument
+    shift               # removes first arg from list of input args
+    # Reverse filter commits by the given labels (i.e. exclude labels)
+    temp=$(echo "$commits" | grep -v -E --ignore-case "$@")
+    # Strip empty lines (that might include tabs, spaces, etc.)
+    temp=$(echo "${temp}" | sed -r '/^\s*$/d')
+    # Make each line a bullet point by appending "- " to lines
     temp=$(echo "${temp}" | sed -e 's/^/- /')
     echo "$temp"
 }
 
 function filter_commits_by_tag_interval {
     local temp
-    temp=$(git log "${1}..${2}" -P --author='^((?!GitHub).*)$' --committer=GitHub)
+    # --format=%B only outputs commit messages (excluding committer, date, etc.)
+    # --first-parent excludes merge commits into the topic branch, ex. dev -> feature
+    temp=$(git log --merges "${1}..${2}" --format=%B --first-parent dev)
     echo "$temp"
 }
 
@@ -58,12 +75,18 @@ tag_new=$(get_nth_recent_tag 1)
 tag_date=$(git show "$tag_new" --format="%cs")
 merge_commits=$(filter_commits_by_tag_interval $tag_old $tag_new)
 
-# Fetching new features/changed API/bugfixes
-features=$(filter_commits_by_label "$merge_commits" "feature" "added" "new")
-enhancements=$(filter_commits_by_label "$merge_commits" "revamped" "improved" "enhanced" "optimized" "enh")
-maintenance=$(filter_commits_by_label "$merge_commits" "backend" "maint")
-changes=$(filter_commits_by_label "$merge_commits" "deprecated" "changed" "removed" "modified" "api")
-fixes=$(filter_commits_by_label "$merge_commits" "bugfix" "hotfix" "fixed" "bug")
+# Fetching new features/enhancements/maintenance/api change/bug fixes/documentation
+features=$(filter_commits_by_label "$merge_commits" "#new")
+enhancements=$(filter_commits_by_label "$merge_commits" "#enh")
+maintenance=$(filter_commits_by_label "$merge_commits" "#maint")
+changes=$(filter_commits_by_label "$merge_commits" "#api")
+fixes=$(filter_commits_by_label "$merge_commits" "#bug")
+documentation=$(filter_commits_by_label "$merge_commits" "#doc")
+
+# Fetching uncategorized merge commits (those w/o keywords)
+all_keywords=$(join_by "|" "#new #enh #maint #api #bug #doc")
+echo $all_keywords
+uncategorized=$(filter_commits_exclude_label "$merge_commits" "$all_keywords")
 
 # Delete "entry" file if already exists
 if test -f entry; then
@@ -82,6 +105,8 @@ append_to_entry_with_label "$enhancements" entry ":cake: Enhancements"
 append_to_entry_with_label "$maintenance" entry ":wrench: Maintenace"
 append_to_entry_with_label "$changes" entry ":warning: API changes"
 append_to_entry_with_label "$fixes" entry ":bug: Bugfixes"
+append_to_entry_with_label "$documentation" entry ":green_book: Documentation"
+append_to_entry_with_label "$uncategorized" entry ":question: Uncategorized"
 
 echo "$(<entry)"
 


### PR DESCRIPTION
- Fix release notes action to only accept keywords with leading hashtag
- Only include merge commit messages (previously, accidental commits done via the web app were also caught)