### PR TITLE
Fix the check whether the image is a boolean in snow partitioning

### DIFF
--- a/porespy/filters/__funcs__.py
+++ b/porespy/filters/__funcs__.py
@@ -249,7 +249,7 @@ def snow_partitioning(im, dt=None, r_max=4, sigma=0.4, return_all=False,
     print("-" * 60)
     print("Beginning SNOW Algorithm")
     im_shape = np.array(im.shape)
-    if im.dtype is not bool:
+    if im.dtype is not np.dtype("bool"):
         print("Converting supplied image (im) to boolean")
         im = im > 0
     if dt is None:


### PR DESCRIPTION
Since im.dtype returns a string, checking whether im.dtype is bool will always be false, so snow_partitioning will always create a full copy of the image in binary format, regardless of the image being binary.

This causes the function to always take more memory than is required. This patch fixes the check in order to achieve expected behaviour.