### PR TITLE
Fix memory leak in dns.tortuosity

### DIFF
--- a/porespy/dns/_funcs.py
+++ b/porespy/dns/_funcs.py
@@ -5,10 +5,12 @@ from porespy.tools import Results
 from loguru import logger
 from porespy.generators import faces
 
+ws = op.Workspace()
+
 
 def tortuosity(im, axis):
     r"""
-    Calculate the tortuosity of image in the specified direction
+    Calculates the tortuosity of image in the specified direction.
 
     Parameters
     ----------
@@ -46,51 +48,54 @@ def tortuosity(im, axis):
 
     # Obtain original porosity
     eps0 = im.sum() / im.size
-    # removing floating pores
-    IN = faces(im.shape, inlet=axis)
-    OUT = faces(im.shape, outlet=axis)
-    im = trim_nonpercolating_paths(im, inlets=IN, outlets=OUT)
-    # porosity is changed because of trimmimg floating pores
+    # Remove floating pores
+    inlets = faces(im.shape, inlet=axis)
+    outlets = faces(im.shape, outlet=axis)
+    im = trim_nonpercolating_paths(im, inlets=inlets, outlets=outlets)
+    # Check if prosity is changed after trimmimg floating pores
     eps = im.sum() / im.size
     if eps < eps0:  # pragma: no cover
         logger.warning(f'True porosity is {eps:.2f}, filled {eps0 - eps:.5f}'
                        ' volume fraction of the image for it to percolate.')
-    # cubic network generation
-    net = op.network.CubicTemplate(template=im, spacing=1)
-    # Adding phase
-    water = op.phases.Water(network=net)
-    water['throat.diffusive_conductance'] = 1  # dummy value
-    # Running Fickian Diffusion
-    fd = op.algorithms.FickianDiffusion(network=net, phase=water)
-    # Choosing axis of concentration gradient
-    inlets = net['pore.coords'][:, axis] <= 1
-    outlets = net['pore.coords'][:, axis] >= im.shape[axis]-1
+
+    # Generate a Cubic network to be used as an orthogonal grid
+    net = op.network.CubicTemplate(template=im, spacing=1.0)
+    # Create a dummy phase
+    phase = op.phases.GenericPhase(network=net)
+    phase['throat.diffusive_conductance'] = 1.0
+    # Run Fickian Diffusion on the image
+    fd = op.algorithms.FickianDiffusion(network=net, phase=phase)
+    # Choose axis of concentration gradient
+    inlets = net.coords[:, axis] <= 1
+    outlets = net.coords[:, axis] >= im.shape[axis] - 1
     # Boundary conditions on concentration
-    C_in = 1.0
-    C_out = 0.0
-    fd.set_value_BC(pores=inlets, values=C_in)
-    fd.set_value_BC(pores=outlets, values=C_out)
-    fd.settings['solver_family'] = 'scipy'
-    fd.settings['solver_type'] = 'cg'
+    cL, cR = 1.0, 0.0
+    fd.set_value_BC(pores=inlets, values=cL)
+    fd.set_value_BC(pores=outlets, values=cR)
+    fd.settings.update({'solver_family': 'scipy', 'solver_type': 'cg'})
     fd.run()
-    # Calculating molar flow rate, effective diffusivity and tortuosity
-    rate_out = fd.rate(pores=outlets)[0]
+    # Calculate molar flow rate, effective diffusivity and tortuosity
     rate_in = fd.rate(pores=inlets)[0]
+    rate_out = fd.rate(pores=outlets)[0]
     if not np.allclose(-rate_out, rate_in):  # pragma: no cover
-        raise Exception('Something went wrong, inlet and outlet rate do not match')
-    delta_C = C_in - C_out
+        raise Exception('Something went wrong, inlet and outlet rates do not match!')
+    dC = cL - cR
     L = im.shape[axis]
     A = np.prod(im.shape) / L
-    N_A = A / (L-1) * delta_C  # -1 because BCs are put inside domain, see #495
-    Deff = rate_in / N_A
+    # L-1 because BCs are put inside the domain, see issue #495
+    Deff = rate_in * (L-1)/A / dC
     tau = eps / Deff
+
     result = Results()
     result.tortuosity = tau
     result.formation_factor = 1 / Deff
     result.original_porosity = eps0
     result.effective_porosity = eps
-    conc = np.zeros([im.size, ], dtype=float)
+    conc = np.zeros(im.size, dtype=float)
     conc[net['pore.template_indices']] = fd['pore.concentration']
-    conc = np.reshape(conc, newshape=im.shape)
-    result.concentration = conc
+    result.concentration = conc.reshape(im.shape)
+
+    # Free memory
+    ws.close_project(net.project)
+
     return result


### PR DESCRIPTION
Every time `dns.tortuosity` is called, a bunch of `openpnm` objects are created, which are not freed. This could become problematic if one tries to invoke `tortuosity` many times on relatively large images.