### PR TITLE
Include ParaView unit tests in the macOS build

### DIFF
--- a/requirements/conda_requirements.txt
+++ b/requirements/conda_requirements.txt
@@ -15,3 +15,4 @@ pyamg
 openpnm
 edt
 pyimagej
+icu>=68.1

--- a/test/unit/test_io.py
+++ b/test/unit/test_io.py
@@ -75,15 +75,13 @@ class ExportTest():
         os.remove("im2stl.stl")
 
     def test_to_paraview(self):
-        # if sys.platform != "darwin":
         im = ps.generators.blobs(shape=[50, 50, 50], spacing=0.1)
         ps.io.to_paraview(im=im, filename='test_to_paraview.pvsm')
         os.remove('test_to_paraview.pvsm')
 
     def test_open_paraview(self):
-        if sys.platform != "darwin":
-            ps.io.open_paraview(filename='../fixtures/image.pvsm')
-            assert "paraview" in (p.name().split('.')[0] for p in psutil.process_iter())
+        ps.io.open_paraview(filename='../fixtures/image.pvsm')
+        assert "paraview" in (p.name().split('.')[0] for p in psutil.process_iter())
 
     def test_spheres_to_comsol_radii_centers(self):
         radii = np.array([10, 20, 25, 5])

--- a/test/unit/test_io.py
+++ b/test/unit/test_io.py
@@ -75,10 +75,10 @@ class ExportTest():
         os.remove("im2stl.stl")
 
     def test_to_paraview(self):
-        if sys.platform != "darwin":
-            im = ps.generators.blobs(shape=[50, 50, 50], spacing=0.1)
-            ps.io.to_paraview(im=im, filename='test_to_paraview.pvsm')
-            os.remove('test_to_paraview.pvsm')
+        # if sys.platform != "darwin":
+        im = ps.generators.blobs(shape=[50, 50, 50], spacing=0.1)
+        ps.io.to_paraview(im=im, filename='test_to_paraview.pvsm')
+        os.remove('test_to_paraview.pvsm')
 
     def test_open_paraview(self):
         if sys.platform != "darwin":


### PR DESCRIPTION
Due to a dependency conflict, we had to add an explicit lower bound for `icu` package, so the macOS build works.