### PR TITLE
Drop python 3.6 and 3.7 support per NEP29

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
 
     - name: Set env variables
       run: |

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: '3.8'
 
     - name: Set env variables
       run: |

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.8]
-        operating-system: [macos-latest]
+        python-version: '3.8'
+        operating-system: macos-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: '3.8'
-        operating-system: macos-latest
+        python-version: ['3.8']
+        operating-system: [macos-latest]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-min.yml
+++ b/.github/workflows/ci-min.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        python-version: '3.8'
-        operating-system: ubuntu-latest
+        python-version: ['3.8']
+        operating-system: [ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-min.yml
+++ b/.github/workflows/ci-min.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        python-version: [3.8]
-        operating-system: [ubuntu-latest]
+        python-version: '3.8'
+        operating-system: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
         operating-system: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -16,7 +16,8 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        # Add '3.10' to the list once #611 is addressed
+        python-version: ['3.8', '3.9']
         operating-system: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.8, 3.9, 3.10]
+        python-version: ['3.8', '3.9', '3.10']
         operating-system: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10]
         operating-system: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.8]
-        operating-system: [windows-latest]
+        python-version: '3.8'
+        operating-system: windows-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: '3.8'
+        python-version: ['3.8']
         operating-system: windows-latest
 
     steps:

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -17,7 +17,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: ['3.8']
-        operating-system: windows-latest
+        operating-system: [windows-latest]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -16,8 +16,8 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: [3.8]
-        operating-system: [ubuntu-latest]
+        python-version: '3.8'
+        operating-system: ubuntu-latest
         # Next line should be [1, 2, ..., max-parallel)
         test_group: [1, 2, 3, 4, 5]
 

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -16,8 +16,8 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: '3.8'
-        operating-system: ubuntu-latest
+        python-version: ['3.8']
+        operating-system: [ubuntu-latest]
         # Next line should be [1, 2, ..., max-parallel)
         test_group: [1, 2, 3, 4, 5]
 

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
 
     - name: Set env variables
       run: |

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: ['3.8']
 
     - name: Set env variables
       run: |

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: '3.8'
 
     - name: Set env variables
       run: |

