### PR TITLE
Add `flux` and `tau_from_cmap` to simulations module

### DIFF
--- a/porespy/beta/__init__.py
+++ b/porespy/beta/__init__.py
@@ -1,1 +1,2 @@
+from ._dns_tools import *
 from ._drainage2 import *

--- a/porespy/beta/_dns_tools.py
+++ b/porespy/beta/_dns_tools.py
@@ -9,7 +9,7 @@ __all__ = ["flux", "tau_from_cmap"]
 
 def flux(c, axis, k=None):
     """
-    Computes the layer-by-layer flux in a given direction.
+    Computes the layer-by-layer diffusive flux in a given direction.
 
     Parameters
     ----------

--- a/porespy/simulations/__init__.py
+++ b/porespy/simulations/__init__.py
@@ -20,4 +20,3 @@ from ._dns import *
 from ._drainage import *
 from ._ibip import *
 from ._ibip_gpu import *
-from ._tools import *

--- a/porespy/simulations/__init__.py
+++ b/porespy/simulations/__init__.py
@@ -16,7 +16,8 @@ This module contains routines for performing simulations directly on images.
 
 """
 
-from ._drainage import *
 from ._dns import *
+from ._drainage import *
 from ._ibip import *
 from ._ibip_gpu import *
+from ._tools import *

--- a/porespy/simulations/_tools.py
+++ b/porespy/simulations/_tools.py
@@ -1,0 +1,109 @@
+import numpy as np
+from scipy.ndimage import convolve1d
+
+from porespy.filters import trim_nonpercolating_paths
+from porespy.generators import faces
+
+__all__ = ["flux", "tau_from_cmap"]
+
+
+def flux(c, axis, k=None):
+    """
+    Computes the layer-by-layer flux in a given direction.
+
+    Parameters
+    ----------
+    c : ndarray
+        The concentration field
+    axis : int
+        The axis along which the flux is computed
+    k : ndarray
+        The conductivity field
+    
+    Returns
+    -------
+    J : ndarray
+        The layer-by-layer flux in the given direction
+
+    """
+    k = np.ones_like(c) if k is None else np.array(k)
+    # Compute the gradient of the concentration field using forward diff
+    dcdX = convolve1d(c, weights=np.array([-1, 1]), axis=axis)
+    # dcdX @ outlet is incorrect due to forward diff -> use backward
+    _fix_gradient_outlet(dcdX, axis)
+    # Compute the conductivity at the faces using resistors in series
+    k_face = 1 / convolve1d(1 / k, weights=np.array([0.5, 0.5]), axis=axis)
+    # Normalize gradient by the conductivity to get the physical flux
+    J = dcdX * k_face
+    return J
+
+
+def tau_from_cmap(c, im, axis):
+    """
+    Computes the tortuosity factor from a concentration field.
+    
+    Parameters
+    ----------
+    c : ndarray
+        The concentration field
+    im : ndarray
+        The binary image of the porous medium
+    axis : int
+        The axis along which tortuosity is computed
+    
+    Returns
+    -------
+    tau : float
+        The tortuosity factor along the given axis
+
+    """
+    im = _trim_nonpercolating_paths(im, axis=axis)
+    # Use the image as conductivity matrix (solid = 0, fluid = 1)
+    k = im.astype(c.dtype)
+    # Find transport length and cross-sectional area
+    L = im.shape[axis]
+    A = np.prod(im.shape) / L
+    # Find the average inlet and outlet concentration
+    cA, cB = _get_BC_values(c, im, axis)
+    # Compute the point-wise flux in the given direction
+    J = flux(c, axis=axis, k=k)
+    # Calculate the net flux for each layer in the given direction
+    normal_axes = tuple(i for i in range(im.ndim) if i != axis)
+    rate = J.sum(axis=normal_axes)
+    # NOTE: L-1 because c is stored at cell centers
+    Deff = rate.mean() * (L-1) / A / (cA-cB)
+    eps = im.sum(dtype=np.int64) / im.size
+    return eps / Deff
+
+
+def _fix_gradient_outlet(J, axis):
+    """Replaces the gradient @ outlet with that of the penultimate layer."""
+    J_outlet = _slice_view(J, -1, axis)
+    J_penultimate_layer = _slice_view(J, -2, axis)
+    J_outlet[:] = J_penultimate_layer
+
+
+def _slice_view(a, i, axis):
+    """Returns a slice view of the array along the given axis."""
+    sl = [slice(None)] * a.ndim
+    sl[axis] = i
+    return a[tuple(sl)]
+
+
+def _get_BC_values(c, im, axis):
+    """Returns the inlet and outlet concentration values."""
+    cA = c.take(0, axis=axis)   # c @ inlet
+    cB = c.take(-1, axis=axis)  # c @ outlet
+    mask_inlet = im.take(0, axis=axis)
+    mask_outlet = im.take(-1, axis=axis)
+    cA = cA[mask_inlet].mean()
+    cB = cB[mask_outlet].mean()
+    return cA, cB
+
+
+def _trim_nonpercolating_paths(im, axis):
+    """Removes non-percolating paths from the image."""
+    inlets = faces(im.shape, inlet=axis)
+    outlets = faces(im.shape, outlet=axis)
+    im = trim_nonpercolating_paths(im, inlets=inlets, outlets=outlets)
+    return im

