### PR TITLE
subtracting the throat cross-sectional areas from the pore surface ar…

### DIFF
--- a/porespy/networks/_getnet.py
+++ b/porespy/networks/_getnet.py
@@ -252,6 +252,8 @@ def regions_to_network(regions, phases=None, voxel_size=1, accuracy='standard'):
                                                 voxel_size=voxel_size)
         A = interface_area.area
         net['throat.cross_sectional_area'] = A
+        np.add.at(net['pore.surface_area'],net['throat.conns'][:, 0], -A)
+        np.add.at(net['pore.surface_area'],net['throat.conns'][:, 1], -A)
         net['throat.equivalent_diameter'] = (4*A/np.pi)**(1/2)
     else:
         net['pore.volume'] = np.copy(p_volume)*(voxel_size**ND)


### PR DESCRIPTION
I made a modification to the regions_to_network function to subtract the cross-sectional area of throats from the surface area of pores.

A correct prediction of the solid-fluid area is necessary for mass transfer processes, such as catalysis, heterogeneous reactions, adsorption, among others.