--- a/.github/workflows/test-duration-logger.yml
+++ b/.github/workflows/test-duration-logger.yml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        python-version: '3.8'
-        operating-system: ubuntu-latest
+        python-version: ['3.8']
+        operating-system: [ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test-duration-logger.yml
+++ b/.github/workflows/test-duration-logger.yml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        python-version: [3.8]
-        operating-system: [ubuntu-latest]
+        python-version: '3.8'
+        operating-system: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/verify-pip-installation.yml
+++ b/.github/workflows/verify-pip-installation.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: '3.8'
 
     - name: Set branch name as env variable
       run: |

--- a/.github/workflows/verify-pip-installation.yml
+++ b/.github/workflows/verify-pip-installation.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: ['3.8']
 
     - name: Set branch name as env variable
       run: |

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -2,6 +2,6 @@
 
 `PoreSpy` uses [Semantic Versioning](http://semver.org) (i.e. X.Y.Z) to label releases.  All versions of `PoreSpy` since "0.3.4" are available on [PyPI](https://pypi.python.org/pypi).  Prior to this, only major and minor version were pushed.
 
-All development occurs on `dev` via feature branches and the pull request functionality of Github. A new release is defined each time the `dev` branch is merged into the `release` branch. Several automations are setup so that upon each release, the code is automatically deployed to PyPi and Conda, and a release announcement is created on Github containing a summary of all the changes. 
+All development occurs on `dev` via feature branches and the pull request functionality of Github. A new release is defined each time the `dev` branch is merged into the `release` branch. Several automations are setup so that upon each release, the code is automatically deployed to PyPi and Conda, and a release announcement is created on Github containing a summary of all the changes.
 
-`PoreSpy` depends on several other packages widely known as the [Scipy Stack](https://www.scipy.org/stackspec.html).  It is our policy to always support the latest version of all these packages and their dependencies.
+`PoreSpy` depends on other packages including [Scipy](https://scipy.org/) and its dependencies.  It is our policy to always support the latest version of all these packages and their dependencies.

--- a/bin/README.rst
+++ b/bin/README.rst
@@ -79,7 +79,7 @@ Installation
 PoreSpy depends heavily on the Scipy Stack.  The best way to get a fully
 functional environment is the
 `Anaconda distribution <https://www.anaconda.com/download/>`_.
-Be sure to get the **Python 3.7+ version**.
+Be sure to get the **Python 3.8+ version**.
 
 
 Once you've installed *Conda*, you can then install PoreSpy.  It is available

--- a/bin/README.rst
+++ b/bin/README.rst
@@ -79,7 +79,7 @@ Installation
 PoreSpy depends heavily on the Scipy Stack.  The best way to get a fully
 functional environment is the
 `Anaconda distribution <https://www.anaconda.com/download/>`_.
-Be sure to get the **Python 3.6+ version**.
+Be sure to get the **Python 3.7+ version**.
 
 
 Once you've installed *Conda*, you can then install PoreSpy.  It is available

--- a/bin/README.rst
+++ b/bin/README.rst
@@ -76,7 +76,7 @@ PoreSpy consists of the following modules:
 Installation
 -------------------------------------------------------------------------------
 
-PoreSpy depends heavily on the Scipy Stack.  The best way to get a fully
+PoreSpy depends heavily on Scipy and its dependencies.  The best way to get a fully
 functional environment is the
 `Anaconda distribution <https://www.anaconda.com/download/>`_.
 Be sure to get the **Python 3.8+ version**.

--- a/docs/user_guide/installation.rst
+++ b/docs/user_guide/installation.rst
@@ -4,7 +4,7 @@
 Installation
 ############
 
-PoreSpy depends heavily on the SciPy Stack. The best way to get a fully
+PoreSpy depends heavily on SciPy and its dependencies. The best way to get a fully
 functional environment is the `Anaconda
 distribution <https://www.anaconda.com/products/individual#Downloads>`__. Be sure to get the
 **Python 3.8+ version**.

--- a/docs/user_guide/installation.rst
+++ b/docs/user_guide/installation.rst
@@ -7,12 +7,12 @@ Installation
 PoreSpy depends heavily on the SciPy Stack. The best way to get a fully
 functional environment is the `Anaconda
 distribution <https://www.anaconda.com/products/individual#Downloads>`__. Be sure to get the
-**Python 3.7+ version**.
+**Python 3.8+ version**.
 
 Once you've installed *Anaconda* you can then install ``porespy``. It is
 available on `conda-forge <https://anaconda.org/conda-forge/porespy>`__
 and can be installed by typing the following at the *conda* prompt::
- 
+
    $ conda install -c conda-forge porespy
 
 It's possible to use ``pip install porespy``, but this will not result
@@ -83,7 +83,7 @@ All the commands in this page need to be typed in the ``conda`` prompt.
    Anaconda program group in the start menu. This will open a Windows
    command console with access to the Python features added by *conda*,
    such as installing things via ``conda``.
-   
+
 .. tabbed:: Mac and Linux
 
    On Mac or Linux, you need to open a normal terminal window, then type

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ max-line-length = 90
 max-violations-per-file = 0
 
 [options]
-python_requires = >= 3.6
+python_requires = >= 3.7
 
 [metadata]
 license_file = LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ max-line-length = 90
 max-violations-per-file = 0
 
 [options]
-python_requires = >= 3.7
+python_requires = >= 3.8
 
 [metadata]
 license_file = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Topic :: Scientific/Engineering',


### PR DESCRIPTION
The dataclasses module was introduced in Python 3.7 (see https://docs.python.org/3/library/dataclasses.html) and therefore not available to use in Python 3.6. The dataclasses module began to be used in `porespy` starting in https://github.com/PMEAL/porespy/commit/4630768d1160e9db5dcfcd2e40c754b1e6509863.

Python 3.6 has also gone end-of-life as of today (https://endoflife.date/python) which is a reason not to make changes to continue to use this codebase on Python 3.6.

This change to drop Python 3.6 support matches what the classifiers are already indicating for this repo. 
https://github.com/PMEAL/porespy/blob/ec9791e63db6e6a1281e364f4d2ea5d3796f70c9/setup.py#L34-L39

I will warn that because `porespy` has quite a large number of dependencies, that not specifying some version limits on dependencies can lead to this package becoming broken once the first dependency decides it is time to drop some Python version. For example `numpy` 1.22.0 will be releasing soon (currently at [1.22.0rc03](https://github.com/numpy/numpy/releases/tag/v1.22.0rc3)) and it is dropping Python 3.7 support per [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html). Therefore `porespy` will need to become documented as Python >= 3.8 as well.