### PR TITLE
Fix codecov to include numba-jitted methods in coverage report

### DIFF
--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -56,6 +56,10 @@ jobs:
           # Install porespy from the checked-out branch
           pip install -e . --no-deps
 
+      - name: Disable numba JIT for codecov to include jitted methods
+        run: |
+          echo "NUMBA_DISABLE_JIT=1" >> $GITHUB_ENV
+
       - name: Running tests
         run: |
           # Install pycodestyle

--- a/porespy/filters/__funcs__.py
+++ b/porespy/filters/__funcs__.py
@@ -24,28 +24,29 @@ tqdm = get_tqdm()
 
 def apply_padded(im, pad_width, func, pad_val=1, **kwargs):
     r"""
-    Applies padding to an image before sending to ``func``, then extracts the
-    result corresponding to the original image shape.
+    Applies padding to an image before sending to ``func``, then extracts
+    the result corresponding to the original image shape.
 
     Parameters
     ----------
-    im : ND-image
+    im : ndarray
         The image to which ``func`` should be applied
     pad_width : int or list of ints
-        The amount of padding to apply to each axis.  Refer to ``numpy.pad``
-        documentation for more details.
+        The amount of padding to apply to each axis. Refer to
+        ``numpy.pad`` documentation for more details.
     pad_val : scalar
         The value to place into the padded voxels.  The default is 1 (or
         ``True``) which extends the pore space.
     func : function handle
-        The function to apply to the padded image
-    kwargs : additional keyword arguments
-        All additional keyword arguments are collected and passed to ``func``.
+        The function to apply to the padded image.
+    kwargs
+        Additional keyword arguments are collected and passed to ``func``.
 
     Notes
     -----
     A use case for this is when using ``skimage.morphology.skeletonize_3d``
     to ensure that the skeleton extends beyond the edges of the image.
+
     """
     padded = np.pad(im, pad_width=pad_width,
                     mode='constant', constant_values=pad_val)
@@ -56,20 +57,20 @@ def apply_padded(im, pad_width, func, pad_val=1, **kwargs):
 
 def trim_small_clusters(im, size=1):
     r"""
-    Remove isolated voxels or clusters of a given size or smaller
+    Remove isolated voxels or clusters of a given size or smaller.
 
     Parameters
     ----------
-    im : ND-array
-        The binary image from which voxels are to be removed
+    im : ndarray
+        The binary image from which voxels are to be removed.
     size : scalar
-        The threshold size of clusters to trim.  As clusters with this many
-        voxels or fewer will be trimmed.  The default is 1 so only single
-        voxels are removed.
+        The threshold size of clusters to trim.  As clusters with this
+        many voxels or fewer will be trimmed.  The default is 1 so only
+        single voxels are removed.
 
     Returns
     -------
-    im : ND-image
+    im : ndarray
         A copy of ``im`` with clusters of voxels smaller than the given
         ``size`` removed.
 
@@ -90,12 +91,15 @@ def trim_small_clusters(im, size=1):
 
 def hold_peaks(im, axis=-1):
     r"""
-    Replaces each voxel with the highest value along the given axis
+    Replaces each voxel with the highest value along the given axis.
 
     Parameters
     ----------
-    im : ND-image
-        A greyscale image whose peaks are to
+    im : ndarray
+        A greyscale image whose peaks are to be found.
+    axis : int
+        The axis along which the operation is to be applied.
+
     """
     A = im
     B = np.swapaxes(A, axis, -1)
@@ -122,30 +126,29 @@ def distance_transform_lin(im, axis=0, mode="both"):
     Parameters
     ----------
     im : ND-array
-        The image of the porous material with ``True`` values indicating the
-        void phase (or phase of interest)
+        The image of the porous material with ``True`` values indicating
+        the void phase (or phase of interest).
 
     axis : int
-        The direction along which the distance should be measured, the default
-        is 0 (i.e. along the x-direction)
+        The direction along which the distance should be measured, the
+        default is 0 (i.e. along the x-direction).
 
-    mode : string
-        Controls how the distance is measured.  Options are:
-
-        'forward' - Distances are measured in the increasing direction along
-        the specified axis
-
-        'reverse' - Distances are measured in the reverse direction.
-        *'backward'* is also accepted.
-
-        'both' - Distances are calculated in both directions (by recursively
-        calling itself), then reporting the minimum value of the two results.
+    mode : str
+        Controls how the distance is measured. Options are:
+        - 'forward': Distances are measured in the increasing direction
+          along the specified axis
+        - 'reverse': Distances are measured in the reverse direction.
+          'backward' is also accepted.
+        - 'both': Distances are calculated in both directions (by
+          recursively calling itself), then reporting the minimum value of
+          the two results.
 
     Returns
     -------
-    image : ND-array
-        A copy of ``im`` with each foreground voxel containing the distance to
-        the nearest background along the specified axis.
+    image : ndarray
+        A copy of ``im`` with each foreground voxel containing the
+        distance to the nearest background along the specified axis.
+
     """
     _check_for_singleton_axes(im)
 
@@ -180,41 +183,43 @@ def distance_transform_lin(im, axis=0, mode="both"):
 def snow_partitioning(im, dt=None, r_max=4, sigma=0.4, return_all=False,
                       mask=True, randomize=True):
     r"""
-    Partitions the void space into pore regions using a marker-based watershed
-    algorithm, with specially filtered peaks as markers.
+    Partitions the void space into pore regions using a marker-based
+    watershed algorithm, with specially filtered peaks as markers.
 
-    The SNOW network extraction algorithm (Sub-Network of an Over-segmented
-    Watershed) was designed to handle to perculiarities of high porosity
-    materials, but it applies well to other materials as well.
+    The SNOW network extraction algorithm (Sub-Network of an
+    Over-segmented Watershed) was designed to handle to perculiarities of
+    high porosity materials, but it applies well to other materials as
+    well.
 
     Parameters
     ----------
     im : array_like
-        A boolean image of the domain, with ``True`` indicating the pore space
-        and ``False`` elsewhere.
+        A boolean image of the domain, with ``True`` indicating the pore
+        space and ``False`` elsewhere.
     dt : array_like, optional
-        The distance transform of the pore space.  This is done automatically
-        if not provided, but if the distance transform has already been
-        computed then supplying it can save some time.
+        The distance transform of the pore space.  This is done
+        automatically if not provided, but if the distance transform has
+        already been computed then supplying it can save some time.
     r_max : int
-        The radius of the spherical structuring element to use in the Maximum
-        filter stage that is used to find peaks.  The default is 4
+        The radius of the spherical structuring element to use in the
+        Maximum filter stage that is used to find peaks. The default is 4.
     sigma : float
-        The standard deviation of the Gaussian filter used in step 1.  The
-        default is 0.4.  If 0 is given then the filter is not applied, which is
-        useful if a distance transform is supplied as the ``im`` argument that
-        has already been processed.
+        The standard deviation of the Gaussian filter used in step 1. The
+        default is 0.4.  If 0 is given then the filter is not applied,
+        which is useful if a distance transform is supplied as the ``im``
+        argument that has already been processed.
     return_all : boolean
-        If set to ``True`` a named tuple is returned containing the original
-        image, the distance transform, the filtered peaks, and the final
-        pore regions.  The default is ``False``
+        If set to ``True`` a named tuple is returned containing the
+        original image, the distance transform, the filtered peaks, and
+        the final pore regions.  The default is ``False``.
     mask : boolean
-        Apply a mask to the regions where the solid phase is.  Default is
+        Apply a mask to the regions where the solid phase is. Default is
         ``True``
     randomize : boolean
-        If ``True`` (default), then the region colors will be randomized before
-        returning.  This is helpful for visualizing otherwise neighboring
-        regions have simlar coloring are are hard to distinguish.
+        If ``True`` (default), then the region colors will be randomized
+        before returning.  This is helpful for visualizing otherwise
+        neighboring regions have simlar coloring are are hard to
+        distinguish.
 
     Returns
     -------
@@ -225,9 +230,9 @@ def snow_partitioning(im, dt=None, r_max=4, sigma=0.4, return_all=False,
 
     Notes
     -----
-    If ``return_all`` is ``True`` then a **named tuple** is returned containing
-    all of the images used during the process.  They can be access as
-    attriutes with the following names:
+    If ``return_all`` is ``True`` then a **named tuple** is returned
+    containing all of the images used during the process.  They can be
+    access as attriutes with the following names:
 
     - ``im``: The binary image of the void space
     - ``dt``: The distance transform of the image
@@ -289,76 +294,79 @@ def snow_partitioning(im, dt=None, r_max=4, sigma=0.4, return_all=False,
 def snow_partitioning_n(im, r_max=4, sigma=0.4, return_all=True,
                         mask=True, randomize=False, alias=None):
     r"""