--- a/porespy/simulations/_tools.py
+++ b/porespy/simulations/_tools.py
@@ -19,7 +19,7 @@ def flux(c, axis, k=None):
         The axis along which the flux is computed
     k : ndarray
         The conductivity field
-    
+
     Returns
     -------
     J : ndarray
@@ -41,7 +41,7 @@ def flux(c, axis, k=None):
 def tau_from_cmap(c, im, axis):
     """
     Computes the tortuosity factor from a concentration field.
-    
+
     Parameters
     ----------
     c : ndarray
@@ -50,7 +50,7 @@ def tau_from_cmap(c, im, axis):
         The binary image of the porous medium
     axis : int
         The axis along which tortuosity is computed
-    
+
     Returns
     -------
     tau : float

--- a/test/unit/test_dns.py
+++ b/test/unit/test_dns.py
@@ -1,8 +1,11 @@
-import pytest
 import numpy as np
 import openpnm as op
+import pytest
+
 import porespy as ps
+
 ps.settings.tqdm['disable'] = True
+ps.settings.loglevel = 40
 
 
 class DNSTest():
@@ -27,6 +30,26 @@ class DNSTest():
         im = ps.generators.blobs(shape=[200, 200], porosity=0.05)
         with pytest.raises(Exception):
             _ = ps.simulations.tortuosity_fd(im=im, axis=1)
+
+    def test_flux(self):
+        im = ps.generators.blobs(shape=[15, 20, 25], porosity=0.85, blobiness=1.5)
+        for axis in range(3):
+            out = ps.simulations.tortuosity_fd(im, axis=axis)
+            c = out["concentration"]
+            J = ps.simulations.flux(c, axis=axis, k=im)
+            normal_axes = tuple(i for i in range(im.ndim) if i != axis)
+            rate = J.sum(axis=normal_axes)
+            # Flux should be constant along the axis for different layers
+            np.testing.assert_allclose(rate, rate[0], rtol=1e-5)
+
+    def test_tau_from_cmap(self):
+        im = ps.generators.blobs(shape=[15, 20, 25], porosity=0.85, blobiness=1.5)
+        for axis in range(3):
+            out = ps.simulations.tortuosity_fd(im, axis=axis)
+            c = out["concentration"]
+            tau_fd = out["tortuosity"]
+            tau = ps.simulations.tau_from_cmap(c, im, axis=axis)
+            np.testing.assert_allclose(tau, tau_fd, rtol=1e-5)
 
 
 if __name__ == '__main__':

--- a/test/unit/test_dns.py
+++ b/test/unit/test_dns.py
@@ -3,6 +3,7 @@ import openpnm as op
 import pytest
 
 import porespy as ps
+import porespy.beta
 
 ps.settings.tqdm['disable'] = True
 ps.settings.loglevel = 40
@@ -36,7 +37,7 @@ class DNSTest():
         for axis in range(3):
             out = ps.simulations.tortuosity_fd(im, axis=axis)
             c = out["concentration"]
-            J = ps.simulations.flux(c, axis=axis, k=im)
+            J = ps.beta.flux(c, axis=axis, k=im)
             normal_axes = tuple(i for i in range(im.ndim) if i != axis)
             rate = J.sum(axis=normal_axes)
             # Flux should be constant along the axis for different layers
@@ -48,7 +49,7 @@ class DNSTest():
             out = ps.simulations.tortuosity_fd(im, axis=axis)
             c = out["concentration"]
             tau_fd = out["tortuosity"]
-            tau = ps.simulations.tau_from_cmap(c, im, axis=axis)
+            tau = ps.beta.tau_from_cmap(c, im, axis=axis)
             np.testing.assert_allclose(tau, tau_fd, rtol=1e-5)
 
 


### PR DESCRIPTION
# `flux`
Takes a concentration field, an axis, and conductivity matrix and returns the fluxes through all layers along the given axis. For the conductivity matrix, you could pass the binary image itself (since solid phase doesn't conduct -> k = 0) multiplied by the bulk diffusivity (or just the image if you don't care about the units).

# `tau_from_cmap`
Takes a concentration field, a binary image, and an axis and returns the tortuosity. Currently, it returns a single value for tortuosity, but we can change it so that it returns as many values as the number of slices along the given direction.