### PR TITLE
Enhance `tortuosity_fd` usability and performance

### DIFF
--- a/porespy/simulations/_dns.py
+++ b/porespy/simulations/_dns.py
@@ -11,7 +11,7 @@ ws = op.Workspace()
 __all__ = ['tortuosity_fd']
 
 
-def tortuosity_fd(im, axis):
+def tortuosity_fd(im, axis, solver=None):
     r"""
     Calculates the tortuosity of image in the specified direction.
 
@@ -54,6 +54,7 @@ def tortuosity_fd(im, axis):
     """
     if axis > (im.ndim - 1):
         raise Exception(f"'axis' must be <= {im.ndim}")
+    openpnm_v3 = op.__version__.startswith('3')
 
     # Obtain original porosity
     eps0 = im.sum() / im.size
@@ -65,16 +66,14 @@ def tortuosity_fd(im, axis):
     # Check if porosity is changed after trimmimg floating pores
     eps = im.sum() / im.size
     if eps < eps0:  # pragma: no cover
-        logger.warning(f'True porosity is {eps:.2f}, filled {eps0 - eps:.5f}'
-                       ' volume fraction of the image for it to percolate.')
+        logger.warning(f'Found non-percolating regions, were filled to percolate')
 
     # Generate a Cubic network to be used as an orthogonal grid
     net = op.network.CubicTemplate(template=im, spacing=1.0)
-    # Create a dummy phase, FIXME: once openpnm v3 is out, remove try/except
-    try:
-        phase = op.phases.GenericPhase(network=net)
-    except AttributeError:
+    if openpnm_v3:
         phase = op.phase.Phase(network=net)
+    else:
+        phase = op.phases.GenericPhase(network=net)
     phase['throat.diffusive_conductance'] = 1.0
     # Run Fickian Diffusion on the image
     fd = op.algorithms.FickianDiffusion(network=net, phase=phase)
@@ -85,24 +84,27 @@ def tortuosity_fd(im, axis):
     cL, cR = 1.0, 0.0
     fd.set_value_BC(pores=inlets, values=cL)
     fd.set_value_BC(pores=outlets, values=cR)
-    # FIXME: get rid of try/except once openpnm v3 is out
-    try:
-        pardiso = op.solvers.PardisoSpsolve()
-        fd.run(solver=pardiso, verbose=False)
-    except AttributeError:
+    if openpnm_v3:
+        if solver is None:
+            solver = op.solvers.PyamgRugeStubenSolver(tol=1e-8)
+        fd._update_A_and_b()
+        fd.x, info = solver.solve(fd.A.tocsr(), fd.b)
+        if info:
+            raise Exception(f'Solver failed to converge, exit code: {info}')
+    else:
         fd.settings.update({'solver_family': 'scipy', 'solver_type': 'cg'})
         fd.run()
 
     # Calculate molar flow rate, effective diffusivity and tortuosity
-    rate_in = fd.rate(pores=inlets)[0]
-    rate_out = fd.rate(pores=outlets)[0]
-    if not np.allclose(-rate_out, rate_in):  # pragma: no cover
-        raise Exception('Something went wrong, inlet and outlet rates do not match!')
+    r_in = fd.rate(pores=inlets)[0]
+    r_out = fd.rate(pores=outlets)[0]
+    if not np.allclose(-r_out, r_in, rtol=1e-4):  # pragma: no cover
+        logger.error(f"Inlet/outlet rates don't match: {r_in:.4e} vs. {r_out:.4e}")
     dC = cL - cR
     L = im.shape[axis]
     A = np.prod(im.shape) / L
     # L-1 because BCs are put inside the domain, see issue #495
-    Deff = rate_in * (L-1)/A / dC
+    Deff = r_in * (L-1)/A / dC
     tau = eps / Deff
 
     # Attach useful parameters to Results object

--- a/test/unit/test_dns.py
+++ b/test/unit/test_dns.py
@@ -1,38 +1,32 @@
-import porespy as ps
 import numpy as np
-import pytest
+import openpnm as op
+import porespy as ps
 ps.settings.tqdm['disable'] = True
 
 
 class DNSTest():
 
-    def setup_class(self):
-        np.random.seed(10)
-
     def test_tortuosity_2D_lattice_spheres(self):
-        im = ps.generators.lattice_spheres(shape=[200, 200],
-                                           r=8, spacing=26)
-        t = ps.dns.tortuosity(im=im, axis=1)
-        assert np.around(t.tortuosity, decimals=6) == 1.359947
+        im = ps.generators.lattice_spheres(shape=[200, 200], r=8, spacing=26)
+        t = ps.simulations.tortuosity_fd(im=im, axis=1)
+        np.testing.assert_allclose(t.tortuosity, 1.35995, rtol=1e-5)
 
     def test_tortuosity_open_space(self):
         im = np.ones([100, 100])
-        t = ps.dns.tortuosity(im=im, axis=0)
-        assert np.around(t.tortuosity, decimals=6) == 1.0
+        t = ps.simulations.tortuosity_fd(im=im, axis=0)
+        np.testing.assert_allclose(t.tortuosity, 1.0, rtol=1e-5)
 
     def test_tortuosity_different_solvers(self):
-        im = ps.generators.lattice_spheres(shape=[200, 200],
-                                           r=8, spacing=26)
-        t = ps.dns.tortuosity(im=im, axis=1)
-        a = 1.359947
-        assert np.around(t.tortuosity, decimals=6) == a
+        im = ps.generators.lattice_spheres(shape=[200, 200], r=8, spacing=26)
+        solver = op.solvers.PardisoSpsolve()
+        t = ps.simulations.tortuosity_fd(im=im, axis=1)
+        np.testing.assert_allclose(t.tortuosity, 1.35995, rtol=1e-4)
 
 
 if __name__ == '__main__':
     t = DNSTest()
     self = t
-    t.setup_class()
     for item in t.__dir__():
         if item.startswith('test'):
-            print('running test: '+item)
+            print(f'Running test: {item}')
             t.__getattribute__(item)()


### PR DESCRIPTION
- [x] Change default solver from `pypardiso` to `pyamg` (especially important for >100^3 images)
- [x] Add `solver` to `tortuosity_fd` args (openpnm solver object) for more fine-grained control