### PR TITLE
Make pyfastnoisesimd optional for conda-forge builds to work

### DIFF
--- a/porespy/generators/_noise.py
+++ b/porespy/generators/_noise.py
@@ -73,7 +73,11 @@ def fractal_noise(shape, frequency=0.05, octaves=4, gain=0.5, mode='simplex',
     `here <https://github.com/jobtalle/CubicNoise>`__.
 
     """
-    from pyfastnoisesimd import Noise, NoiseType, PerturbType
+    try:
+        from pyfastnoisesimd import Noise, NoiseType, PerturbType
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError("You need to install `pyfastnoisesimd` using"
+                                  " `pip install pyfastnoisesimd`")
     if cores is None:
         cores = multiprocessing.cpu_count()
     if seed is None:

--- a/porespy/generators/_noise.py
+++ b/porespy/generators/_noise.py
@@ -1,4 +1,3 @@
-import pyfastnoisesimd as fns
 import multiprocessing
 import numpy as np
 from porespy.tools import norm_to_uniform
@@ -74,24 +73,18 @@ def fractal_noise(shape, frequency=0.05, octaves=4, gain=0.5, mode='simplex',
     `here <https://github.com/jobtalle/CubicNoise>`__.
 
     """
+    from pyfastnoisesimd import Noise, NoiseType, PerturbType
     if cores is None:
         cores = multiprocessing.cpu_count()
     if seed is None:
         seed = np.random.randint(2**31)
-    perlin = fns.Noise(numWorkers=cores)
-    if mode == 'simplex':
-        perlin.noiseType = fns.NoiseType.SimplexFractal
-    elif mode == 'perlin':
-        perlin.noiseType = fns.NoiseType.PerlinFractal
-    elif mode == 'cubic':
-        perlin.noiseType = fns.NoiseType.CubicFractal
-    elif mode == 'value':
-        perlin.noiseType = fns.NoiseType.ValueFractal
+    perlin = Noise(numWorkers=cores)
+    perlin.noiseType = getattr(NoiseType, f'{mode.capitalize()}Fractal')
     perlin.frequency = frequency
     perlin.fractal.octaves = octaves
     perlin.fractal.gain = gain
     perlin.fractal.lacunarity = 2
-    perlin.perturb.perturbType = fns.PerturbType.NoPerturb
+    perlin.perturb.perturbType = PerturbType.NoPerturb
     perlin.seed = seed
     result = perlin.genAsGrid(shape)
     if uniform:

--- a/test/unit/test_generators.py
+++ b/test/unit/test_generators.py
@@ -349,7 +349,7 @@ class GeneratorTest():
         with pytest.raises(Exception):
             ps.generators.faces(shape=[10, 10, 10])
 
-    def test_fractal_noise_2D(self):
+    def test_fractal_noise_2d(self):
         s = [100, 100]
         # Ensure identical images are returned if seed is same
         im1 = ps.generators.fractal_noise(shape=s, seed=0, cores=1)


### PR DESCRIPTION
Basicaly, `pyfastnoisesimd` isn't on `conda-forge`, so can't be installed. The only way is to make it optional, so unless the user calls the `fractal_noise` function, `porespy` doesn't complain.