### PR TITLE
Expose resequence labels

### DIFF
--- a/porespy/filters/_snows.py
+++ b/porespy/filters/_snows.py
@@ -9,8 +9,8 @@ from collections import namedtuple
 from skimage.segmentation import watershed
 from skimage.morphology import ball, disk, square, cube
 from porespy.tools import _check_for_singleton_axes
-from porespy.tools import extend_slice
-from porespy.filters import chunked_func, resequence_labels
+from porespy.tools import extend_slice, resequence_labels
+from porespy.filters import chunked_func
 from porespy import settings
 from loguru import logger
 

--- a/porespy/networks/_funcs.py
+++ b/porespy/networks/_funcs.py
@@ -3,7 +3,7 @@ import openpnm as op
 import scipy.ndimage as spim
 from skimage.segmentation import find_boundaries
 from skimage.morphology import ball, cube, disk, square
-from porespy.tools import make_contiguous
+from porespy.tools import resequence_labels
 from porespy.tools import overlay
 from porespy.tools import insert_cylinder
 from porespy.generators import borders
@@ -99,7 +99,7 @@ def add_boundary_regions(regions, pad_width=3):
     # Trim image down to user specified size
     s = tuple([slice(t-ax[0], -(t-ax[1]) or None) for ax in faces])
     new_regions = new_regions[s]
-    new_regions = make_contiguous(new_regions)
+    new_regions = resequence_labels(new_regions)
     return new_regions
 
 

--- a/porespy/networks/_getnet.py
+++ b/porespy/networks/_getnet.py
@@ -4,7 +4,7 @@ from skimage.morphology import disk, ball
 from edt import edt
 from porespy.tools import extend_slice
 from porespy import settings
-from porespy.tools import get_tqdm, make_contiguous
+from porespy.tools import get_tqdm, resequence_labels
 from porespy.metrics import region_surface_areas, region_interface_areas
 from porespy.metrics import region_volumes, throat_perimeter
 from loguru import logger
@@ -97,7 +97,7 @@ def regions_to_network(regions, phases=None, voxel_size=1, accuracy='standard'):
     """
     logger.trace('Extracting pore/throat information')
 
-    im = make_contiguous(regions)
+    im = resequence_labels(regions)
     struc_elem = disk if im.ndim == 2 else ball
     voxel_size = float(voxel_size)
     if phases is None:

--- a/porespy/tools/__init__.py
+++ b/porespy/tools/__init__.py
@@ -39,6 +39,7 @@ ways do NOT return a modified version of the original image.
    tools.ps_round
    tools.randomize_colors
    tools.recombine
+   tools.resequence_labels
    tools.subdivide
    tools.unpad
 
@@ -69,6 +70,7 @@ __all__ = [
     "ps_round",
     "randomize_colors",
     "recombine",
+    "resequence_labels",
     "subdivide",
     "unpad",
     "sanitize_filename",
@@ -95,6 +97,7 @@ from ._funcs import norm_to_uniform
 from ._funcs import overlay
 from ._funcs import randomize_colors
 from ._funcs import recombine
+from ._funcs import resequence_labels
 from ._funcs import ps_ball
 from ._funcs import ps_disk
 from ._funcs import ps_rect


### PR DESCRIPTION
The make_contiguous function was SUPER slow, so we moved to using the skimage 'rankdata' function, but this seem to use a lot of memory, so this PR exposes a previously hidden function called resequence_labels that @Zohaib-Atiq wrote for his parallelization project.  It's numba jitted, and parallelized.  It does not have the fully functionality of the make_contiguous function, so let's hope it works.