### PR TITLE
adding ps_rect function to tools

### DIFF
--- a/porespy/tools/__funcs__.py
+++ b/porespy/tools/__funcs__.py
@@ -911,6 +911,32 @@ def ps_round(r, ndim, smooth=True):
     return ball
 
 
+def ps_rect(w, ndim):
+    r"""
+    Creates rectilinear structuring element with the given size and
+    dimensionality
+
+    Parameters
+    ----------
+    w : scalar
+        The desired width of the structuring element
+    ndim : int
+        The dimensionality of the element, either 2 or 3.
+
+    Returns
+    -------
+    strel : D-aNrray
+        A numpy array of the structuring element
+    """
+    if ndim == 2:
+        from skimage.morphology import square
+        strel = square(w)
+    if ndim == 3:
+        from skimage.morphology import cube
+        strel = cube(w)
+    return strel
+
+
 def overlay(im1, im2, c):
     r"""
     Overlays ``im2`` onto ``im1``, given voxel coords of center of ``im2``

--- a/porespy/tools/__init__.py
+++ b/porespy/tools/__init__.py
@@ -29,8 +29,10 @@ that do NOT return a modified version of the original image.
     porespy.tools.mesh_region
     porespy.tools.norm_to_uniform
     porespy.tools.overlay
-    porespy.tools.ps_disk
     porespy.tools.ps_ball
+    porespy.tools.ps_disk
+    porespy.tools.ps_rect
+    porespy.tools.ps_round
     porespy.tools.pad_faces
     porespy.tools.randomize_colors
     porespy.tools.seq_to_satn
@@ -55,8 +57,10 @@ that do NOT return a modified version of the original image.
 .. autofunction:: mesh_region
 .. autofunction:: norm_to_uniform
 .. autofunction:: overlay
-.. autofunction:: ps_disk
 .. autofunction:: ps_ball
+.. autofunction:: ps_disk
+.. autofunction:: ps_rect
+.. autofunction:: ps_round
 .. autofunction:: pad_faces
 .. autofunction:: randomize_colors
 .. autofunction:: seq_to_satn
@@ -86,8 +90,10 @@ from .__funcs__ import mesh_region
 from .__funcs__ import norm_to_uniform
 from .__funcs__ import overlay
 from .__funcs__ import randomize_colors
-from .__funcs__ import ps_disk
 from .__funcs__ import ps_ball
+from .__funcs__ import ps_disk
+from .__funcs__ import ps_rect
+from .__funcs__ import ps_round
 from .__funcs__ import pad_faces
 from .__funcs__ import seq_to_satn
 from .__funcs__ import size_to_seq

--- a/test/unit/test_tools.py
+++ b/test/unit/test_tools.py
@@ -273,6 +273,20 @@ class ToolsTest():
         assert ps.tools.sanitize_filename(fname, "vtk") == "test.stl.stl.vtk"
         assert ps.tools.sanitize_filename(fname, "stl", exclude_ext=True) == "test.stl"
 
+    def test_ps_strels(self):
+        c = ps.tools.ps_disk(r=3)
+        assert c.sum() == 25
+        c = ps.tools.ps_disk(r=3, smooth=False)
+        assert c.sum() == 29
+        b = ps.tools.ps_ball(r=3)
+        assert b.sum() == 93
+        b = ps.tools.ps_ball(r=3, smooth=False)
+        assert b.sum() == 123
+        s = ps.tools.ps_rect(w=3, ndim=2)
+        assert s.sum() == 9
+        c = ps.tools.ps_rect(w=3, ndim=3)
+        assert c.sum() == 27
+
 
 if __name__ == '__main__':
     t = ToolsTest()


### PR DESCRIPTION
I already added a ``ps_round`` function that ``ps_ball`` and ``ps_disk`` call behind the scenes, but I forgot to do the cubic version.  This PR adds a ``ps_rect`` (for rectilinear) function, that accepts ``ndim`` argument.

closes #212