### PR TITLE
Speeding up sphere insertions

### DIFF
--- a/porespy/beta/_drainage2.py
+++ b/porespy/beta/_drainage2.py
@@ -145,7 +145,8 @@ def _insert_disks_npoints_nradii_1value_parallel(
     coords,
     radii,
     v,
-    overwrite=False
+    overwrite=False,
+    smooth=False,
 ):  # pragma: no cover
     if im.ndim == 2:
         xlim, ylim = im.shape
@@ -157,7 +158,7 @@ def _insert_disks_npoints_nradii_1value_parallel(
                     for b, y in enumerate(range(j-r, j+r+1)):
                         if (y >= 0) and (y < ylim):
                             R = ((a - r)**2 + (b - r)**2)**0.5
-                            if R <= r:
+                            if (R <= r)*(~smooth) or (R < r)*(smooth):
                                 if overwrite or (im[x, y] == 0):
                                     im[x, y] = v
     else:
@@ -172,7 +173,7 @@ def _insert_disks_npoints_nradii_1value_parallel(
                             for c, z in enumerate(range(k-r, k+r+1)):
                                 if (z >= 0) and (z < zlim):
                                     R = ((a - r)**2 + (b - r)**2 + (c - r)**2)**0.5
-                                    if R <= r:
+                                    if (R <= r)*(~smooth) or (R < r)*(smooth):
                                         if overwrite or (im[x, y, z] == 0):
                                             im[x, y, z] = v
     return im

--- a/porespy/tools/_sphere_insertions.py
+++ b/porespy/tools/_sphere_insertions.py
@@ -1,5 +1,5 @@
 import numpy as np
-from numba import njit
+from numba import njit, prange
 
 
 __all__ = [
@@ -67,6 +67,60 @@ def _make_balls(r, smooth=True):  # pragma: no cover
 
 
 @njit
+def _insert_disk_at_point(im, coords, r, v,
+                           smooth=True, overwrite=False):  # pragma: no cover
+    r"""
+    Insert spheres (or disks) into the given ND-image at given locations
+
+    This function uses numba to accelerate the process, and does not
+    overwrite any existing values (i.e. only writes to locations containing
+    zeros).
+
+    Parameters
+    ----------
+    im : ND-array
+        The image into which the spheres/disks should be inserted. This is an
+        'in-place' operation.
+    coords : ND-array
+        The center point of the sphere/disk
+    r : int
+        The radius of all the spheres/disks to add. It is assumed that they
+        are all the same radius.
+    v : scalar
+        The value to insert
+    smooth : boolean
+        If ``True`` (default) then the spheres/disks will not have the litte
+        nibs on the surfaces.
+
+    """
+    if im.ndim == 2:
+        xlim, ylim = im.shape
+        pt = coords
+        for a, x in enumerate(range(pt[0]-r, pt[0]+r+1)):
+            if (x >= 0) and (x < xlim):
+                for b, y in enumerate(range(pt[1]-r, pt[1]+r+1)):
+                    if (y >= 0) and (y < ylim):
+                        R = ((a - r)**2 + (b - r)**2)**0.5
+                        if (R <= r)*(~smooth) or (R < r)*(smooth):
+                            if overwrite or (im[x, y] == 0):
+                                im[x, y] = v
+    elif im.ndim == 3:
+        xlim, ylim, zlim = im.shape
+        pt = coords
+        for a, x in enumerate(range(pt[0]-r, pt[0]+r+1)):
+            if (x >= 0) and (x < xlim):
+                for b, y in enumerate(range(pt[1]-r, pt[1]+r+1)):
+                    if (y >= 0) and (y < ylim):
+                        for c, z in enumerate(range(pt[2]-r, pt[2]+r+1)):
+                            if (z >= 0) and (z < zlim):
+                                R = ((a - r)**2 + (b - r)**2 + (c - r)**2)**0.5
+                                if (R <= r)*(~smooth) or (R < r)*(smooth):
+                                    if overwrite or (im[x, y, z] == 0):
+                                        im[x, y, z] = v
+    return im
+
+
+@njit
 def _insert_disk_at_points(im, coords, r, v,
                            smooth=True, overwrite=False):  # pragma: no cover
     r"""
@@ -124,12 +178,39 @@ def _insert_disk_at_points(im, coords, r, v,
     return im
 
 
-@njit
+@njit(parallel=True)
 def _insert_disks_at_points_parallel(im, coords, radii, v, smooth=True,
                                      overwrite=False):  # pragma: no cover
-    for r in radii:
-        im = _insert_disk_at_points(im=im, coords=coords, r=r, v=v,
-                                    smooth=smooth, overwrite=overwrite)
+    npts = len(coords[0])
+    if im.ndim == 2:
+        xlim, ylim = im.shape
+        for i in prange(npts):
+            r = radii[i]
+            pt = coords[:, i]
+            for a, x in enumerate(range(pt[0]-r, pt[0]+r+1)):
+                if (x >= 0) and (x < xlim):
+                    for b, y in enumerate(range(pt[1]-r, pt[1]+r+1)):
+                        if (y >= 0) and (y < ylim):
+                            R = ((a - r)**2 + (b - r)**2)**0.5
+                            if (R <= r)*(~smooth) or (R < r)*(smooth):
+                                if overwrite or (im[x, y] == 0):
+                                    im[x, y] = v
+    elif im.ndim == 3:
+        xlim, ylim, zlim = im.shape
+        for i in prange(npts):
+            r = radii[i]
+            pt = coords[:, i]
+            for a, x in enumerate(range(pt[0]-r, pt[0]+r+1)):
+                if (x >= 0) and (x < xlim):
+                    for b, y in enumerate(range(pt[1]-r, pt[1]+r+1)):
+                        if (y >= 0) and (y < ylim):
+                            for c, z in enumerate(range(pt[2]-r, pt[2]+r+1)):
+                                if (z >= 0) and (z < zlim):
+                                    R = ((a - r)**2 + (b - r)**2 + (c - r)**2)**0.5
+                                    if (R <= r)*(~smooth) or (R < r)*(smooth):
+                                        if overwrite or (im[x, y, z] == 0):
+                                            im[x, y, z] = v
+    return im
 
 
 @njit
@@ -258,12 +339,29 @@ if __name__ == "__main__":
     import matplotlib.pyplot as plt
     import numpy as np
 
-    im = np.random.rand(300, 300) > 0.999
+    # %%
+    np.random.seed(0)
+    im = np.random.rand(300, 300, 300) > 0.999
     coords = np.where(im)
-    im = _insert_disk_at_points(im=im, coords=np.vstack(coords), r=10, v=1, smooth=True)
-    plt.imshow(im)
 
+    # %%
+    im2 = np.zeros_like(im)
+    im2 = _insert_disk_at_points(im=im2, coords=np.vstack(coords), r=10, v=1, smooth=True)
+    # plt.imshow(im2)
 
+    # %%
+    im3 = np.zeros_like(im)
+    np.random.seed(0)
+    rs = np.random.randint(5, 10, len(coords[0]))
+    im3 = _insert_disks_at_points(im=im3, coords=np.vstack(coords), radii=rs, v=1)
+    # plt.imshow(im3)
+
+    # %%
+    im4 = np.zeros_like(im)
+    np.random.seed(0)
+    rs = np.random.randint(5, 10, len(coords[0]))
+    im4 = _insert_disks_at_points_parallel(im=im4, coords=np.vstack(coords), radii=rs, v=1)
+    # plt.imshow(im4)
 
 
 

--- a/porespy/tools/_sphere_insertions.py
+++ b/porespy/tools/_sphere_insertions.py
@@ -12,172 +12,6 @@ __all__ = [
 ]
 
 
-@njit(parallel=False)
-def _make_disks(r, smooth=True):  # pragma: no cover
-    r"""
-    Returns a list of disks from size 0 to ``r``
-
-    Parameters
-    ----------
-    r : int
-        The size of the largest disk to generate
-    smooth : bool
-        Indicates whether the disks should include the nibs (``False``) on
-        the surface or not (``True``).  The default is ``True``.
-
-    Returns
-    -------
-    disks : list of ND-arrays
-        A list containing the disk images, with the disk of radius R at index
-        R of the list, meaning it can be accessed as ``disks[R]``.
-
-    """
-    disks = []
-    for val in range(0, r):
-        disk = _make_disk(val, smooth)
-        disks.append(disk)
-    return disks
-
-
-@njit(parallel=False)
-def _make_balls(r, smooth=True):  # pragma: no cover
-    r"""
-    Returns a list of balls from size 0 to ``r``
-
-    Parameters
-    ----------
-    r : int
-        The size of the largest ball to generate
-    smooth : bool
-        Indicates whether the balls should include the nibs (``False``) on
-        the surface or not (``True``).  The default is ``True``.
-
-    Returns
-    -------
-    balls : list of ND-arrays
-        A list containing the ball images, with the ball of radius R at index
-        R of the list, meaning it can be accessed as ``balls[R]``.
-
-    """
-    balls = []
-    for val in range(0, r):
-        ball = _make_ball(val, smooth)
-        balls.append(ball)
-    return balls
-
-
-@njit
-def _insert_disk_at_point(im, coords, r, v,
-                           smooth=True, overwrite=False):  # pragma: no cover
-    r"""
-    Insert spheres (or disks) into the given ND-image at given locations
-
-    This function uses numba to accelerate the process, and does not
-    overwrite any existing values (i.e. only writes to locations containing
-    zeros).
-
-    Parameters
-    ----------
-    im : ND-array
-        The image into which the spheres/disks should be inserted. This is an
-        'in-place' operation.
-    coords : ND-array
-        The center point of the sphere/disk
-    r : int
-        The radius of all the spheres/disks to add. It is assumed that they
-        are all the same radius.
-    v : scalar
-        The value to insert
-    smooth : boolean
-        If ``True`` (default) then the spheres/disks will not have the litte
-        nibs on the surfaces.
-
-    """
-    if im.ndim == 2:
-        xlim, ylim = im.shape
-        pt = coords
-        for a, x in enumerate(range(pt[0]-r, pt[0]+r+1)):
-            if (x >= 0) and (x < xlim):
-                for b, y in enumerate(range(pt[1]-r, pt[1]+r+1)):
-                    if (y >= 0) and (y < ylim):
-                        R = ((a - r)**2 + (b - r)**2)**0.5
-                        if (R <= r)*(~smooth) or (R < r)*(smooth):
-                            if overwrite or (im[x, y] == 0):
-                                im[x, y] = v
-    elif im.ndim == 3:
-        xlim, ylim, zlim = im.shape
-        pt = coords
-        for a, x in enumerate(range(pt[0]-r, pt[0]+r+1)):
-            if (x >= 0) and (x < xlim):
-                for b, y in enumerate(range(pt[1]-r, pt[1]+r+1)):
-                    if (y >= 0) and (y < ylim):
-                        for c, z in enumerate(range(pt[2]-r, pt[2]+r+1)):
-                            if (z >= 0) and (z < zlim):
-                                R = ((a - r)**2 + (b - r)**2 + (c - r)**2)**0.5
-                                if (R <= r)*(~smooth) or (R < r)*(smooth):
-                                    if overwrite or (im[x, y, z] == 0):
-                                        im[x, y, z] = v
-    return im
-
-
-@njit
-def _insert_disk_at_points(im, coords, r, v,
-                           smooth=True, overwrite=False):  # pragma: no cover
-    r"""
-    Insert spheres (or disks) into the given ND-image at given locations
-
-    This function uses numba to accelerate the process, and does not
-    overwrite any existing values (i.e. only writes to locations containing
-    zeros).
-
-    Parameters
-    ----------
-    im : ND-array
-        The image into which the spheres/disks should be inserted. This is an
-        'in-place' operation.
-    coords : ND-array
-        The center point of each sphere/disk in an array of shape
-        ``ndim by npts``
-    r : int
-        The radius of all the spheres/disks to add. It is assumed that they
-        are all the same radius.
-    v : scalar
-        The value to insert
-    smooth : boolean
-        If ``True`` (default) then the spheres/disks will not have the litte
-        nibs on the surfaces.
-
-    """
-    npts = len(coords[0])
-    if im.ndim == 2:
-        xlim, ylim = im.shape
-        for i in range(npts):
-            pt = coords[:, i]
-            for a, x in enumerate(range(pt[0]-r, pt[0]+r+1)):
-                if (x >= 0) and (x < xlim):
-                    for b, y in enumerate(range(pt[1]-r, pt[1]+r+1)):
-                        if (y >= 0) and (y < ylim):
-                            R = ((a - r)**2 + (b - r)**2)**0.5
-                            if (R <= r)*(~smooth) or (R < r)*(smooth):
-                                if overwrite or (im[x, y] == 0):
-                                    im[x, y] = v
-    elif im.ndim == 3:
-        xlim, ylim, zlim = im.shape
-        for i in range(npts):
-            pt = coords[:, i]
-            for a, x in enumerate(range(pt[0]-r, pt[0]+r+1)):
-                if (x >= 0) and (x < xlim):
-                    for b, y in enumerate(range(pt[1]-r, pt[1]+r+1)):
-                        if (y >= 0) and (y < ylim):
-                            for c, z in enumerate(range(pt[2]-r, pt[2]+r+1)):
-                                if (z >= 0) and (z < zlim):
-                                    R = ((a - r)**2 + (b - r)**2 + (c - r)**2)**0.5
-                                    if (R <= r)*(~smooth) or (R < r)*(smooth):
-                                        if overwrite or (im[x, y, z] == 0):
-                                            im[x, y, z] = v
-    return im
-
-
 @njit(parallel=True)
 def _insert_disks_at_points_parallel(im, coords, radii, v, smooth=True,
                                      overwrite=False):  # pragma: no cover
@@ -275,6 +109,183 @@ def _insert_disks_at_points(im, coords, radii, v, smooth=True,
 
 
 @njit(parallel=False)
+def _insert_disk_at_points(im, coords, r, v,
+                           smooth=True, overwrite=False):  # pragma: no cover
+    r"""
+    Insert spheres (or disks) into the given ND-image at given locations
+
+    This function uses numba to accelerate the process, and does not
+    overwrite any existing values (i.e. only writes to locations containing
+    zeros).
+
+    Parameters
+    ----------
+    im : ND-array
+        The image into which the spheres/disks should be inserted. This is an
+        'in-place' operation.
+    coords : ND-array
+        The center point of each sphere/disk in an array of shape
+        ``ndim by npts``
+    r : int
+        The radius of all the spheres/disks to add. It is assumed that they
+        are all the same radius.
+    v : scalar
+        The value to insert
+    smooth : boolean
+        If ``True`` (default) then the spheres/disks will not have the litte
+        nibs on the surfaces.
+
+    """
+    npts = len(coords[0])
+    if im.ndim == 2:
+        xlim, ylim = im.shape
+        s = _make_disk(r, smooth)
+        for i in range(npts):
+            pt = coords[:, i]
+            for a, x in enumerate(range(pt[0]-r, pt[0]+r+1)):
+                if (x >= 0) and (x < xlim):
+                    for b, y in enumerate(range(pt[1]-r, pt[1]+r+1)):
+                        if (y >= 0) and (y < ylim):
+                            if s[a, b] == 1:
+                                if overwrite or (im[x, y] == 0):
+                                    im[x, y] = v
+    elif im.ndim == 3:
+        xlim, ylim, zlim = im.shape
+        s = _make_ball(r, smooth)
+        for i in range(npts):
+            pt = coords[:, i]
+            for a, x in enumerate(range(pt[0]-r, pt[0]+r+1)):
+                if (x >= 0) and (x < xlim):
+                    for b, y in enumerate(range(pt[1]-r, pt[1]+r+1)):
+                        if (y >= 0) and (y < ylim):
+                            for c, z in enumerate(range(pt[2]-r, pt[2]+r+1)):
+                                if (z >= 0) and (z < zlim):
+                                    if (s[a, b, c] == 1):
+                                        if overwrite or (im[x, y, z] == 0):
+                                            im[x, y, z] = v
+    return im
+
+
+@njit(parallel=True)
+def _insert_disk_at_points_parallel(im, coords, r, v,
+                           smooth=True, overwrite=False):  # pragma: no cover
+    r"""
+    Insert spheres (or disks) into the given ND-image at given locations
+
+    This function uses numba to accelerate the process, and does not
+    overwrite any existing values (i.e. only writes to locations containing
+    zeros).
+
+    Parameters
+    ----------
+    im : ND-array
+        The image into which the spheres/disks should be inserted. This is an
+        'in-place' operation.
+    coords : ND-array
+        The center point of each sphere/disk in an array of shape
+        ``ndim by npts``
+    r : int
+        The radius of all the spheres/disks to add. It is assumed that they
+        are all the same radius.
+    v : scalar
+        The value to insert
+    smooth : boolean
+        If ``True`` (default) then the spheres/disks will not have the litte
+        nibs on the surfaces.
+
+    """
+    npts = len(coords[0])
+    if im.ndim == 2:
+        xlim, ylim = im.shape
+        s = _make_disk(r, smooth)
+        for i in prange(npts):
+            pt = coords[:, i]
+            for a, x in enumerate(range(pt[0]-r, pt[0]+r+1)):
+                if (x >= 0) and (x < xlim):
+                    for b, y in enumerate(range(pt[1]-r, pt[1]+r+1)):
+                        if (y >= 0) and (y < ylim):
+                            if s[a, b] == 1:
+                                if overwrite or (im[x, y] == 0):
+                                    im[x, y] = v
+    elif im.ndim == 3:
+        xlim, ylim, zlim = im.shape
+        s = _make_ball(r, smooth)
+        for i in prange(npts):
+            pt = coords[:, i]
+            for a, x in enumerate(range(pt[0]-r, pt[0]+r+1)):
+                if (x >= 0) and (x < xlim):
+                    for b, y in enumerate(range(pt[1]-r, pt[1]+r+1)):
+                        if (y >= 0) and (y < ylim):
+                            for c, z in enumerate(range(pt[2]-r, pt[2]+r+1)):
+                                if (z >= 0) and (z < zlim):
+                                    if (s[a, b, c] == 1):
+                                        if overwrite or (im[x, y, z] == 0):
+                                            im[x, y, z] = v
+    return im
+
+
+@njit(parallel=False)
+def _insert_disks_at_points_legacy(im, coords, radii, v, smooth=True,
+                                   overwrite=False):  # pragma: no cover
+    r"""
+    Insert spheres (or disks) of specified radii into an ND-image at given locations.
+
+    This function uses numba to accelerate the process, and does not overwrite
+    any existing values (i.e. only writes to locations containing zeros).
+
+    Parameters
+    ----------
+    im : ND-array
+        The image into which the spheres/disks should be inserted. This is an
+        'in-place' operation.
+    coords : ND-array
+        The center point of each sphere/disk in an array of shape
+        ``ndim by npts``
+    radii : array_like
+        The radii of the spheres/disks to add.
+    v : scalar
+        The value to insert
+    smooth : boolean, optional
+        If ``True`` (default) then the spheres/disks will not have the litte
+        nibs on the surfaces.
+    overwrite : boolean, optional
+        If ``True`` then the inserted spheres overwrite existing values.  The
+        default is ``False``.
+
+    """
+    npts = len(coords[0])
+    if im.ndim == 2:
+        xlim, ylim = im.shape
+        for i in range(npts):
+            r = radii[i]
+            s = _make_disk(r, smooth)
+            pt = coords[:, i]
+            for a, x in enumerate(range(pt[0]-r, pt[0]+r+1)):
+                if (x >= 0) and (x < xlim):
+                    for b, y in enumerate(range(pt[1]-r, pt[1]+r+1)):
+                        if (y >= 0) and (y < ylim):
+                            if s[a, b] == 1:
+                                if overwrite or (im[x, y] == 0):
+                                    im[x, y] = v
+    elif im.ndim == 3:
+        xlim, ylim, zlim = im.shape
+        for i in range(npts):
+            r = radii[i]
+            s = _make_ball(r, smooth)
+            pt = coords[:, i]
+            for a, x in enumerate(range(pt[0]-r, pt[0]+r+1)):
+                if (x >= 0) and (x < xlim):
+                    for b, y in enumerate(range(pt[1]-r, pt[1]+r+1)):
+                        if (y >= 0) and (y < ylim):
+                            for c, z in enumerate(range(pt[2]-r, pt[2]+r+1)):
+                                if (z >= 0) and (z < zlim):
+                                    if s[a, b, c] == 1:
+                                        if overwrite or (im[x, y, z] == 0):
+                                            im[x, y, z] = v
+    return im
+
+
+@njit(parallel=False)
 def _make_disk(r, smooth=True):  # pragma: no cover
     r"""
     Generate a circular structuring element of the given radius
@@ -335,34 +346,107 @@ def _make_ball(r, smooth=True):  # pragma: no cover
     return s
 
 
+@njit(parallel=False)
+def _make_disks(r, smooth=True):  # pragma: no cover
+    r"""
+    Returns a list of disks from size 0 to ``r``
+
+    Parameters
+    ----------
+    r : int
+        The size of the largest disk to generate
+    smooth : bool
+        Indicates whether the disks should include the nibs (``False``) on
+        the surface or not (``True``).  The default is ``True``.
+
+    Returns
+    -------
+    disks : list of ND-arrays
+        A list containing the disk images, with the disk of radius R at index
+        R of the list, meaning it can be accessed as ``disks[R]``.
+
+    """
+    disks = []
+    for val in range(0, r):
+        disk = _make_disk(val, smooth)
+        disks.append(disk)
+    return disks
+
+
+@njit(parallel=False)
+def _make_balls(r, smooth=True):  # pragma: no cover
+    r"""
+    Returns a list of balls from size 0 to ``r``
+
+    Parameters
+    ----------
+    r : int
+        The size of the largest ball to generate
+    smooth : bool
+        Indicates whether the balls should include the nibs (``False``) on
+        the surface or not (``True``).  The default is ``True``.
+
+    Returns
+    -------
+    balls : list of ND-arrays
+        A list containing the ball images, with the ball of radius R at index
+        R of the list, meaning it can be accessed as ``balls[R]``.
+
+    """
+    balls = []
+    for val in range(0, r):
+        ball = _make_ball(val, smooth)
+        balls.append(ball)
+    return balls
+
+
 if __name__ == "__main__":
     import matplotlib.pyplot as plt
     import numpy as np
+    from porespy.tools import tic, toc
 
-    # %%
     np.random.seed(0)
-    im = np.random.rand(300, 300, 300) > 0.999
+    im = np.random.rand(400, 400, 400) > 0.995
     coords = np.where(im)
+    rs = np.random.randint(5, 10, len(coords[0]))
 
-    # %%
     im2 = np.zeros_like(im)
+    # Call function once to trigger jit before timing
     im2 = _insert_disk_at_points(im=im2, coords=np.vstack(coords), r=10, v=1, smooth=True)
-    # plt.imshow(im2)
+    im2 = np.zeros_like(im)
+    tic()
+    im2 = _insert_disk_at_points(im=im2, coords=np.vstack(coords), r=10, v=1, smooth=True)
+    t = toc(quiet=True)
+    print(f"Single radii, serial: {t}")
 
-    # %%
+    im2 = np.zeros_like(im)
+    im2 = _insert_disk_at_points_parallel(im=im2, coords=np.vstack(coords), r=10, v=1, smooth=True)
+    im2 = np.zeros_like(im)
+    tic()
+    im2 = _insert_disk_at_points_parallel(im=im2, coords=np.vstack(coords), r=10, v=1, smooth=True)
+    t = toc(quiet=True)
+    print(f"Single radii, parallel: {t}")
+
     im3 = np.zeros_like(im)
-    np.random.seed(0)
-    rs = np.random.randint(5, 10, len(coords[0]))
+    im3 = _insert_disks_at_points_legacy(im=im3, coords=np.vstack(coords), radii=rs, v=1)
+    im3 = np.zeros_like(im)
+    tic()
+    im3 = _insert_disks_at_points_legacy(im=im3, coords=np.vstack(coords), radii=rs, v=1)
+    t = toc(quiet=True)
+    print(f"Multiple radii, legacy: {t}")
+
+    im3 = np.zeros_like(im)
     im3 = _insert_disks_at_points(im=im3, coords=np.vstack(coords), radii=rs, v=1)
-    # plt.imshow(im3)
+    im3 = np.zeros_like(im)
+    tic()
+    im3 = _insert_disks_at_points(im=im3, coords=np.vstack(coords), radii=rs, v=1)
+    t = toc(quiet=True)
+    print(f"Multiple radii, new: {t}")
 
-    # %%
     im4 = np.zeros_like(im)
-    np.random.seed(0)
-    rs = np.random.randint(5, 10, len(coords[0]))
     im4 = _insert_disks_at_points_parallel(im=im4, coords=np.vstack(coords), radii=rs, v=1)
-    # plt.imshow(im4)
-
-
-
-
+    im4 = np.zeros_like(im)
+    tic()
+    im4 = _insert_disks_at_points_parallel(im=im4, coords=np.vstack(coords), radii=rs, v=1)
+    t = toc(quiet=True)
+    print(f"Multiple radii, parallel: {t}")

--- a/porespy/tools/_sphere_insertions.py
+++ b/porespy/tools/_sphere_insertions.py
@@ -8,7 +8,10 @@ __all__ = [
     '_make_ball',
     '_make_balls',
     '_insert_disk_at_points',
+    '_insert_disk_at_points_parallel',
     '_insert_disks_at_points',
+    '_insert_disks_at_points_legacy',
+    '_insert_disks_at_points_parallel',
 ]
 
 
@@ -167,8 +170,8 @@ def _insert_disk_at_points(im, coords, r, v,
 
 
 @njit(parallel=True)
-def _insert_disk_at_points_parallel(im, coords, r, v,
-                           smooth=True, overwrite=False):  # pragma: no cover
+def _insert_disk_at_points_parallel(im, coords, r, v, smooth=True,
+                                    overwrite=False):  # pragma: no cover
     r"""
     Insert spheres (or disks) into the given ND-image at given locations
 
@@ -401,7 +404,6 @@ def _make_balls(r, smooth=True):  # pragma: no cover
 
 
 if __name__ == "__main__":
-    import matplotlib.pyplot as plt
     import numpy as np
     from porespy.tools import tic, toc
 
@@ -412,26 +414,32 @@ if __name__ == "__main__":
 
     im2 = np.zeros_like(im)
     # Call function once to trigger jit before timing
-    im2 = _insert_disk_at_points(im=im2, coords=np.vstack(coords), r=10, v=1, smooth=True)
+    im2 = _insert_disk_at_points(im=im2, coords=np.vstack(coords),
+                                 r=10, v=1, smooth=True)
     im2 = np.zeros_like(im)
     tic()
-    im2 = _insert_disk_at_points(im=im2, coords=np.vstack(coords), r=10, v=1, smooth=True)
+    im2 = _insert_disk_at_points(im=im2, coords=np.vstack(coords),
+                                 r=10, v=1, smooth=True)
     t = toc(quiet=True)
     print(f"Single radii, serial: {t}")
 
     im2 = np.zeros_like(im)
-    im2 = _insert_disk_at_points_parallel(im=im2, coords=np.vstack(coords), r=10, v=1, smooth=True)
+    im2 = _insert_disk_at_points_parallel(im=im2, coords=np.vstack(coords),
+                                          r=10, v=1, smooth=True)
     im2 = np.zeros_like(im)
     tic()
-    im2 = _insert_disk_at_points_parallel(im=im2, coords=np.vstack(coords), r=10, v=1, smooth=True)
+    im2 = _insert_disk_at_points_parallel(im=im2, coords=np.vstack(coords),
+                                          r=10, v=1, smooth=True)
     t = toc(quiet=True)
     print(f"Single radii, parallel: {t}")
 
     im3 = np.zeros_like(im)
-    im3 = _insert_disks_at_points_legacy(im=im3, coords=np.vstack(coords), radii=rs, v=1)
+    im3 = _insert_disks_at_points_legacy(im=im3, coords=np.vstack(coords),
+                                         radii=rs, v=1)
     im3 = np.zeros_like(im)
     tic()
-    im3 = _insert_disks_at_points_legacy(im=im3, coords=np.vstack(coords), radii=rs, v=1)
+    im3 = _insert_disks_at_points_legacy(im=im3, coords=np.vstack(coords),
+                                         radii=rs, v=1)
     t = toc(quiet=True)
     print(f"Multiple radii, legacy: {t}")
 
@@ -444,9 +452,11 @@ if __name__ == "__main__":
     print(f"Multiple radii, new: {t}")
 
     im4 = np.zeros_like(im)
-    im4 = _insert_disks_at_points_parallel(im=im4, coords=np.vstack(coords), radii=rs, v=1)
+    im4 = _insert_disks_at_points_parallel(im=im4, coords=np.vstack(coords),
+                                           radii=rs, v=1)
     im4 = np.zeros_like(im)
     tic()
-    im4 = _insert_disks_at_points_parallel(im=im4, coords=np.vstack(coords), radii=rs, v=1)
+    im4 = _insert_disks_at_points_parallel(im=im4, coords=np.vstack(coords),
+                                           radii=rs, v=1)
     t = toc(quiet=True)
     print(f"Multiple radii, parallel: {t}")

--- a/porespy/tools/_sphere_insertions.py
+++ b/porespy/tools/_sphere_insertions.py
@@ -10,7 +10,7 @@ __all__ = [
     '_insert_disk_at_points',
     '_insert_disk_at_points_parallel',
     '_insert_disks_at_points',
-    '_insert_disks_at_points_legacy',
+    '_insert_disks_at_points_serial',
     '_insert_disks_at_points_parallel',
 ]
 
@@ -51,8 +51,8 @@ def _insert_disks_at_points_parallel(im, coords, radii, v, smooth=True,
 
 
 @njit
-def _insert_disks_at_points(im, coords, radii, v, smooth=True,
-                            overwrite=False):  # pragma: no cover
+def _insert_disks_at_points_serial(im, coords, radii, v, smooth=True,
+                                   overwrite=False):  # pragma: no cover
     r"""
     Insert spheres (or disks) of specified radii into an ND-image at given locations.
 
@@ -228,8 +228,8 @@ def _insert_disk_at_points_parallel(im, coords, r, v, smooth=True,
 
 
 @njit(parallel=False)
-def _insert_disks_at_points_legacy(im, coords, radii, v, smooth=True,
-                                   overwrite=False):  # pragma: no cover
+def _insert_disks_at_points(im, coords, radii, v, smooth=True,
+                            overwrite=False):  # pragma: no cover
     r"""
     Insert spheres (or disks) of specified radii into an ND-image at given locations.
 
@@ -434,20 +434,20 @@ if __name__ == "__main__":
     print(f"Single radii, parallel: {t}")
 
     im3 = np.zeros_like(im)
-    im3 = _insert_disks_at_points_legacy(im=im3, coords=np.vstack(coords),
+    im3 = _insert_disks_at_points(im=im3, coords=np.vstack(coords),
                                          radii=rs, v=1)
     im3 = np.zeros_like(im)
     tic()
-    im3 = _insert_disks_at_points_legacy(im=im3, coords=np.vstack(coords),
+    im3 = _insert_disks_at_points(im=im3, coords=np.vstack(coords),
                                          radii=rs, v=1)
     t = toc(quiet=True)
     print(f"Multiple radii, legacy: {t}")
 
     im3 = np.zeros_like(im)
-    im3 = _insert_disks_at_points(im=im3, coords=np.vstack(coords), radii=rs, v=1)
+    im3 = _insert_disks_at_points_serial(im=im3, coords=np.vstack(coords), radii=rs, v=1)
     im3 = np.zeros_like(im)
     tic()
-    im3 = _insert_disks_at_points(im=im3, coords=np.vstack(coords), radii=rs, v=1)
+    im3 = _insert_disks_at_points_serial(im=im3, coords=np.vstack(coords), radii=rs, v=1)
     t = toc(quiet=True)
     print(f"Multiple radii, new: {t}")
 


### PR DESCRIPTION
This fixes #862

It turns out that using math instead of templates only slows down the case where all spheres are the same size (insert_disk_at_points) so I didn't implement this change to that function, but it helps by about 20% for the case of different size spheres (insert_disks_at_points).  

I also created parallelized versions using numba's `prange` so the spheres are all inserted in parallel. 

Overall the timings on inserted 300,000 spheres (a lot!) into a 400-cubed image are as follows:

```
Single radii, serial: 2.5974252223968506
Single radii, parallel: 0.690955638885498
Multiple radii, legacy: 6.902696371078491
Multiple radii, new: 5.111146450042725
Multiple radii, parallel: 1.0703320503234863
```

So parallelization helps, not surprizingly.  This new parallelized function is called `insert_disks_at_points_parallel`.  