### PR TITLE
Fix trap region

### DIFF
--- a/porespy/filters/_funcs.py
+++ b/porespy/filters/_funcs.py
@@ -121,8 +121,8 @@ def find_trapped_regions(seq, outlets=None, bins=25, return_mask=True):
     elif isinstance(bins, int):
         # starting the max_bin at: minimum sequence at outlets
         # This means soon as the fluid reaches the outlets
-        #outlet_seq = np.setdiff1d(seq[outlets], np.array([0]))
-        #bins_start = outlet_seq.min()
+        # outlet_seq = np.setdiff1d(seq[outlets], np.array([0]))
+        # bins_start = outlet_seq.min()
         # starting the max_bin at: maximum sequence available
         # in the image. No matter if it's after percolation
         # threshold (reaching the outlets):

--- a/porespy/filters/_funcs.py
+++ b/porespy/filters/_funcs.py
@@ -123,7 +123,12 @@ def find_trapped_regions(seq, outlets=None, bins=25, return_mask=True):
     for i in tqdm(bins, **settings.tqdm):
         temp = seq >= i
         labels = spim.label(temp)[0]
-        keep = np.unique(labels[outlets])[1:]
+        keep = np.unique(labels[outlets])
+        # In cases where entire outlet is filled, the
+        # first indice is not necessarily the
+        # void space. Only the element with value
+        # of zero needs to be removed, if it's in keep.
+        keep = np.setdiff1d(keep, np.array([0]))
         trapped += temp*np.isin(labels, keep, invert=True)
     if return_mask:
         return trapped

--- a/porespy/filters/_funcs.py
+++ b/porespy/filters/_funcs.py
@@ -119,7 +119,15 @@ def find_trapped_regions(seq, outlets=None, bins=25, return_mask=True):
         bins = np.unique(seq)[-1::-1]
         bins = bins[bins > 0]
     elif isinstance(bins, int):
-        bins = np.linspace(seq.max(), 1, bins)
+        # starting the max_bin at: minimum sequence at outlets
+        # This means soon as the fluid reaches the outlets
+        outlet_seq = np.setdiff1d(seq[outlets], np.array([0]))
+        bins_start = outlet_seq.min()
+        # starting the max_bin at: maximum sequence available
+        # in the image. No matter if it's after percolation
+        # threshold (reaching the outlets):
+        #bins_start = seq.max()
+        bins = np.linspace(bins_start, 1, bins)
     for i in tqdm(bins, **settings.tqdm):
         temp = seq >= i
         labels = spim.label(temp)[0]

--- a/porespy/filters/_funcs.py
+++ b/porespy/filters/_funcs.py
@@ -121,12 +121,12 @@ def find_trapped_regions(seq, outlets=None, bins=25, return_mask=True):
     elif isinstance(bins, int):
         # starting the max_bin at: minimum sequence at outlets
         # This means soon as the fluid reaches the outlets
-        outlet_seq = np.setdiff1d(seq[outlets], np.array([0]))
-        bins_start = outlet_seq.min()
+        #outlet_seq = np.setdiff1d(seq[outlets], np.array([0]))
+        #bins_start = outlet_seq.min()
         # starting the max_bin at: maximum sequence available
         # in the image. No matter if it's after percolation
         # threshold (reaching the outlets):
-        #bins_start = seq.max()
+        bins_start = seq.max()
         bins = np.linspace(bins_start, 1, bins)
     for i in tqdm(bins, **settings.tqdm):
         temp = seq >= i


### PR DESCRIPTION
Here, we updated the "keep" array. The problem occured when the outlet didn't have any pixel with value=0 (solid phase), so the indice of keep[0:] would remove the invaded pixel from the array not the solid phase.
Note: There's possibility of changing the starting point of the max_bin (The code is added but commented for now).