-    This function partitions an imaging oontain an arbitrary number of phases
-    into regions using a marker-based watershed segmentation. Its an extension
-    of snow_partitioning function with all phases partitioned together.
+    This function partitions an imaging oontain an arbitrary number of
+    phases into regions using a marker-based watershed segmentation. Its
+    an extension of snow_partitioning function with all phases partitioned
+    together.
 
     Parameters
     ----------
-    im : ND-array
+    im : ndarray
         Image of porous material where each phase is represented by unique
         integer starting from 1 (0's are ignored).
     r_max : scalar
-        The radius of the spherical structuring element to use in the Maximum
-        filter stage that is used to find peaks.  The default is 4.
+        The radius of the spherical structuring element to use in the
+        Maximum filter stage that is used to find peaks. The default is 4.
     sigma : scalar
-        The standard deviation of the Gaussian filter used.  The default is
-        0.4. If 0 is given then the filter is not applied, which is useful if a
-        distance transform is supplied as the ``im`` argument that has already
-        been processed.
+        The standard deviation of the Gaussian filter used. The default is
+        0.4. If 0 is given then the filter is not applied, which is useful
+        if a distance transform is supplied as the ``im`` argument that
+        has already been processed.
     return_all : boolean (default is False)
-        If set to ``True`` a named tuple is returned containing the original
-        image, the combined distance transform, list of each phase max label,
-        and the final combined regions of all phases.
+        If set to ``True`` a named tuple is returned containing the
+        original image, the combined distance transform, list of each
+        phase max label, and the final combined regions of all phases.
     mask : boolean (default is True)
         Apply a mask to the regions which are not under concern.
     randomize : boolean
-        If ``True`` (default), then the region colors will be randomized before
-        returning.  This is helpful for visualizing otherwise neighboring
-        regions have similar coloring and are hard to distinguish.
+        If ``True`` (default), then the region colors will be randomized
+        before returning.  This is helpful for visualizing otherwise
+        neighboring regions have similar coloring and are hard to
+        distinguish.
     alias : dict (Optional)
-        A dictionary that assigns unique image label to specific phases. For
-        example {1: 'Solid'} will show all structural properties associated
-        with label 1 as Solid phase properties. If ``None`` then default
-        labelling will be used i.e {1: 'Phase1',..}.
+        A dictionary that assigns unique image label to specific phases.
+        For example {1: 'Solid'} will show all structural properties
+        associated with label 1 as Solid phase properties. If ``None``
+        then default labelling will be used i.e {1: 'Phase1',..}.
 
     Returns
     -------
     An image the same shape as ``im`` with the all phases partitioned into
     regions using a marker based watershed with the peaks found by the
-    SNOW algorithm [1].  If ``return_all`` is ``True`` then a **named tuple**
-    is returned with the following attribute:
+    SNOW algorithm [1].  If ``return_all`` is ``True`` then a
+    **named tuple** is returned with the following attribute:
 
-        * ``im`` : The actual image of the porous material
-        * ``dt`` : The combined distance transform of the image
-        * ``phase_max_label`` : The list of max label of each phase in order to
-        distinguish between each other
-        * ``regions`` : The partitioned regions of n phases using a marker
-        based watershed with the peaks found by the SNOW algorithm
+    - ``im`` : The actual image of the porous material
+    - ``dt`` : The combined distance transform of the image
+    - ``phase_max_label`` : The list of max label of each phase in order to
+      distinguish between each other
+    - ``regions`` : The partitioned regions of n phases using a marker
+      based watershed with the peaks found by the SNOW algorithm
 
     References
     ----------
-    [1] Gostick, J. "A versatile and efficient network extraction algorithm
-    using marker-based watershed segmentation".  Physical Review E. (2017)
+    [1] Gostick, J. "A versatile and efficient network extraction
+    algorithm using marker-based watershed segmentation".  Physical Review
+    E. (2017)
 
     [2] Khan, ZA et al. "Dual network extraction algorithm to investigate
     multiple transport processes in porous materials: Image-based modeling
-    of pore and grain-scale processes".  Computers in Chemical Engineering.
+    of pore and grain-scale processes". Computers in Chemical Engineering.
     (2019)
 
     See Also
-    ----------
+    --------
     snow_partitioning
 
     Notes
     -----
     In principle it is possible to perform a distance transform on each
     phase separately, merge these into a single image, then apply the
-    watershed only once. This, however, has been found to create edge artifacts
-    between regions arising from the way watershed handles plateaus in the
-    distance transform. To overcome this, this function applies the watershed
-    to each of the distance transforms separately, then merges the segmented
-    regions back into a single image.
+    watershed only once. This, however, has been found to create edge
+    artifacts between regions arising from the way watershed handles
+    plateaus in the distance transform. To overcome this, this function
+    applies the watershed to each of the distance transforms separately,
+    then merges the segmented regions back into a single image.
 
     """
     # Get alias if provided by user
@@ -409,12 +417,12 @@ def find_peaks(dt, r_max=4, footprint=None, **kwargs):
 
     Parameters
     ----------
-    dt : ND-array
-        The distance transform of the pore space.  This may be calculated and
-        filtered using any means desired.
+    dt : ndarray
+        The distance transform of the pore space.  This may be calculated
+        and filtered using any means desired.
     r_max : scalar
-        The size of the structuring element used in the maximum filter.  This
-        controls the localness of any maxima. The default is 4 voxels.
+        The size of the structuring element used in the maximum filter.
+        This controls the localness of any maxima. The default is 4 voxels.
     footprint : ND-array
         Specifies the shape of the structuring element used to define the
         neighborhood when looking for peaks.  If ``None`` (the default) is
@@ -422,7 +430,7 @@ def find_peaks(dt, r_max=4, footprint=None, **kwargs):
 
     Returns
     -------
-    image : ND-array
+    image : ndarray
         An array of booleans with ``True`` values at the location of any
         local maxima.
 
@@ -435,7 +443,9 @@ def find_peaks(dt, r_max=4, footprint=None, **kwargs):
     indices=False)``
 
     The *skimage* function automatically uses a square structuring element
-    which is significantly faster than using a circular or spherical element.
+    which is significantly faster than using a circular or spherical
+    element.
+
     """
     im = dt > 0
     _check_for_singleton_axes(im)
@@ -469,20 +479,21 @@ def reduce_peaks(peaks):
     Parameters
     ----------
     peaks : ND-image
-        An image containing ``True`` values indicating peaks in the distance
-        transform
+        An image containing ``True`` values indicating peaks in the
+        distance transform
 
     Returns
     -------
     image : ND-array
-        An array with the same number of isolated peaks as the original image,
-        but fewer total ``True`` voxels.
+        An array with the same number of isolated peaks as the original
+        image, but fewer total ``True`` voxels.
 
     Notes
     -----
-    The center of mass of a group of voxels is used as the new single voxel, so
-    if the group has an odd shape (like a horse shoe), the new voxel may *not*
-    lie on top of the original set.
+    The center of mass of a group of voxels is used as the new single
+    voxel, so if the group has an odd shape (like a horse shoe), the new
+    voxel may *not* lie on top of the original set.
+
     """
     if peaks.ndim == 2:
         strel = square
@@ -507,13 +518,13 @@ def trim_saddle_points(peaks, dt, max_iters=10):
 
     Parameters
     ----------
-    peaks : ND-array
-        A boolean image containing True values to mark peaks in the distance
-        transform (``dt``)
+    peaks : ndarray
+        A boolean image containing True values to mark peaks in the
+        distance transform (``dt``)
 
-    dt : ND-array
-        The distance transform of the pore space for which the true peaks are
-        sought.
+    dt : ndarray
+        The distance transform of the pore space for which the true peaks
+        are sought.
 
     max_iters : int
         The maximum number of iterations to run while eroding the saddle
@@ -565,35 +576,37 @@ def trim_saddle_points(peaks, dt, max_iters=10):
 
 def trim_nearby_peaks(peaks, dt):
     r"""
-    Finds pairs of peaks that are nearer to each other than to the solid phase,
-    and removes the peak that is closer to the solid.
+    Finds pairs of peaks that are nearer to each other than to the solid
+    phase, and removes the peak that is closer to the solid.
 
     Parameters
     ----------
-    peaks : ND-array
-        A boolean image containing True values to mark peaks in the distance
-        transform (``dt``)
+    peaks : ndarray
+        A boolean image containing True values to mark peaks in the
+        distance transform (``dt``)
 
-    dt : ND-array
-        The distance transform of the pore space for which the true peaks are
-        sought.
+    dt : ndarray
+        The distance transform of the pore space for which the true peaks
+        are sought.
 
     Returns
     -------
-    image : ND-array
-        An array the same size as ``peaks`` containing a subset of the peaks
-        in the original image.
+    image : ndarray
+        An array the same size as ``peaks`` containing a subset of the
+        peaks in the original image.
 
     Notes
     -----
-    Each pair of peaks is considered simultaneously, so for a triplet of peaks
-    each pair is considered.  This ensures that only the single peak that is
-    furthest from the solid is kept.  No iteration is required.
+    Each pair of peaks is considered simultaneously, so for a triplet of
+    peaks each pair is considered.  This ensures that only the single peak
+    that is furthest from the solid is kept.  No iteration is required.
 
     References
     ----------
-    [1] Gostick, J. "A versatile and efficient network extraction algorithm
-    using marker-based watershed segmenation".  Physical Review E. (2017)
+    [1] Gostick, J. "A versatile and efficient network extraction
+    algorithm using marker-based watershed segmenation".  Physical Review
+    E. (2017)
+
     """
     peaks = np.copy(peaks)
     if dt.ndim == 2:
@@ -629,32 +642,32 @@ def trim_nearby_peaks(peaks, dt):
 
 def find_disconnected_voxels(im, conn=None):
     r"""
-    This identifies all pore (or solid) voxels that are not connected to the
-    edge of the image.  This can be used to find blind pores, or remove
-    artifacts such as solid phase voxels that are floating in space.
+    This identifies all pore (or solid) voxels that are not connected to
+    the edge of the image.  This can be used to find blind pores, or
+    remove artifacts such as solid phase voxels that are floating in space.
 
     Parameters
     ----------
-    im : ND-image
+    im : ndarray
         A Boolean image, with True values indicating the phase for which
         disconnected voxels are sought.
     conn : int
-        For 2D the options are 4 and 8 for square and diagonal neighbors, while
-        for the 3D the options are 6 and 26, similarily for square and diagonal
-        neighbors.  The default is the maximum option.
+        For 2D the options are 4 and 8 for square and diagonal neighbors,
+        while for the 3D the options are 6 and 26, similarily for square
+        and diagonal neighbors. The default is the maximum option.
 
     Returns
     -------
-    image : ND-array
+    image : ndarray
         An ND-image the same size as ``im``, with True values indicating
         voxels of the phase of interest (i.e. True values in the original
         image) that are not connected to the outer edges.
 
     Notes
     -----
-    image : ND-array
-        The returned array (e.g. ``holes``) be used to trim blind pores from
-        ``im`` using: ``im[holes] = False``
+    image : ndarray
+        The returned array (e.g. ``holes``) be used to trim blind pores
+        from ``im`` using: ``im[holes] = False``
 
     """
     _check_for_singleton_axes(im)
@@ -692,9 +705,9 @@ def fill_blind_pores(im, conn=None):
     image : ND-array
         A version of ``im`` but with all the disconnected pores removed.
     conn : int
-        For 2D the options are 4 and 8 for square and diagonal neighbors, while
-        for the 3D the options are 6 and 26, similarily for square and diagonal
-        neighbors.  The default is the maximum option.
+        For 2D the options are 4 and 8 for square and diagonal neighbors,
+        while for the 3D the options are 6 and 26, similarily for square
+        and diagonal neighbors. The default is the maximum option.
 
     See Also
     --------
@@ -713,16 +726,16 @@ def trim_floating_solid(im, conn=None):
 
     Parameters
     ----------
-    im : ND-array
+    im : ndarray
         The image of the porous material
     conn : int
-        For 2D the options are 4 and 8 for square and diagonal neighbors, while
-        for the 3D the options are 6 and 26, similarily for square and diagonal
-        neighbors.  The default is the maximum option.
+        For 2D the options are 4 and 8 for square and diagonal neighbors,
+        while for the 3D the options are 6 and 26, similarily for square
+        and diagonal neighbors. The default is the maximum option.
 
     Returns
     -------
-    image : ND-array
+    image : ndarray
         A version of ``im`` but with all the disconnected solid removed.
 
     See Also
@@ -742,28 +755,30 @@ def trim_nonpercolating_paths(im, inlet_axis=0, outlet_axis=0,
     Removes all nonpercolating paths between specified edges
 
     This function is essential when performing transport simulations on an
-    image, since image regions that do not span between the desired inlet and
-    outlet do not contribute to the transport.
+    image, since image regions that do not span between the desired inlet
+    and outlet do not contribute to the transport.
 
     Parameters
     ----------
-    im : ND-array
-        The image of the porous material with ```True`` values indicating the
-        phase of interest
+    im : ndarray
+        The image of the porous material with ```True`` values indicating
+        the phase of interest
     inlet_axis : int
         Inlet axis of boundary condition. For three dimensional image the
         number ranges from 0 to 2. For two dimensional image the range is
-        between 0 to 1. If ``inlets`` is given then this argument is ignored.
+        between 0 to 1. If ``inlets`` is given then this argument is
+        ignored.
     outlet_axis : int
         Outlet axis of boundary condition. For three dimensional image the
         number ranges from 0 to 2. For two dimensional image the range is
-        between 0 to 1. If ``outlets`` is given then this argument is ignored.
+        between 0 to 1. If ``outlets`` is given then this argument is
+        ignored.
     inlets : ND-image (optional)
-        A boolean mask indicating locations of inlets.  If this argument is
-        supplied then ``inlet_axis`` is ignored.
+        A boolean mask indicating locations of inlets.  If this argument
+        is supplied then ``inlet_axis`` is ignored.
     outlets : ND-image (optional)
-        A boolean mask indicating locations of outlets. If this argument is
-        supplied then ``outlet_axis`` is ignored.
+        A boolean mask indicating locations of outlets. If this argument
+        is supplied then ``outlet_axis`` is ignored.
 
     Returns
     -------
@@ -779,8 +794,8 @@ def trim_nonpercolating_paths(im, inlet_axis=0, outlet_axis=0,
     """
     _check_for_singleton_axes(im)
     labels = spim.label(im)[0]
-    # The following non-sense is only needed to support the inlet/outlet_axis
-    # arguments which will be removed in V2.0
+    # The following non-sense is only needed to support the
+    # inlet/outlet_axis arguments which will be removed in V2.0
     if inlets is None:
         inlets = np.zeros_like(im, dtype=bool)
         if im.ndim == 3:
@@ -824,7 +839,7 @@ def trim_extrema(im, h, mode="maxima"):
 
     Parameters
     ----------
-    im : ND-array
+    im : ndarray
         The image whose extrema are to be removed
 
     h : float
@@ -835,8 +850,9 @@ def trim_extrema(im, h, mode="maxima"):
 
     Returns
     -------
-    image : ND-array
-        A copy of the input image with all the peaks and/or valleys removed.
+    image : ndarray
+        A copy of the input image with all the peaks and/or valleys
+        removed.
 
     Notes
     -----
@@ -865,27 +881,23 @@ def flood(im, regions=None, mode="max"):
         and 0's elsewhere.
     regions : array_like
         An array the same shape as ``im`` with each region labeled.  If
-        ``None`` is supplied (default) then ``scipy.ndimage.label`` is used
-        with its default arguments.
+        ``None`` is supplied (default) then ``scipy.ndimage.label`` is
+        used with its default arguments.
     mode : string
-        Specifies how to determine which value should be used to flood each
-        region.  Options are:
+        Specifies how to determine which value should be used to flood
+        each region. Options are:
 
-        'maximum' - Floods each region with the local maximum in that region
-
-        'minimum' - Floods each region the local minimum in that region
-
-        'median' - Floods each region the local median in that region
-
-        'mean' - Floods each region the local mean in that region
-
-        'size' - Floods each region with the size of that region
+        - 'maximum': Floods each region with the local max in that region
+        - 'minimum': Floods each region the local minimum in that region
+        - 'median': Floods each region the local median in that region
+        - 'mean': Floods each region the local mean in that region
+        - 'size': Floods each region with the size of that region
 
     Returns
     -------
-    image : ND-array
-        A copy of ``im`` with new values placed in each forground voxel based
-        on the ``mode``.
+    image : ndarray
+        A copy of ``im`` with new values placed in each forground voxel
+        based on the ``mode``.
 
     See Also
     --------
@@ -913,26 +925,28 @@ def flood(im, regions=None, mode="max"):
 
 def find_dt_artifacts(dt):
     r"""
-    Finds points in a distance transform that are closer to wall than solid.
+    Finds points in a distance transform that are closer to wall than
+    solid.
 
-    These points could *potentially* be erroneously high since their distance
-    values do not reflect the possibility that solid may have been present
-    beyond the border of the image but lost by trimming.
+    These points could *potentially* be erroneously high since their
+    distance values do not reflect the possibility that solid may have
+    been present beyond the border of the image but lost by trimming.
 
     Parameters
     ----------
-    dt : ND-array
-        The distance transform of the phase of interest
+    dt : ndarray
+        The distance transform of the phase of interest.
 
     Returns
     -------
-    image : ND-array
-        An ND-array the same shape as ``dt`` with numerical values indicating
-        the maximum amount of error in each volxel, which is found by
-        subtracting the distance to nearest edge of image from the distance
-        transform value. In other words, this is the error that would be found
-        if there were a solid voxel lurking just beyond the nearest edge of
-        the image.  Obviously, voxels with a value of zero have no error.
+    image : ndarray
+        An ndarray the same shape as ``dt`` with numerical values
+        indicating the maximum amount of error in each volxel, which is
+        found by subtracting the distance to nearest edge of image from
+        the distance transform value. In other words, this is the error
+        that would be found if there were a solid voxel lurking just
+        beyond the nearest edge of the image.  Obviously, voxels with a
+        value of zero have no error.
 
     """
     temp = np.ones(shape=dt.shape) * np.inf
@@ -946,11 +960,11 @@ def find_dt_artifacts(dt):
 
 def region_size(im):
     r"""
-    Replace each voxel with size of region to which it belongs
+    Replace each voxel with size of region to which it belongs.
 
     Parameters
     ----------
-    im : ND-array
+    im : ndarray
         Either a boolean image wtih ``True`` indicating the features of
         interest, in which case ``scipy.ndimage.label`` will be applied to
         find regions, or a greyscale image with integer values indicating
@@ -958,14 +972,15 @@ def region_size(im):
 
     Returns
     -------
-    image : ND-array
+    image : ndarray
         A copy of ``im`` with each voxel value indicating the size of the
-        region to which it belongs.  This is particularly useful for finding
-        chord sizes on the image produced by ``apply_chords``.
+        region to which it belongs.  This is particularly useful for
+        finding chord sizes on the image produced by ``apply_chords``.
 
     See Also
     --------
     flood
+
     """
     if im.dtype == bool:
         im = spim.label(im)[0]
@@ -977,36 +992,32 @@ def region_size(im):
 
 def apply_chords(im, spacing=1, axis=0, trim_edges=True, label=False):
     r"""
-    Adds chords to the void space in the specified direction.  The chords are
-    separated by 1 voxel plus the provided spacing.
+    Adds chords to the void space in the specified direction. The chords
+    are separated by 1 voxel plus the provided spacing.
 
     Parameters
     ----------
-    im : ND-array
+    im : ndarray
         An image of the porous material with void marked as ``True``.
-
     spacing : int
         Separation between chords.  The default is 1 voxel.  This can be
-        decreased to 0, meaning that the chords all touch each other, which
-        automatically sets to the ``label`` argument to ``True``.
-
+        decreased to 0, meaning that the chords all touch each other,
+        which automatically sets to the ``label`` argument to ``True``.
     axis : int (default = 0)
         The axis along which the chords are drawn.
-
     trim_edges : bool (default = ``True``)
         Whether or not to remove chords that touch the edges of the image.
         These chords are artifically shortened, so skew the chord length
         distribution.
-
     label : bool (default is ``False``)
-        If ``True`` the chords in the returned image are each given a unique
-        label, such that all voxels lying on the same chord have the same
-        value.  This is automatically set to ``True`` if spacing is 0, but is
-        ``False`` otherwise.
+        If ``True`` the chords in the returned image are each given a
+        unique label, such that all voxels lying on the same chord have
+        the same value.  This is automatically set to ``True`` if spacing
+        is 0, but is ``False`` otherwise.
 
     Returns
     -------
-    image : ND-array
+    image : ndarray
         A copy of ``im`` with non-zero values indicating the chords.
 
     See Also
@@ -1039,19 +1050,17 @@ def apply_chords(im, spacing=1, axis=0, trim_edges=True, label=False):
 
 def apply_chords_3D(im, spacing=0, trim_edges=True):
     r"""
-    Adds chords to the void space in all three principle directions.  The
-    chords are seprated by 1 voxel plus the provided spacing.  Chords in the X,
-    Y and Z directions are labelled 1, 2 and 3 resepctively.
+    Adds chords to the void space in all three principle directions. The
+    chords are seprated by 1 voxel plus the provided spacing. Chords in
+    the X, Y and Z directions are labelled 1, 2 and 3 resepctively.
 
     Parameters
     ----------
-    im : ND-array
+    im : ndarray
         A 3D image of the porous material with void space marked as True.
-
     spacing : int (default = 0)
         Chords are automatically separed by 1 voxel on all sides, and this
         argument increases the separation.
-
     trim_edges : bool (default is ``True``)
         Whether or not to remove chords that touch the edges of the image.
         These chords are artifically shortened, so skew the chord length
@@ -1059,15 +1068,16 @@ def apply_chords_3D(im, spacing=0, trim_edges=True):
 
     Returns
     -------
-    image : ND-array
+    image : ndarray
         A copy of ``im`` with values of 1 indicating x-direction chords,
-        2 indicating y-direction chords, and 3 indicating z-direction chords.
+        2 indicating y-direction chords, and 3 indicating z-direction
+        chords.
 
     Notes
     -----
-    The chords are separated by a spacing of at least 1 voxel so that tools
-    that search for connected components, such as ``scipy.ndimage.label`` can
-    detect individual chords.
+    The chords are separated by a spacing of at least 1 voxel so that
+    tools that search for connected components, such as
+    ``scipy.ndimage.label`` can detect individual chords.
 
     See Also
     --------
@@ -1080,8 +1090,8 @@ def apply_chords_3D(im, spacing=0, trim_edges=True):
     if spacing < 0:
         raise Exception("Spacing cannot be less than 0")
     ch = np.zeros_like(im, dtype=int)
-    ch[:, :: 4 + 2 * spacing, :: 4 + 2 * spacing] = 1       # X-direction
-    ch[:: 4 + 2 * spacing, :, 2::4 + 2 * spacing] = 2     # Y-direction
+    ch[:, :: 4 + 2 * spacing, :: 4 + 2 * spacing] = 1   # X-direction
+    ch[:: 4 + 2 * spacing, :, 2::4 + 2 * spacing] = 2   # Y-direction
     ch[2::4 + 2 * spacing, 2::4 + 2 * spacing, :] = 3   # Z-direction
     chords = ch * im
     if trim_edges:
@@ -1092,44 +1102,42 @@ def apply_chords_3D(im, spacing=0, trim_edges=True):
 
 def local_thickness(im, sizes=25, mode="hybrid", **kwargs):
     r"""
-    For each voxel, this function calculates the radius of the largest sphere
-    that both engulfs the voxel and fits entirely within the foreground.
+    For each voxel, this function calculates the radius of the largest
+    sphere that both engulfs the voxel and fits entirely within the
+    foreground.
 
     This is not the same as a simple distance transform, which finds the
     largest sphere that could be *centered* on each voxel.
 
     Parameters
     ----------
-    im : array_like
+    im : ndarray
         A binary image with the phase of interest set to True
-
     sizes : array_like or scalar
-        The sizes to invade.  If a list of values of provided they are used
-        directly.  If a scalar is provided then that number of points spanning
-        the min and max of the distance transform are used.
+        The sizes to invade.  If a list of values of provided they are
+        used directly. If a scalar is provided then that number of points
+        spanning the min and max of the distance transform are used.
+    mode : str
+        Controls with method is used to compute the result. Options are:
 
-    mode : string
-        Controls with method is used to compute the result.  Options are:
-
-        'hybrid' - (default) Performs a distance tranform of the void space,
-        thresholds to find voxels larger than ``sizes[i]``, trims the resulting
-        mask if ``access_limitations`` is ``True``, then dilates it using the
-        efficient fft-method to obtain the non-wetting fluid configuration.
-
-        'dt' - Same as 'hybrid', except uses a second distance transform,
-        relative to the thresholded mask, to find the invading fluid
-        configuration.  The choice of 'dt' or 'hybrid' depends on speed, which
-        is system and installation specific.
-
-        'mio' - Using a single morphological image opening step to obtain the
-        invading fluid confirguration directly, *then* trims if
-        ``access_limitations`` is ``True``.  This method is not ideal and is
-        included mostly for comparison purposes.
+        - 'hybrid': (default) Performs a distance tranform of the void
+          space, thresholds to find voxels larger than ``sizes[i]``, trims
+          the resulting mask if ``access_limitations`` is ``True``, then
+          dilates it using the efficient fft-method to obtain the
+          non-wetting fluid configuration.
+        - 'dt': Same as 'hybrid', except uses a second distance transform,
+          relative to the thresholded mask, to find the invading fluid
+          configuration. The choice of 'dt' or 'hybrid' depends on speed,
+          which is system and installation specific.
+        - 'mio': Using a single morphological image opening step to obtain
+          the invading fluid confirguration directly, *then* trims if
+          ``access_limitations`` is ``True``. This method is not ideal and
+          is included mostly for comparison purposes.
 
     Returns
     -------
-    image : ND-array
-        A copy of ``im`` with the pore size values in each voxel
+    image : ndarray
+        A copy of ``im`` with the pore size values in each voxel.
 
     See Also
     --------
@@ -1137,76 +1145,70 @@ def local_thickness(im, sizes=25, mode="hybrid", **kwargs):
 
     Notes
     -----
-    The term *foreground* is used since this function can be applied to both
-    pore space or the solid, whichever is set to ``True``.
+    The term *foreground* is used since this function can be applied to
+    both pore space or the solid, whichever is set to ``True``.
 
-    This function is identical to ``porosimetry`` with ``access_limited`` set
-    to ``False``.
+    This function is identical to ``porosimetry`` with ``access_limited``
+    set to ``False``.
 
-    The way local thickness is found in PoreSpy differs from the traditional
-    method (i.e. `used in ImageJ <https://imagej.net/Local_Thickness>`_).
-    Our approach is probably slower, but it allows for the same code to be
-    used for ``local_thickness`` and ``porosimetry``, since we can 'trim'
-    invaded regions that are not connected to the inlets in the ``porosimetry``
-    function.  This is not needed in ``local_thickness`` however.
+    The way local thickness is found in PoreSpy differs from the
+    traditional method (i.e. used in ImageJ
+    `<https://imagej.net/Local_Thickness>`_). Our approach is probably
+    slower, but it allows for the same code to be used for
+    ``local_thickness`` and ``porosimetry``, since we can 'trim' invaded
+    regions that are not connected to the inlets in the ``porosimetry``
+    function. This is not needed in ``local_thickness`` however.
 
     """
-    im_new = porosimetry(im=im, sizes=sizes, access_limited=False, mode=mode,
-                         **kwargs)
+    im_new = porosimetry(im=im, sizes=sizes, access_limited=False, mode=mode, **kwargs)
     return im_new
 
 
 def porosimetry(im, sizes=25, inlets=None, access_limited=True, mode='hybrid',
                 fft=True, **kwargs):
     r"""
-    Performs a porosimetry simulution on an image
+    Performs a porosimetry simulution on an image.
 
     Parameters
     ----------
-    im : ND-array
+    im : ndarray
         An ND image of the porous material containing ``True`` values in the
         pore space.
-
     sizes : array_like or scalar
-        The sizes to invade.  If a list of values of provided they are used
-        directly.  If a scalar is provided then that number of points spanning
-        the min and max of the distance transform are used.
-
-    inlets : ND-array, boolean
+        The sizes to invade.  If a list of values of provided they are
+        used directly.  If a scalar is provided then that number of points
+        spanning the min and max of the distance transform are used.
+    inlets : ndarray, boolean
         A boolean mask with ``True`` values indicating where the invasion
         enters the image.  By default all faces are considered inlets,
         akin to a mercury porosimetry experiment.  Users can also apply
         solid boundaries to their image externally before passing it in,
-        allowing for complex inlets like circular openings, etc.  This argument
-        is only used if ``access_limited`` is ``True``.
-
-    access_limited : Boolean
+        allowing for complex inlets like circular openings, etc.
+        This argument is only used if ``access_limited`` is ``True``.
+    access_limited : bool
         This flag indicates if the intrusion should only occur from the
-        surfaces (``access_limited`` is ``True``, which is the default), or
-        if the invading phase should be allowed to appear in the core of
-        the image.  The former simulates experimental tools like mercury
-        intrusion porosimetry, while the latter is useful for comparison
-        to gauge the extent of shielding effects in the sample.
-
-    mode : string
-        Controls with method is used to compute the result.  Options are:
-
-        'hybrid' - (default) Performs a distance tranform of the void space,
-        thresholds to find voxels larger than ``sizes[i]``, trims the resulting
-        mask if ``access_limitations`` is ``True``, then dilates it using the
-        efficient fft-method to obtain the non-wetting fluid configuration.
-
-        'dt' - Same as 'hybrid', except uses a second distance transform,
-        relative to the thresholded mask, to find the invading fluid
-        configuration.  The choice of 'dt' or 'hybrid' depends on speed, which
-        is system and installation specific.
-
-        'mio' - Using a single morphological image opening step to obtain the
-        invading fluid confirguration directly, *then* trims if
-        ``access_limitations`` is ``True``.  This method is not ideal and is
-        included mostly for comparison purposes.  The morphological operations
-        are done using fft-based method implementations.
-
+        surfaces (``access_limited`` is ``True``, which is the default),
+        or if the invading phase should be allowed to appear in the core
+        of the image.  The former simulates experimental tools like
+        mercury intrusion porosimetry, while the latter is useful for
+        comparison to gauge the extent of shielding effects in the sample.
+    mode : str
+        Controls with method is used to compute the result. Options are:
+        - 'hybrid': (default) Performs a distance tranform of the void
+          space, thresholds to find voxels larger than ``sizes[i]``, trims
+          the resulting mask if ``access_limitations`` is ``True``, then
+          dilates it using the efficient fft-method to obtain the
+          non-wetting fluid configuration.
+        - 'dt': Same as 'hybrid', except uses a second distance transform,
+          relative to the thresholded mask, to find the invading fluid
+          configuration. The choice of 'dt' or 'hybrid' depends on speed,
+          which is system and installation specific.
+        - 'mio': Using a single morphological image opening step to obtain
+          the invading fluid confirguration directly, *then* trims if
+          ``access_limitations`` is ``True``.  This method is not ideal
+          and is included mostly for comparison purposes. The
+          morphological operations are done using fft-based method
+          implementations.
     fft : boolean (default is ``True``)
         Indicates whether to use the ``fftmorphology`` function in
         ``porespy.filters`` or to use the standard morphology functions in
@@ -1215,21 +1217,22 @@ def porosimetry(im, sizes=25, inlets=None, access_limited=True, mode='hybrid',
 
     Returns
     -------
-    image : ND-array
+    image : ndarray
         A copy of ``im`` with voxel values indicating the sphere radius at
-        which it becomes accessible from the inlets.  This image can be used
-        to find invading fluid configurations as a function of applied
-        capillary pressure by applying a boolean comparison:
-        ``inv_phase = im > r`` where ``r`` is the radius (in voxels) of the
-        invading sphere.  Of course, ``r`` can be converted to capillary
-        pressure using a preferred model.
+        which it becomes accessible from the inlets.  This image can be
+        used to find invading fluid configurations as a function of
+        applied capillary pressure by applying a boolean comparison:
+        ``inv_phase = im > r`` where ``r`` is the radius (in voxels) of
+        the invading sphere.  Of course, ``r`` can be converted to
+        capillary pressure using a preferred model.
 
     Notes
     -----
-    There are many ways to perform this filter, and PoreSpy offers 3, which
-    users can choose between via the ``mode`` argument.  These methods all
-    work in a similar way by finding which foreground voxels can accomodate
-    a sphere of a given radius, then repeating for smaller radii.
+    There are many ways to perform this filter, and PoreSpy offers 3,
+    which users can choose between via the ``mode`` argument. These
+    methods all work in a similar way by finding which foreground voxels
+    can accomodate a sphere of a given radius, then repeating for smaller
+    radii.
 
     See Also
     --------
@@ -1324,28 +1327,30 @@ def porosimetry(im, sizes=25, inlets=None, access_limited=True, mode='hybrid',
 
 def trim_disconnected_blobs(im, inlets, strel=None):
     r"""
-    Removes foreground voxels not connected to specified inlets
+    Removes foreground voxels not connected to specified inlets.
 
     Parameters
     ----------
-    im : ND-array
+    im : ndarray
         The image containing the blobs to be trimmed
-    inlets : ND-array or tuple of indices
-        The locations of the inlets.  Can either be a boolean mask the same
-        shape as ``im``, or a tuple of indices such as that returned by the
-        ``where`` function.  Any voxels *not* connected directly to
+    inlets : ndarray or tuple of indices
+        The locations of the inlets.  Can either be a boolean mask the
+        same shape as ``im``, or a tuple of indices such as that returned
+        by the ``where`` function.  Any voxels *not* connected directly to
         the inlets will be trimmed.
-    strel : ND-array
-        The neighborhood over which connectivity should be checked. It must
-        be symmetric and the same dimensionality as the image.  It is passed
-        directly to the ``scipy.ndimage.label`` function as the ``structure``
-        argument so refer to that docstring for additional info.
+    strel : ndarray
+        The neighborhood over which connectivity should be checked. It
+        must be symmetric and the same dimensionality as the image. It is
+        passed directly to the ``scipy.ndimage.label`` function as the
+        ``structure`` argument so refer to that docstring for additional
+        info.
 
     Returns
     -------
-    image : ND-array
+    image : ndarray
         An array of the same shape as ``im``, but with all foreground
         voxels not connected to the ``inlets`` removed.
+
     """
     if type(inlets) == tuple:
         temp = np.copy(inlets)
@@ -1402,9 +1407,11 @@ def _make_stack(im, include_diagonals=False):
     r"""
     Creates a stack of images with one extra dimension to the input image
     with length equal to the number of borders to search + 1.
+
     Image is rolled along the axial shifts so that the border pixel is
     overlapping the original pixel. First image in stack is the original.
     Stacking makes direct vectorized array comparisons possible.
+
     """
     ndim = len(np.shape(im))
     axial_shift = _get_axial_shifts(ndim, include_diagonals)
@@ -1436,20 +1443,21 @@ def nphase_border(im, include_diagonals=False):
 
     Parameters
     ----------
-    im : ND-array
-        An ND image of the porous material containing discrete values in the
-        pore space identifying different regions. e.g. the result of a
+    im : ndarray
+        An ND image of the porous material containing discrete values in
+        the pore space identifying different regions. e.g. the result of a
         snow-partition
 
-    include_diagonals : boolean
-        When identifying bordering pixels (2D) and voxels (3D) include those
-        shifted along more than one axis
+    include_diagonals : bool
+        When identifying bordering pixels (2D) and voxels (3D) include
+        those shifted along more than one axis
 
     Returns
     -------
-    image : ND-array
+    image : ndarray
         A copy of ``im`` with voxel values equal to the number of uniquely
         different bordering values
+
     """
     _check_for_singleton_axes(im)
     # Get dimension of image
@@ -1484,18 +1492,19 @@ def prune_branches(skel, branch_points=None, iterations=1, **kwargs):
 
     Parameters
     ----------
-    skel : ND-image
-        A image of a full or partial skeleton from which the tails should be
-        trimmed.
+    skel : ndarray
+        A image of a full or partial skeleton from which the tails should
+        be trimmed.
 
-    branch_points : ND-image, optional
-        An image the same size ``skel`` with True values indicating the branch
-        points of the skeleton.  If this is not provided it is calculated
-        automatically.
+    branch_points : ndarray, optional
+        An image the same size ``skel`` with True values indicating the
+        branch points of the skeleton.  If this is not provided it is
+        calculated automatically.
 
     Returns
     -------
-    An ND-image containing the skeleton with tails removed.
+    ndarray
+        An ndarray containing the skeleton with tails removed.
 
     """
     skel = skel > 0
@@ -1559,15 +1568,15 @@ def chunked_func(func,
                  strel_arg=["strel", "structure", "footprint"],
                  **kwargs):
     r"""
-    Performs the specfied operation "chunk-wise" in parallel using dask
+    Performs the specfied operation "chunk-wise" in parallel using dask.
 
-    This can be used to save memory by doing one chunk at a time (``cores=1``)
-    or to increase computation speed by spreading the work across multiple
-    cores (e.g. ``cores=8``)
+    This can be used to save memory by doing one chunk at a time
+    (``cores=1``) or to increase computation speed by spreading the work
+    across multiple cores (e.g. ``cores=8``)
 
-    This function can be used with any operation that applies a structuring
-    element of some sort, since this implies that the operation is local
-    and can be chunked.
+    This function can be used with any operation that applies a
+    structuring element of some sort, since this implies that the
+    operation is local and can be chunked.
 
     Parameters
     ----------
@@ -1575,50 +1584,52 @@ def chunked_func(func,
         The function which should be applied to each chunk, such as
         ``spipy.ndimage.binary_dilation``.
     overlap : scalar or list of scalars, optional
-        The amount of overlap to include when dividing up the image.  This
+        The amount of overlap to include when dividing up the image. This
         value will almost always be the size (i.e. diameter) of the
-        structuring element. If not specified then the amount of overlap is
-        inferred from the size of the structuring element, in which case the
-        ``strel_arg`` must be specified.
+        structuring element. If not specified then the amount of overlap
+        is inferred from the size of the structuring element, in which
+        case the ``strel_arg`` must be specified.
     divs : scalar or list of scalars (default = [2, 2, 2])
-        The number of chunks to divide the image into in each direction.  The
-        default is 2 chunks in each direction, resulting in a quartering of
-        the image and 8 total chunks (in 3D).  A scalar is interpreted as
-        applying to all directions, while a list of scalars is interpreted
-        as applying to each individual direction.
+        The number of chunks to divide the image into in each direction.
+        The default is 2 chunks in each direction, resulting in a
+        quartering of the image and 8 total chunks (in 3D).  A scalar is
+        interpreted as applying to all directions, while a list of scalars
+        is interpreted as applying to each individual direction.
     cores : scalar
-        The number of cores which should be used.  By default, all cores will
-        be used, or as many are needed for the given number of chunks, which
-        ever is smaller.
-    im_arg : string
-        The keyword used by ``func`` for the image to be operated on.  By
-        default this function will look for ``image``, ``input``, and ``im``
-        which are commonly used by *scipy.ndimage* and *skimage*.
-    strel_arg : string
+        The number of cores which should be used.  By default, all cores
+        will be used, or as many are needed for the given number of
+        chunks, which ever is smaller.
+    im_arg : str
+        The keyword used by ``func`` for the image to be operated on. By
+        default this function will look for ``image``, ``input``, and
+        ``im`` which are commonly used by *scipy.ndimage* and *skimage*.
+    strel_arg : str
         The keyword used by ``func`` for the structuring element to apply.
-        This is only needed if ``overlap`` is not specified. By default this
-        function will look for ``strel``, ``structure``, and ``footprint``
-        which are commonly used by *scipy.ndimage* and *skimage*.
-    kwargs : additional keyword arguments
-        All other arguments are passed to ``func`` as keyword arguments. Note
-        that PoreSpy will fetch the image from this list of keywords using the
-        value provided to ``im_arg``.
+        This is only needed if ``overlap`` is not specified. By default
+        this function will look for ``strel``, ``structure``, and
+        ``footprint`` which are commonly used by *scipy.ndimage* and
+        *skimage*.
+    kwargs
+        All other arguments are passed to ``func`` as keyword arguments.
+        Note that PoreSpy will fetch the image from this list of keywords
+        using the value provided to ``im_arg``.
 
     Returns
     -------
-    result : ND-image
-        An image the same size as the input image, with the specified filter
-        applied as though done on a single large image.  There should be *no*
-        difference.
+    result : ndarray
+        An image the same size as the input image, with the specified
+        filter applied as though done on a single large image. There
+        should be *no* difference.
 
     Notes
     -----
-    This function divides the image into the specified number of chunks, but
-    also applies a padding to each chunk to create an overlap with neighboring
-    chunks.  This way the operation does not have any edge artifacts. The
-    amount of padding is usually equal to the radius of the structuring
-    element but some functions do not use one, such as the distance transform
-    and Gaussian blur.  In these cases the user can specify ``overlap``.
+    This function divides the image into the specified number of chunks,
+    but also applies a padding to each chunk to create an overlap with
+    neighboring chunks. This way the operation does not have any edge
+    artifacts. The amount of padding is usually equal to the radius of the
+    structuring element but some functions do not use one, such as the
+    distance transform and Gaussian blur.  In these cases the user can
+    specify ``overlap``.
 
     See Also
     --------
@@ -1724,56 +1735,57 @@ def snow_partitioning_parallel(im,
                                crop=True,
                                return_all=False):
     r"""
-    Perform SNOW algorithm in parallel and serial mode to reduce time and
-    memory usage repectively by geomertirc domain decomposition of large size
-    image.
+    Performs SNOW algorithm in parallel and serial mode to reduce time and
+    memory usage repectively by geomertirc domain decomposition of large
+    size image.
 
     Parameters
     ----------
     im : ndarray
-        A binary image of porous media with 'True' values indicating phase of
-        interest
+        A binary image of porous media with 'True' values indicating phase
+        of interest
     overlap : float or int or str
         Overlapping thickness between two subdomains that is used to merge
-        watershed segmented regions at intersection of two or more subdomains.
-        If 'dt' the overlap will be calculated based on maximum
-        distance transform in the whole image.
-        If 'ws' the overlap will be calculated by finding the maximum dimension
-        of the bounding box of largest segmented region. The image is scale down
-        by 'zoom_factor' provided by user.
-        If any real number of overlap is provided then this value will be
-        considered as overlapping thickness.
+        watershed segmented regions at intersection of two or more
+        subdomains.
+        - If 'dt' the overlap will be calculated based on maximum distance
+          transform in the whole image.
+        - If 'ws' the overlap will be calculated by finding the maximum
+          dimension of the bounding box of largest segmented region. The
+          image is scale down by 'zoom_factor' provided by user.
+        - If any real number of overlap is provided then this value will
+          be considered as overlapping thickness.
     divs : list or int
         Number of domains each axis will be divided.
-        If a scalar is provided then it will be assigned to all axis.
-        If list is provided then each respective axis will be divided by its
-        corresponding number in the list. For example [2, 3, 4] will divide
-        z, y and x axis to 2, 3, and 4 respectively.
+        - If a scalar is provided then it will be assigned to all axis.
+        - If list is provided then each respective axis will be divided by
+          its corresponding number in the list. For example [2, 3, 4] will
+          divide z, y and x axis to 2, 3, and 4 respectively.
     mode : str
-        if 'parallel' then all subdomains will be processed in number of cores
-        provided as num_workers
-        if 'serial' then all subdomains will be processed one by one in one core
-        of CPU.
+        - If 'parallel' then all subdomains will be processed in number of
+          cores provided as num_workers.
+        - If 'serial' then all subdomains will be processed one by one in
+          one core of CPU.
     num_workers : int or None
         Number of cores that will be used to parallel process all domains.
-        If None then all cores will be used but user can specify any integer
-        values to control the memory usage.
+        If None then all cores will be used but user can specify any
+        integer values to control the memory usage.
     crop : bool
         If True the image shape is cropped to fit specified division.
     zoom_factor : float or int
-        The amount of zoom appiled to image to find overlap thickness using "ws"
-        overlap mode.
+        The amount of zoom appiled to image to find overlap thickness
+        using "ws" overlap mode.
     return_all : boolean
-        If set to ``True`` a named tuple is returned containing the original
-        image, the distance transform, and the final
-        pore regions.  The default is ``False``
+        If set to ``True`` a named tuple is returned containing the
+        original image, the distance transform, and the final pore
+        regions. The default is ``False``.
 
     Returns
-    ----------
+    -------
     regions : ndarray
         Partitioned image of segmentated regions with unique labels. Each
-        region correspond to pore body while intersection with other region
-        correspond throat area.
+        region correspond to pore body while intersection with other
+        region correspond throat area.
 
     """
     # Adjust image shape according to specified dimension
@@ -1856,32 +1868,33 @@ def snow_partitioning_parallel(im,
 
 def chunked_snow(im, r_max=5, sigma=0.4):
     r"""
-    Partitions the void space into pore regions using a marker-based watershed
-    algorithm, with specially filtered peaks as markers.
+    Partitions the void space into pore regions using a marker-based
+    watershed algorithm, with specially filtered peaks as markers.
 
-    The SNOW network extraction algorithm (Sub-Network of an Over-segmented
-    Watershed) was designed to handle to perculiarities of high porosity
-    materials, but it applies well to other materials as well.
+    The SNOW network extraction algorithm (Sub-Network of an
+    Over-segmented Watershed) was designed to handle to perculiarities of
+    high porosity materials, but it applies well to other materials as
+    well.
 
     Parameters
     ----------
     im : array_like
         Distance transform of phase of interest in a binary image
     r_max : int
-        The radius of the spherical structuring element to use in the Maximum
-        filter stage that is used to find peaks.  The default is 5
+        The radius of the spherical structuring element to use in the
+        maximum filter stage that is used to find peaks.  The default is 5
     sigma : float
-        The standard deviation of the Gaussian filter used in step 1.  The
-        default is 0.4.  If 0 is given then the filter is not applied, which is
-        useful if a distance transform is supplied as the ``im`` argument that
-        has already been processed.
+        The standard deviation of the Gaussian filter used in step 1. The
+        default is 0.4.  If 0 is given then the filter is not applied,
+        which is useful if a distance transform is supplied as the ``im``
+        argument that has already been processed.
 
     Returns
     -------
-    image : ND-array
-        An image the same shape as ``im`` with the void space partitioned into
-        pores using a marker based watershed with the peaks found by the
-        SNOW algorithm [1].
+    image : ndarray
+        An image the same shape as ``im`` with the void space partitioned
+        into pores using a marker based watershed with the peaks found by
+        the SNOW algorithm [1].
 
     References
     ----------
@@ -1904,20 +1917,21 @@ def pad(im, pad_width=1, constant_value=0):
     r"""
     Pad the image with a constant values and width.
 
-    Parameters:
+    Parameters
     ----------
-    im : ND-array
+    im : ndarray
         The image that requires padding
     pad_width : int
-        The number of values that will be padded from the edges. Default values
-        is 1.
+        The number of values that will be padded from the edges. Default
+        values is 1.
     contant_value : int
         Pads with the specified constant value
 
-    return:
+    Returns
     -------
-    output: ND-array
+    output: ndarray
         Padded image with same dimnesions as provided image
+
     """
     shape = np.array(im.shape)
     pad_shape = shape + (2 * pad_width)
@@ -1937,26 +1951,26 @@ def pad(im, pad_width=1, constant_value=0):
     return temp
 
 
-def relabel_chunks(im, chunk_shape):  # pragma: no cover
+def relabel_chunks(im, chunk_shape):
     r"""
     Assign new labels to each chunk or sub-domain of actual image. This
     prevents from two or more regions to have same label.
 
-    Parameters:
-    -----------
-
-    im: ND-array
-        Actual image that contains repeating labels in chunks or sub-domains
+    Parameters
+    ----------
+    im: ndarray
+        Actual image that contains repeating labels in chunks/sub-domains.
 
     chunk_shape: tuple
-        The shape of chunk that will be relabeled in actual image. Note the
-        chunk shape should be a multiple of actual image shape otherwise some
-        labels will not be relabeled.
+        The shape of chunk that will be relabeled in actual image. Note
+        the chunk shape should be a multiple of actual image shape
+        otherwise some labels will not be relabeled.
 
-    return:
+    Returns
     -------
-    output : ND-array
+    output : ndarray
         Relabeled image with unique label assigned to each region.
+
     """
     im = pad(im, pad_width=1)
     im_shape = np.array(im.shape, dtype=np.uint32)
@@ -1991,10 +2005,10 @@ def relabel_chunks(im, chunk_shape):  # pragma: no cover
     return im
 
 
-def _trim_internal_slice(im, chunk_shape):  # pragma: no cover
+def _trim_internal_slice(im, chunk_shape):
     r"""
-    Delete extra slices from image that were used to stitch two or more chunks
-    together.
+    Delete extra slices from image that were used to stitch two or more
+    chunks together.
 
     Parameters:
     -----------
@@ -2006,9 +2020,10 @@ def _trim_internal_slice(im, chunk_shape):  # pragma: no cover
 
     Return:
     -------
-    output :  ND-array
-        Image without extra internal slices. The shape of the image will be
-        same as input image provided for waterhsed segmentation.
+    output : ndarray
+        Image without extra internal slices. The shape of the image will
+        be same as input image provided for waterhsed segmentation.
+
     """
     im_shape = np.array(im.shape, dtype=np.uint32)
     c1 = np.array(chunk_shape, dtype=np.uint32) + 2
@@ -2043,25 +2058,25 @@ def _trim_internal_slice(im, chunk_shape):  # pragma: no cover
 def _watershed_stitching(im, chunk_shape):
     r"""
     Stitch individual sub-domains of watershed segmentation into one big
-    segmentation with all boundary labels of each sub-domain relabeled to merge
-    boundary regions.
+    segmentation with all boundary labels of each sub-domain relabeled to
+    merge boundary regions.
 
     Parameters:
     -----------
-    im : ND-array
-        A worked image with watershed segmentation performed on all sub-domains
-        individually.
+    im : ndarray
+        A worked image with watershed segmentation performed on all
+        sub-domains individually.
 
     chunk_shape: tuple
-        The shape of the sub-domain in which image segmentation is performed.
+        The shape of the sub-domain in which segmentation is performed.
 
-    return:
+    Returns
     -------
-    output : ND-array
-        Stitched watershed segmentation with all sub-domains merged to form a
-        single watershed segmentation.
-    """
+    output : ndarray
+        Stitched watershed segmentation with all sub-domains merged to
+        form a single watershed segmentation.
 
+    """
     c_shape = np.array(chunk_shape)
     cuts_num = (np.array(im.shape) / c_shape).astype(np.uint32)
 
@@ -2093,22 +2108,23 @@ def _watershed_stitching(im, chunk_shape):
 
 
 @njit(parallel=True)
-def _copy(im, output):  # pragma: no cover
+def _copy(im, output):
     r"""
-    The function copy the input array and make output array that is allocated
-    in different memory space. This a numba version of copy function of numpy.
-    Because each element is copied using parallel approach this implementation
-    is faster than numpy version of copy.
+    The function copy the input array and make output array that is
+    allocated in different memory space. This a numba version of copy
+    function of numpy. Because each element is copied using parallel
+    approach this implementation is faster than numpy version of copy.
 
-    parameter:
+    Parameters
     ----------
-    array: ND-array
-        Array that needs to be copied
+    array: ndarray
+        Array that needs to be copied.
 
-    Return:
+    Returns
     -------
-    output: ND-array
-        Copied array
+    output: ndarray
+        Copied array.
+
     """
 
     if im.ndim == 3:
@@ -2128,24 +2144,26 @@ def _copy(im, output):  # pragma: no cover
 
 
 @njit(parallel=True)
-def _replace(array, keys, values, ind_sort):  # pragma: no cover
+def _replace(array, keys, values, ind_sort):
     r"""
-    This function replace keys elements in input array with new value elements.
-    This function is used as internal function of replace_relabels.
+    This function replace keys elements in input array with new value
+    elements. This function is used as internal function of
+    replace_relabels.
 
-    Parameter:
+    Parameters
     ----------
-    array : ND-array
-        Array which requires replacing labels
-    keys :  1D-array
-        The unique labels that need to be replaced
-    values : 1D-array
-        The unique values that will be assigned to labels
+    array : ndarray
+        Array which requires replacing labels.
+    keys :  ndarray
+        1d array containing unique labels that need to be replaced.
+    values : ndarray
+        1d array containing unique values that will be assigned to labels.
 
-    return:
+    Returns
     -------
-    array : ND-array
+    array : ndarray
         Array with replaced labels.
+
     """
     # ind_sort = np.argsort(keys)
     keys_sorted = keys[ind_sort]
@@ -2187,27 +2205,31 @@ def _replace_labels(array, keys, values):
 
 
 @njit()
-def _sequence(array, count):  # pragma: no cover
+def _sequence(array, count):
     r"""
-    Internal function of resequnce_labels method. This function resquence array
-    elements in an ascending order using numba technique which is many folds
-    faster than make contigious funcition.
+    Internal function of resequnce_labels method. This function resquence
+    array elements in an ascending order using numba technique which is
+    many folds faster than make contigious funcition.
 
-    parameter:
+    Parameters
     ----------
-    array: 1d-array
-        1d-array that needs resquencing
-    count: 1d-array
-        1d-array of zeros having same size as array
+    array: ndarray
+        1d array that needs resquencing.
+    count: ndarray
+        1d array of zeros having same size as array.
 
-    return:
+    Returns
     -------
     array: 1d-array
         The input array with elements resequenced in ascending order
-    Note: The output of this function is not same as make_contigous or
-    relabel_sequential function of scikit-image. This function resequence and
-    randomize the regions while other methods only do resequencing and output
-    sorted array.
+
+    Notes
+    -----
+    The output of this function is not same as make_contigous or
+    relabel_sequential function of scikit-image. This function resequence
+    and randomize the regions while other methods only do resequencing and
+    output sorted array.
+
     """
     a = 1
     i = 0
@@ -2222,20 +2244,21 @@ def _sequence(array, count):  # pragma: no cover
 
 
 @njit(parallel=True)
-def _amax(array):  # pragma: no cover
+def _amax(array):
     r"""
-    Find largest element in an array using fast parallel numba technique
+    Find largest element in an array using fast parallel numba technique.
 
     Parameter:
     ----------
-    array: ND-array
-        array in which largest elements needs to be calcuted
+    array: ndarray
+        Array in which largest elements needs to be calcuted.
 
-    return:
+    Returns
+    -------
     scalar: float or int
-        The largest element value in the input array
-    """
+        The largest element value in the input array.
 
+    """
     return np.max(array)
 
 
@@ -2243,15 +2266,16 @@ def _resequence_labels(array):
     r"""
     Resequence the lablels to make them contigious.
 
-    Parameter:
+    Parameters
     ----------
-    array: ND-array
-        Array that requires resequencing
+    array: ndarray
+        Array that requires resequencing.
 
-    return:
+    Returns
     -------
-    array : ND-array
-        Resequenced array with same shape as input array
+    array : ndarray
+        Resequenced array with same shape as input array.
+
     """
     a_shape = array.shape
     array = array.ravel()

--- a/test/unit/test_generators.py
+++ b/test/unit/test_generators.py
@@ -1,10 +1,9 @@
-import porespy as ps
-import numpy as np
 import pytest
+import numpy as np
+from numpy.testing import assert_allclose
 import scipy.ndimage as spim
 import scipy.stats as spst
-import matplotlib.pyplot as plt
-plt.close('all')
+import porespy as ps
 
 
 class GeneratorTest():
@@ -310,8 +309,8 @@ class GeneratorTest():
     def test_pseudo_electrostatic_packing(self):
         im1 = ps.generators.blobs(shape=[100, 100])
         im2 = ps.generators.pseudo_electrostatic_packing(im=im1, r=3,
-                                                         clearance=1,
-                                                         protrusion=1)
+                                                          clearance=1,
+                                                          protrusion=1)
         assert (im1.sum() > im2.sum())
         assert im2.sum() > 0
 
@@ -321,6 +320,14 @@ class GeneratorTest():
         im = ps.generators.pseudo_electrostatic_packing(
             im=im, r=3, clearance=1, protrusion=1)
         np.testing.assert_allclose(np.linalg.norm(im), 46.2276, rtol=1e-5)
+
+    def test_insert_disk_at_points(self):
+        from porespy.generators.__gravity__ import insert_disks_at_points
+        im = np.ones((50, 50))
+        coords = np.array([[15, 25], [35, 25]]).T
+        radii = np.array([5, 6])
+        im = insert_disks_at_points(im, coords, radii=radii, v=10)
+        assert_allclose(np.linalg.norm(im), 141.852036)
 
 
 if __name__ == '__main__':

--- a/test/unit/test_generators.py
+++ b/test/unit/test_generators.py
@@ -306,28 +306,36 @@ class GeneratorTest():
         e4 = im.sum()/im.size
         assert e4 > e3
 
+    def test_pseudo_gravity_packing_values(self):
+        np.random.seed(0)
+        # 2d
+        im = np.ones([50, 50], dtype=bool)
+        im = ps.generators.pseudo_gravity_packing(im=im, r=5, clearance=0)
+        assert_allclose(np.linalg.norm(im), 37.3497, rtol=1e-5)
+        # 3d
+        im = np.ones([50, 50, 50], dtype=bool)
+        im = ps.generators.pseudo_gravity_packing(im=im, r=5, clearance=0)
+        assert_allclose(np.linalg.norm(im), 218.3804, rtol=1e-5)
+
     def test_pseudo_electrostatic_packing(self):
         im1 = ps.generators.blobs(shape=[100, 100])
-        im2 = ps.generators.pseudo_electrostatic_packing(im=im1, r=3,
-                                                          clearance=1,
-                                                          protrusion=1)
+        im2 = ps.generators.pseudo_electrostatic_packing(
+            im=im1, r=3, clearance=1, protrusion=1)
         assert (im1.sum() > im2.sum())
         assert im2.sum() > 0
 
-    def test_pseudo_electrostatic_packing_vals(self):
+    def test_pseudo_electrostatic_packing_values(self):
         np.random.seed(0)
+        # 2d
         im = ps.generators.blobs(shape=[100, 100])
         im = ps.generators.pseudo_electrostatic_packing(
             im=im, r=3, clearance=1, protrusion=1)
-        np.testing.assert_allclose(np.linalg.norm(im), 46.2276, rtol=1e-5)
-
-    def test_insert_disk_at_points(self):
-        from porespy.generators.__gravity__ import insert_disks_at_points
-        im = np.ones((50, 50))
-        coords = np.array([[15, 25], [35, 25]]).T
-        radii = np.array([5, 6])
-        im = insert_disks_at_points(im, coords, radii=radii, v=10)
-        assert_allclose(np.linalg.norm(im), 141.852036)
+        assert_allclose(np.linalg.norm(im), 46.2276, rtol=1e-5)
+        # 3d
+        im = ps.generators.blobs(shape=[50, 50, 50])
+        im = ps.generators.pseudo_electrostatic_packing(
+            im=im, r=3, clearance=1, protrusion=1)
+        assert_allclose(np.linalg.norm(im), 135.3403, rtol=1e-5)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Basically, we need to run Ubuntu CI, which deploys to codecov, in "no-jit" mode by setting the environment variable `NUMBA_DISABLE_JIT=1`.