### PR TITLE
Adding morphology related tools

### DIFF
--- a/examples/generators/reference/borders.ipynb
+++ b/examples/generators/reference/borders.ipynb
@@ -88,7 +88,7 @@
    "id": "8c4c447d",
    "metadata": {},
    "source": [
-    "# `thickness`\n",
+    "## `thickness`\n",
     "Controls the thickness of the border:"
    ]
   },
@@ -130,7 +130,7 @@
    "id": "512d1201",
    "metadata": {},
    "source": [
-    "# `mode`\n",
+    "## `mode`\n",
     "The type of borders to generate, with options being `corners`, `edges` and `faces`.  In 2D `edges` and `faces` are the same."
    ]
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -277,3 +277,11 @@ docstring-code-format = true
 # This only has an effect when the `docstring-code-format` setting is
 # enabled.
 docstring-code-line-length = "dynamic"
+
+[tool.uv.sources]
+porespy = { workspace = true }
+
+[dependency-groups]
+dev = [
+    "porespy",
+]

--- a/src/porespy/beta/_tortuosity_bt_funcs.py
+++ b/src/porespy/beta/_tortuosity_bt_funcs.py
@@ -1,7 +1,7 @@
 import time
 import porespy as ps
 from porespy import tools
-from porespy.tools import Results
+from porespy.tools import Results, get_edt
 import porespy as ps
 import logging
 import numpy as np
@@ -9,10 +9,10 @@ import openpnm as op
 import pandas as pd
 import dask
 from dask.diagnostics import ProgressBar
-try:
-    from pyedt import edt
-except ModuleNotFoundError:
-    from edt import edt
+
+
+edt = get_edt()
+
 
 __all__ = [
     'tortuosity_bt',
@@ -199,7 +199,7 @@ def analyze_blocks(im, block_size=None, method="chords", use_dask=True):
             dt = edt(im)
             # TODO: Is the following supposed to be over 2 or over im.ndim?
             block_size = min(dt.max() * scale_factor, min(np.array(im.shape)/2))
-        
+
         else:
             print("Provide a valid method")
             raise Exception
@@ -303,7 +303,7 @@ def df_to_tortuosity(im, df):
 def tortuosity_bt(im, block_size=None, method="chords", use_dask=True):
     r"""
     Computes the tortuosity of an image in all directions
-    
+
     Parameters
     ----------
     im : ndarray
@@ -332,7 +332,7 @@ def tortuosity_bt(im, block_size=None, method="chords", use_dask=True):
 if __name__ =="__main__":
     import porespy as ps
     import numpy as np
-    
+
     np.random.seed(1)
 
     im = ps.generators.blobs([100, 100, 100])

--- a/src/porespy/filters/__init__.py
+++ b/src/porespy/filters/__init__.py
@@ -17,29 +17,36 @@ image, but with altered values.
     filters.apply_chords
     filters.apply_chords_3D
     filters.apply_padded
+    filters.capillary_transform
     filters.chunked_func
+    filters.dilate
     filters.distance_transform_lin
+    filters.erode
     filters.fftmorphology
     filters.fill_closed_pores
+    filters.fill_trapped_voxels
+    filters.find_closed_pores
     filters.find_disconnected_voxels
     filters.find_dt_artifacts
+    filters.find_invalid_pores
     filters.find_peaks
+    filters.find_surface_pores
     filters.find_trapped_regions
     filters.flood
     filters.flood_func
     filters.hold_peaks
-    filters.ibip
-    filters.ibip_gpu
     filters.local_thickness
     filters.nl_means_layered
     filters.nphase_border
     filters.pc_to_satn
+    filters.pc_to_seq
     filters.porosimetry
     filters.prune_branches
     filters.reduce_peaks
     filters.region_size
     filters.satn_to_seq
     filters.seq_to_satn
+    filters.size_to_pc
     filters.size_to_satn
     filters.size_to_seq
     filters.snow_partitioning
@@ -51,6 +58,7 @@ image, but with altered values.
     filters.trim_nearby_peaks
     filters.trim_nonpercolating_paths
     filters.trim_saddle_points
+    filters.trim_saddle_points_legacy
     filters.trim_small_clusters
 
 """
@@ -63,3 +71,4 @@ from ._size_seq_satn import *
 from ._snows import *
 from ._transforms import *
 from ._invasion import *
+from ._morphology import *

--- a/src/porespy/filters/_morphology.py
+++ b/src/porespy/filters/_morphology.py
@@ -1,0 +1,67 @@
+import numpy as np
+from scipy.signal import fftconvolve
+from porespy.tools import (
+    ps_round,
+    get_edt
+)
+
+
+edt = get_edt()
+
+
+__all__ = [
+    'erode',
+    'dilate',
+]
+
+
+def erode(im, r, dt=None, method='dt', smooth=True):
+    from porespy import settings
+    if dt is None:
+        dt = edt(im, parallel=settings.ncores)
+    if method == 'dt':
+        ero = dt >= r if smooth else dt > r
+    elif method.startswith('conv'):
+        se = ps_round(r=r, ndim=im.ndim, smooth=smooth)
+        ero = ~(fftconvolve(~im, se, mode='same') > 0.1)
+    return ero
+
+
+def dilate(im, r, method='dt', smooth=True):
+    from porespy import settings
+    im = im == 1
+    if method == 'dt':
+        dt = edt(~im, parallel=settings.ncores)
+        dil = dt < r if smooth else dt <= r
+        dil += im
+    elif method.startswith('conv'):
+        se = ps_round(r=r, ndim=im.ndim, smooth=smooth)
+        dil = fftconvolve(im, se, mode='same') > 0.1
+    return dil
+
+
+if __name__ == "__main__":
+    import porespy as ps
+    import matplotlib.pyplot as plt
+
+    im = ps.generators.blobs([200, 200], porosity=0.6, seed=5)
+
+    ero1 = erode(im, 5, method='dt').astype(int)
+    ero1[~im] = -1
+
+    ero2 = erode(im, 5, method='conv').astype(int)
+    ero2[~im] = -1
+
+    fig, ax = plt.subplots(2, 2)
+    ax[0][0].imshow(ero1)
+    ax[0][1].imshow(ero2)
+
+    ero1 = erode(im, 10, method='dt').astype(int)
+    dil1 = dilate(ero1, 10, method='dt').astype(int)
+    dil1[~im] = -1
+
+    dil2 = dilate(ero1, 10, method='conv').astype(int)
+    dil2[~im] = -1
+
+    ax[1][0].imshow(dil1)
+    ax[1][1].imshow(dil2)

--- a/src/porespy/filters/_snows.py
+++ b/src/porespy/filters/_snows.py
@@ -18,12 +18,8 @@ from porespy.tools import (
     get_tqdm,
     ps_rect,
     ps_round,
+    get_edt,
 )
-
-try:
-    from pyedt import edt
-except ModuleNotFoundError:
-    from edt import edt
 
 
 __all__ = [
@@ -38,6 +34,7 @@ __all__ = [
 ]
 
 
+edt = get_edt()
 tqdm = get_tqdm()
 logger = logging.getLogger(__name__)
 

--- a/src/porespy/filters/_transforms.py
+++ b/src/porespy/filters/_transforms.py
@@ -1,15 +1,15 @@
 import numpy as np
 import numpy.typing as npt
 from porespy.generators import ramp
-try:
-    from pyedt import edt
-except ModuleNotFoundError:
-    from edt import edt
+from porespy.tools import get_edt
 
 
 __all__ = [
     'capillary_transform',
 ]
+
+
+edt = get_edt()
 
 
 def capillary_transform(

--- a/src/porespy/generators/__init__.py
+++ b/src/porespy/generators/__init__.py
@@ -13,12 +13,14 @@ debugging, and illustration purposes.
    :template: mybase.rst
    :toctree: generated/
 
-    generators.random_spheres
     generators.blobs
     generators.borders
     generators.bundle_of_tubes
     generators.cylinders
+    generators.cylindrical_pillars_array
+    generators.cylindrical_pillars_mesh
     generators.cylindrical_plug
+    generators.elevation
     generators.faces
     generators.fractal_noise
     generators.insert_shape
@@ -28,8 +30,12 @@ debugging, and illustration purposes.
     generators.polydisperse_spheres
     generators.pseudo_electrostatic_packing
     generators.pseudo_gravity_packing
+    generators.ramp
     generators.random_cantor_dust
+    generators.random_spheres
+    generators.rectangular_pillars_array
     generators.sierpinski_foam
+    generators.spheres_from_coords
     generators.voronoi_edges
 
 """

--- a/src/porespy/generators/_imgen.py
+++ b/src/porespy/generators/_imgen.py
@@ -1,14 +1,12 @@
 import inspect as insp
 import logging
 from typing import List, Literal
-
 import numpy as np
 import numpy.typing as npt
 import scipy.ndimage as spim
 import scipy.spatial as sptl
 import scipy.stats as spst
 from numba import njit
-
 from porespy import metrics, settings
 from porespy.filters import chunked_func
 from porespy.tools import (
@@ -21,12 +19,8 @@ from porespy.tools import (
     insert_sphere,
     ps_ball,
     ps_disk,
+    get_edt,
 )
-
-try:
-    from pyedt import edt
-except ModuleNotFoundError:
-    from edt import edt
 
 
 __all__ = [
@@ -47,6 +41,7 @@ __all__ = [
 ]
 
 
+edt = get_edt()
 tqdm = get_tqdm()
 logger = logging.getLogger(__name__)
 

--- a/src/porespy/generators/_pseudo_packings.py
+++ b/src/porespy/generators/_pseudo_packings.py
@@ -14,12 +14,8 @@ from porespy.tools import (
     get_tqdm,
     ps_round,
     unpad,
+    get_edt,
 )
-
-try:
-    from pyedt import edt
-except ModuleNotFoundError:
-    from edt import edt
 
 
 __all__ = [
@@ -29,6 +25,7 @@ __all__ = [
 ]
 
 
+edt = get_edt()
 tqdm = get_tqdm()
 logger = logging.getLogger(__name__)
 

--- a/src/porespy/io/_funcs.py
+++ b/src/porespy/io/_funcs.py
@@ -1,19 +1,15 @@
 import os
 import subprocess
-
 import numpy as np
 import scipy.ndimage as nd
 import skimage.measure as ms
 from skimage.morphology import ball
-
 from porespy.filters import reduce_peaks
 from porespy.networks import generate_voxel_image
-from porespy.tools import sanitize_filename
+from porespy.tools import sanitize_filename, get_edt
 
-try:
-    from pyedt import edt
-except ModuleNotFoundError:
-    from edt import edt
+
+edt = get_edt()
 
 
 def dict_to_vtk(data, filename, voxel_size=1, origin=(0, 0, 0)):

--- a/src/porespy/metrics/__init__.py
+++ b/src/porespy/metrics/__init__.py
@@ -13,6 +13,7 @@ but a few functions can be applied directly to the binary image.
    :template: mybase.rst
    :toctree: generated/
 
+    metrics.bond_number
     metrics.boxcount
     metrics.chord_counts
     metrics.chord_length_distribution
@@ -21,8 +22,7 @@ but a few functions can be applied directly to the binary image.
     metrics.mesh_surface_area
     metrics.mesh_volume
     metrics.pc_curve
-    metrics.pc_curve_from_ibip
-    metrics.pc_curve_from_mio
+    metrics.pc_map_to_pc_curve
     metrics.phase_fraction
     metrics.pore_size_distribution
     metrics.porosity

--- a/src/porespy/metrics/_funcs.py
+++ b/src/porespy/metrics/_funcs.py
@@ -20,11 +20,8 @@ from porespy.tools import (
     extend_slice,
     get_tqdm,
     im_to_slabs,
+    get_edt
 )
-try:
-    from pyedt import edt
-except ModuleNotFoundError:
-    from edt import edt
 
 
 __all__ = [
@@ -47,6 +44,7 @@ __all__ = [
 ]
 
 
+edt = get_edt()
 tqdm = get_tqdm()
 logger = logging.getLogger(__name__)
 

--- a/src/porespy/metrics/_regionprops.py
+++ b/src/porespy/metrics/_regionprops.py
@@ -6,17 +6,13 @@ from pandas import DataFrame
 from skimage.measure import mesh_surface_area, regionprops
 from skimage.measure._regionprops import RegionProperties
 from skimage.morphology import ball, skeletonize
-
-from porespy.tools import bbox_to_slices, extract_subsection
+from porespy.tools import bbox_to_slices, extract_subsection, get_edt
 
 try:
     from skimage.measure import marching_cubes
 except ImportError:
     from skimage.measure import marching_cubes_lewiner as marching_cubes
-try:
-    from pyedt import edt
-except ModuleNotFoundError:
-    from edt import edt
+
 
 
 __all__ = [
@@ -26,6 +22,7 @@ __all__ = [
 ]
 
 
+edt = get_edt()
 logger = logging.getLogger(__name__)
 
 

--- a/src/porespy/networks/_getnet_para.py
+++ b/src/porespy/networks/_getnet_para.py
@@ -16,12 +16,8 @@ from porespy.tools import (
     jit_marching_squares_perimeter_and_area,
     make_contiguous,
     pad,
+    get_edt,
 )
-
-try:
-    from pyedt import edt, jit_edt_cpu
-except ModuleNotFoundError:
-    from edt import edt
 
 
 IDLE = np.uint32(0)
@@ -39,6 +35,7 @@ __all__ = [
 ]
 
 
+edt = get_edt()
 tqdm = get_tqdm()
 logger = logging.getLogger(__name__)
 

--- a/src/porespy/networks/_snow2.py
+++ b/src/porespy/networks/_snow2.py
@@ -1,7 +1,5 @@
 import logging
-
 import numpy as np
-
 from porespy.filters import (
     snow_partitioning,
     snow_partitioning_parallel,
@@ -11,13 +9,9 @@ from porespy.networks import (
     label_boundaries,
     label_phases,
     regions_to_network,
+    get_edt,
 )
 from porespy.tools import Results
-
-try:
-    from pyedt import edt
-except ModuleNotFoundError:
-    from edt import edt
 
 
 __all__ = [
@@ -26,6 +20,7 @@ __all__ = [
 ]
 
 
+edt = get_edt()
 logger = logging.getLogger(__name__)
 
 

--- a/src/porespy/networks/_snow2.py
+++ b/src/porespy/networks/_snow2.py
@@ -9,9 +9,8 @@ from porespy.networks import (
     label_boundaries,
     label_phases,
     regions_to_network,
-    get_edt,
 )
-from porespy.tools import Results
+from porespy.tools import Results, get_edt
 
 
 __all__ = [

--- a/src/porespy/simulations/__init__.py
+++ b/src/porespy/simulations/__init__.py
@@ -12,6 +12,18 @@ This module contains routines for performing simulations directly on images.
    :toctree: generated/
 
     simulations.drainage
+    simulations.drainage_dsi
+    simulations.drainage_dt
+    simulations.drainage_dt_fft
+    simulations.drainage_fft
+    simulations.ibip
+    simulations.imbibition
+    simulations.imbibition_dsi
+    simulations.imbibition_dt
+    simulations.imbibition_dt_fft
+    simulations.imbibition_fft
+    simulations.injection
+    simulations.qbip
     simulations.tortuosity_fd
 
 """

--- a/src/porespy/simulations/_drainage.py
+++ b/src/porespy/simulations/_drainage.py
@@ -15,6 +15,7 @@ from porespy.tools import (
     ps_rect,
     ps_round,
     make_contiguous,
+    get_edt,
 )
 from porespy.filters import (
     trim_disconnected_blobs,
@@ -26,10 +27,6 @@ from porespy.filters import (
 from porespy.generators import (
     borders,
 )
-try:
-    from pyedt import edt
-except ModuleNotFoundError:
-    from edt import edt
 
 
 __all__ = [
@@ -42,6 +39,7 @@ __all__ = [
 ]
 
 
+edt = get_edt()
 tqdm = get_tqdm()
 strel = {2: {'min': disk(1), 'max': square(3)}, 3: {'min': ball(1), 'max': cube(3)}}
 

--- a/src/porespy/simulations/_ibip_gpu.py
+++ b/src/porespy/simulations/_ibip_gpu.py
@@ -6,12 +6,9 @@ from porespy.tools import (
     Results,
     get_border,
     get_tqdm,
+    get_edt,
 )
 
-try:
-    from pyedt import edt
-except ModuleNotFoundError:
-    from edt import edt
 
 
 __all__ = [
@@ -19,6 +16,7 @@ __all__ = [
 ]
 
 
+edt = get_edt()
 tqdm = get_tqdm()
 logger = logging.getLogger(__name__)
 

--- a/src/porespy/simulations/_injection.py
+++ b/src/porespy/simulations/_injection.py
@@ -10,20 +10,18 @@ from porespy.tools import (
     make_contiguous,
     _insert_disk_at_points,
     Results,
+    get_edt,
 )
 from typing import Literal
 from porespy.filters import (
     find_trapped_regions,
     seq_to_satn,
 )
-try:
-    from pyedt import edt
-except ModuleNotFoundError:
-    from edt import edt
 
 
 logger = logging.getLogger(__name__)
 tqdm = get_tqdm()
+edt = get_edt()
 
 
 __all__ = [

--- a/src/porespy/tools/__init__.py
+++ b/src/porespy/tools/__init__.py
@@ -51,6 +51,7 @@ from ._funcs import _check_for_singleton_axes, center_of_mass
 from ._sphere_insertions import *
 from ._marching_cubes import *
 from ._marching_squares import *
+from ._morphology import *
 
 
 def _get_version():

--- a/src/porespy/tools/__init__.py
+++ b/src/porespy/tools/__init__.py
@@ -42,16 +42,16 @@ ways that do NOT return a modified version of the original image.
     tools.show_docstring
     tools.subdivide
     tools.unpad
-
 """
 
-from ._funcs import *
+
 from ._utils import *
+from ._morphology import *
+from ._funcs import *
 from ._funcs import _check_for_singleton_axes, center_of_mass
 from ._sphere_insertions import *
 from ._marching_cubes import *
 from ._marching_squares import *
-from ._morphology import *
 
 
 def _get_version():

--- a/src/porespy/tools/_funcs.py
+++ b/src/porespy/tools/_funcs.py
@@ -1,24 +1,18 @@
 import logging
-
 import numpy as np
 import scipy.ndimage as spim
-from scipy.stats import rankdata
 from numba import boolean, njit
 from skimage.morphology import ball, disk
 from skimage.segmentation import relabel_sequential
-
-from ._utils import Results
+from ._utils import Results, get_edt
 
 try:
     from skimage.measure import marching_cubes
 except ImportError:
     from skimage.measure import marching_cubes_lewiner as marching_cubes
-try:
-    from pyedt import edt
-except ModuleNotFoundError:
-    from edt import edt
 
 
+edt = get_edt()
 logger = logging.getLogger(__name__)
 
 
@@ -46,10 +40,6 @@ __all__ = [
     'overlay',
     'randomize_colors',
     'recombine',
-    'ps_ball',
-    'ps_disk',
-    'ps_rect',
-    'ps_round',
     'subdivide',
     'tilde',
     'unpad',
@@ -834,6 +824,7 @@ def extend_slice(slices, shape, pad=1):
         a.append(slice(start, stop, None))
     return tuple(a)
 
+
 @njit
 def jit_extend_slice(slices, shape, pad=1):
     shape = np.array(shape)
@@ -843,6 +834,7 @@ def jit_extend_slice(slices, shape, pad=1):
         stop = min(s.stop + pad, shape[i])
         a.append(slice(start, stop, None))
     return (a[0], a[1], a[2])
+
 
 @njit
 def pad(img):
@@ -1126,7 +1118,7 @@ def all_to_uniform(im, scale=None):
     # Alternative, might be faster
     # im2 = rankdata(im).reshape(im.shape)
     # im = (im2 - im2.min())/(im2.max() - im2.min())*(scale[1] - scale[0]) + scale[0]
-    aargsort_im = np.argsort(np.argsort(im.flatten()))  # Twice for the inverse permutation
+    aargsort_im = np.argsort(np.argsort(im.flatten()))  # 2x forinverse permutation
     linspace_im = np.linspace(scale[0], scale[1], len(aargsort_im), endpoint=True)
     uniform_flatten_im = linspace_im[aargsort_im]
     im = np.reshape(uniform_flatten_im, im.shape)
@@ -1232,131 +1224,6 @@ def mesh_region(region: bool, strel=None, voxel_size=(1.0, 1.0, 1.0)):
     result.norm = norm
     result.val = val
     return result
-
-
-def ps_disk(r, smooth=True):
-    r"""
-    Creates circular disk structuring element for morphological operations
-
-    Parameters
-    ----------
-    r : float or int
-        The desired radius of the structuring element
-    smooth : boolean
-        Indicates whether the faces of the sphere should have the little
-        nibs (``True``) or not (``False``, default)
-
-    Returns
-    -------
-    disk : ndarray
-        A 2D numpy bool array of the structring element
-
-    Examples
-    --------
-    `Click here
-    <https://porespy.org/examples/tools/reference/ps_disk.html>`_
-    to view online example.
-
-    """
-    disk = ps_round(r=r, ndim=2, smooth=smooth)
-    return disk
-
-
-def ps_ball(r, smooth=True):
-    r"""
-    Creates spherical ball structuring element for morphological operations
-
-    Parameters
-    ----------
-    r : scalar
-        The desired radius of the structuring element
-    smooth : boolean
-        Indicates whether the faces of the sphere should have the little
-        nibs (``True``) or not (``False``, default)
-
-    Returns
-    -------
-    ball : ndarray
-        A 3D numpy array of the structuring element
-
-    Examples
-    --------
-    `Click here
-    <https://porespy.org/examples/tools/reference/ps_ball.html>`_
-    to view online example.
-
-    """
-    ball = ps_round(r=r, ndim=3, smooth=smooth)
-    return ball
-
-
-def ps_round(r, ndim, smooth=True):
-    r"""
-    Creates round structuring element with the given radius and dimensionality
-
-    Parameters
-    ----------
-    r : scalar
-        The desired radius of the structuring element
-    ndim : int
-        The dimensionality of the element, either 2 or 3.
-    smooth : boolean
-        Indicates whether the faces of the sphere should have the little
-        nibs (``True``) or not (``False``, default)
-
-    Returns
-    -------
-    strel : ndarray
-        A 3D numpy array of the structuring element
-
-    Examples
-    --------
-    `Click here
-    <https://porespy.org/examples/tools/reference/ps_round.html>`_
-    to view online example.
-
-    """
-    rad = int(np.ceil(r))
-    other = np.ones([2*rad + 1 for i in range(ndim)], dtype=bool)
-    other[tuple(rad for i in range(ndim))] = False
-    if smooth:
-        ball = edt(other) < r
-    else:
-        ball = edt(other) <= r
-    return ball
-
-
-def ps_rect(w, ndim):
-    r"""
-    Creates rectilinear structuring element with the given size and
-    dimensionality
-
-    Parameters
-    ----------
-    w : scalar
-        The desired width of the structuring element
-    ndim : int
-        The dimensionality of the element, either 2 or 3.
-
-    Returns
-    -------
-    strel : D-aNrray
-        A numpy array of the structuring element
-
-    Examples
-    --------
-    `Click here
-    <https://porespy.org/examples/tools/reference/ps_rect.html>`_
-    to view online example.
-
-    """
-    if ndim == 2:
-        from skimage.morphology import square
-        strel = square(w)
-    if ndim == 3:
-        from skimage.morphology import cube
-        strel = cube(w)
-    return strel
 
 
 def overlay(im1, im2, c):
@@ -1571,7 +1438,8 @@ def extract_regions(regions, labels: list, trim=True):
         x_min, x_max = min(s[i - 1][0].start, x_min), max(s[i - 1][0].stop, x_max)
         y_min, y_max = min(s[i - 1][1].start, y_min), max(s[i - 1][1].stop, y_max)
         if regions.ndim == 3:
-            z_min, z_max = min(s[i - 1][2].start, z_min), max(s[i - 1][2].stop, z_max)
+            z_min, z_max = \
+                min(s[i - 1][2].start, z_min), max(s[i - 1][2].stop, z_max)
     if trim:
         if regions.ndim == 3:
             bbox = bbox_to_slices([x_min, y_min, z_min, x_max, y_max, z_max])
@@ -1596,6 +1464,7 @@ def _check_for_singleton_axes(im):  # pragma: no cover
         logger.warning("Input image conains a singleton axis. Reduce"
                        " dimensionality with np.squeeze(im) to avoid"
                        " unexpected behavior.")
+
 
 @njit
 def center_of_mass(im):

--- a/src/porespy/tools/_morphology.py
+++ b/src/porespy/tools/_morphology.py
@@ -13,6 +13,8 @@ __all__ = [
     'disk',
     'cube',
     'square',
+    'ps_disk',
+    'ps_square',
 ]
 
 

--- a/src/porespy/tools/_morphology.py
+++ b/src/porespy/tools/_morphology.py
@@ -1,6 +1,5 @@
 import numpy as np
 from scipy.signal import fftconvolve
-from skimage.morphology import ball, disk, cube, square
 from porespy.tools import (
     ps_round,
     get_edt
@@ -13,11 +12,39 @@ edt = get_edt()
 __all__ = [
     'erode',
     'dilate',
-    'get_strels',
+    'get_conns',
+    'ball',
+    'disk',
+    'cube',
+    'square',
 ]
 
 
-def get_strels():
+def ball(r):
+    se = np.ones([r*2+1]*3, dtype=bool)
+    se[r, r, r] = False
+    se = edt(se) <= r
+    return se
+
+
+def disk(r):
+    se = np.ones([r*2+1]*2, dtype=bool)
+    se[r, r] = False
+    se = edt(se) <= r
+    return se
+
+
+def cube(w):
+    se = np.ones([w, w, w], dtype=bool)
+    return se
+
+
+def square(w):
+    se = np.ones([w, w], dtype=bool)
+    return se
+
+
+def get_conns():
     se = {2: {'min': disk(1),
               'max': square(3)},
           3: {'min': ball(1),

--- a/src/porespy/tools/_morphology.py
+++ b/src/porespy/tools/_morphology.py
@@ -1,7 +1,5 @@
 import numpy as np
-from scipy.signal import fftconvolve
 from porespy.tools import (
-    ps_round,
     get_edt
 )
 
@@ -48,3 +46,128 @@ def get_conns():
           3: {'min': ball(1),
               'max': cube(3)}}
     return se
+
+
+def ps_disk(r, smooth=True):
+    r"""
+    Creates circular disk structuring element for morphological operations
+
+    Parameters
+    ----------
+    r : float or int
+        The desired radius of the structuring element
+    smooth : boolean
+        Indicates whether the faces of the sphere should have the little
+        nibs (``True``) or not (``False``, default)
+
+    Returns
+    -------
+    disk : ndarray
+        A 2D numpy bool array of the structring element
+
+    Examples
+    --------
+    `Click here
+    <https://porespy.org/examples/tools/reference/ps_disk.html>`_
+    to view online example.
+
+    """
+    disk = ps_round(r=r, ndim=2, smooth=smooth)
+    return disk
+
+
+def ps_ball(r, smooth=True):
+    r"""
+    Creates spherical ball structuring element for morphological operations
+
+    Parameters
+    ----------
+    r : scalar
+        The desired radius of the structuring element
+    smooth : boolean
+        Indicates whether the faces of the sphere should have the little
+        nibs (``True``) or not (``False``, default)
+
+    Returns
+    -------
+    ball : ndarray
+        A 3D numpy array of the structuring element
+
+    Examples
+    --------
+    `Click here
+    <https://porespy.org/examples/tools/reference/ps_ball.html>`_
+    to view online example.
+
+    """
+    ball = ps_round(r=r, ndim=3, smooth=smooth)
+    return ball
+
+
+def ps_round(r, ndim, smooth=True):
+    r"""
+    Creates round structuring element with the given radius and dimensionality
+
+    Parameters
+    ----------
+    r : scalar
+        The desired radius of the structuring element
+    ndim : int
+        The dimensionality of the element, either 2 or 3.
+    smooth : boolean
+        Indicates whether the faces of the sphere should have the little
+        nibs (``True``) or not (``False``, default)
+
+    Returns
+    -------
+    strel : ndarray
+        A 3D numpy array of the structuring element
+
+    Examples
+    --------
+    `Click here
+    <https://porespy.org/examples/tools/reference/ps_round.html>`_
+    to view online example.
+
+    """
+    rad = int(np.ceil(r))
+    other = np.ones([2*rad + 1 for i in range(ndim)], dtype=bool)
+    other[tuple(rad for i in range(ndim))] = False
+    if smooth:
+        ball = edt(other) < r
+    else:
+        ball = edt(other) <= r
+    return ball
+
+
+def ps_rect(w, ndim):
+    r"""
+    Creates rectilinear structuring element with the given size and
+    dimensionality
+
+    Parameters
+    ----------
+    w : scalar
+        The desired width of the structuring element
+    ndim : int
+        The dimensionality of the element, either 2 or 3.
+
+    Returns
+    -------
+    strel : D-aNrray
+        A numpy array of the structuring element
+
+    Examples
+    --------
+    `Click here
+    <https://porespy.org/examples/tools/reference/ps_rect.html>`_
+    to view online example.
+
+    """
+    if ndim == 2:
+        from skimage.morphology import square
+        strel = square(w)
+    if ndim == 3:
+        from skimage.morphology import cube
+        strel = cube(w)
+    return strel

--- a/src/porespy/tools/_morphology.py
+++ b/src/porespy/tools/_morphology.py
@@ -1,10 +1,5 @@
 import numpy as np
-from porespy.tools import (
-    get_edt
-)
-
-
-edt = get_edt()
+from ._utils import get_edt
 
 
 __all__ = [
@@ -13,9 +8,15 @@ __all__ = [
     'disk',
     'cube',
     'square',
+    'ps_disk',
+    'ps_ball',
     'ps_round',
     'ps_rect',
 ]
+
+
+edt = get_edt()
+
 
 
 def ball(r):

--- a/src/porespy/tools/_morphology.py
+++ b/src/porespy/tools/_morphology.py
@@ -1,0 +1,77 @@
+import numpy as np
+from scipy.signal import fftconvolve
+from skimage.morphology import ball, disk, cube, square
+from porespy.tools import (
+    ps_round,
+    get_edt
+)
+
+
+edt = get_edt()
+
+
+__all__ = [
+    'erode',
+    'dilate',
+    'get_strels',
+]
+
+
+def get_strels():
+    se = {2: {'min': disk(1),
+              'max': square(3)},
+          3: {'min': ball(1),
+              'max': cube(3)}}
+    return se
+
+
+def erode(im, r, dt=None, method='dt', smooth=True):
+    from porespy import settings
+    if dt is None:
+        dt = edt(im, parallel=settings.ncores)
+    if method == 'dt':
+        ero = dt >= r if smooth else dt > r
+    elif method.startswith('conv'):
+        se = ps_round(r=r, ndim=im.ndim, smooth=smooth)
+        ero = ~(fftconvolve(~im, se, mode='same') > 0.1)
+    return ero
+
+
+def dilate(im, r, method='dt', smooth=True):
+    from porespy import settings
+    im = im == 1
+    if method == 'dt':
+        dt = edt(~im, parallel=settings.ncores)
+        dil = dt < r if smooth else dt <= r
+        dil += im
+    elif method.startswith('conv'):
+        se = ps_round(r=r, ndim=im.ndim, smooth=smooth)
+        dil = fftconvolve(im, se, mode='same') > 0.1
+    return dil
+
+
+if __name__ == "__main__":
+    import porespy as ps
+    import matplotlib.pyplot as plt
+
+    im = ps.generators.blobs([200, 200], porosity=0.6, seed=5)
+
+    ero1 = erode(im, 5, method='dt').astype(int)
+    ero1[~im] = -1
+
+    ero2 = erode(im, 5, method='conv').astype(int)
+    ero2[~im] = -1
+
+    fig, ax = plt.subplots(2, 2)
+    ax[0][0].imshow(ero1)
+    ax[0][1].imshow(ero2)
+
+    ero1 = erode(im, 10, method='dt').astype(int)
+    dil1 = dilate(ero1, 10, method='dt').astype(int)
+    dil1[~im] = -1
+
+    dil2 = dilate(ero1, 10, method='conv').astype(int)
+    dil2[~im] = -1
+
+    ax[1][0].imshow(dil1)
+    ax[1][1].imshow(dil2)

--- a/src/porespy/tools/_morphology.py
+++ b/src/porespy/tools/_morphology.py
@@ -13,8 +13,8 @@ __all__ = [
     'disk',
     'cube',
     'square',
-    'ps_disk',
-    'ps_square',
+    'ps_round',
+    'ps_rect',
 ]
 
 

--- a/src/porespy/tools/_morphology.py
+++ b/src/porespy/tools/_morphology.py
@@ -10,8 +10,6 @@ edt = get_edt()
 
 
 __all__ = [
-    'erode',
-    'dilate',
     'get_conns',
     'ball',
     'disk',
@@ -50,55 +48,3 @@ def get_conns():
           3: {'min': ball(1),
               'max': cube(3)}}
     return se
-
-
-def erode(im, r, dt=None, method='dt', smooth=True):
-    from porespy import settings
-    if dt is None:
-        dt = edt(im, parallel=settings.ncores)
-    if method == 'dt':
-        ero = dt >= r if smooth else dt > r
-    elif method.startswith('conv'):
-        se = ps_round(r=r, ndim=im.ndim, smooth=smooth)
-        ero = ~(fftconvolve(~im, se, mode='same') > 0.1)
-    return ero
-
-
-def dilate(im, r, method='dt', smooth=True):
-    from porespy import settings
-    im = im == 1
-    if method == 'dt':
-        dt = edt(~im, parallel=settings.ncores)
-        dil = dt < r if smooth else dt <= r
-        dil += im
-    elif method.startswith('conv'):
-        se = ps_round(r=r, ndim=im.ndim, smooth=smooth)
-        dil = fftconvolve(im, se, mode='same') > 0.1
-    return dil
-
-
-if __name__ == "__main__":
-    import porespy as ps
-    import matplotlib.pyplot as plt
-
-    im = ps.generators.blobs([200, 200], porosity=0.6, seed=5)
-
-    ero1 = erode(im, 5, method='dt').astype(int)
-    ero1[~im] = -1
-
-    ero2 = erode(im, 5, method='conv').astype(int)
-    ero2[~im] = -1
-
-    fig, ax = plt.subplots(2, 2)
-    ax[0][0].imshow(ero1)
-    ax[0][1].imshow(ero2)
-
-    ero1 = erode(im, 10, method='dt').astype(int)
-    dil1 = dilate(ero1, 10, method='dt').astype(int)
-    dil1[~im] = -1
-
-    dil2 = dilate(ero1, 10, method='conv').astype(int)
-    dil2[~im] = -1
-
-    ax[1][0].imshow(dil1)
-    ax[1][1].imshow(dil2)

--- a/src/porespy/tools/_utils.py
+++ b/src/porespy/tools/_utils.py
@@ -14,15 +14,16 @@ logger = logging.getLogger("porespy")
 __all__ = [
     "sanitize_filename",
     "get_tqdm",
-    "get_edt",
     "show_docstring",
     "Results",
     "tic",
     "toc",
+    "get_edt",
 ]
 
 
 def get_edt():
+    import importlib
     try:
         package = importlib.import_module("pyedt")
         return package.edt

--- a/test/integration/test_drainage.py
+++ b/test/integration/test_drainage.py
@@ -1,11 +1,9 @@
 import numpy as np
 import porespy as ps
 import matplotlib.pyplot as plt
-try:
-    from pyedt import edt
-except ModuleNotFoundError:
-    from edt import edt
 
+
+edt = ps.get_edt()
 ps.settings.tqdm['disable'] = False
 ps.settings.tqdm['leave'] = True
 

--- a/test/integration/test_drainage.py
+++ b/test/integration/test_drainage.py
@@ -3,7 +3,7 @@ import porespy as ps
 import matplotlib.pyplot as plt
 
 
-edt = ps.get_edt()
+edt = ps.tools.get_edt()
 ps.settings.tqdm['disable'] = False
 ps.settings.tqdm['leave'] = True
 

--- a/test/integration/test_drainage_from_top.py
+++ b/test/integration/test_drainage_from_top.py
@@ -1,10 +1,9 @@
 import matplotlib.pyplot as plt
 import numpy as np
 import porespy as ps
-try:
-    from pyedt import edt
-except ModuleNotFoundError:
-    from edt import edt
+
+
+edt = ps.tools.get_edt()
 
 
 def test_drainage_from_top():

--- a/test/integration/test_inverse_Bo_study.py
+++ b/test/integration/test_inverse_Bo_study.py
@@ -3,10 +3,8 @@ import numpy as np
 import pandas as pd
 import porespy as ps
 
-try:
-    from pyedt import edt
-except ModuleNotFoundError:
-    from edt import edt
+
+edt = ps.tools.get_edt()
 
 
 def test_inverse_Bo_study(plot=False):

--- a/test/integration/test_pc_curves_with_drainage.py
+++ b/test/integration/test_pc_curves_with_drainage.py
@@ -1,10 +1,9 @@
 import numpy as np
 import porespy as ps
 import matplotlib.pyplot as plt
-try:
-    from pyedt import edt
-except ModuleNotFoundError:
-    from edt import edt
+
+
+edt = ps.tools.get_edt()
 
 
 def test_drainage(plot=False):

--- a/test/integration/test_pc_curves_with_imbibition.py
+++ b/test/integration/test_pc_curves_with_imbibition.py
@@ -1,10 +1,9 @@
 import numpy as np
 import porespy as ps
 import matplotlib.pyplot as plt
-try:
-    from pyedt import edt
-except ModuleNotFoundError:
-    from edt import edt
+
+
+edt = ps.get_edt()
 
 
 def test_drainage(plot=False):

--- a/test/integration/test_pc_curves_with_imbibition.py
+++ b/test/integration/test_pc_curves_with_imbibition.py
@@ -3,7 +3,7 @@ import porespy as ps
 import matplotlib.pyplot as plt
 
 
-edt = ps.get_edt()
+edt = ps.tools.get_edt()
 
 
 def test_drainage(plot=False):

--- a/test/unit/test_filters.py
+++ b/test/unit/test_filters.py
@@ -5,12 +5,9 @@ import scipy.ndimage as spim
 from skimage.morphology import disk, ball
 from skimage.util import random_noise
 import matplotlib.pyplot as plt
-try:
-    from pyedt import edt
-except ModuleNotFoundError:
-    from edt import edt
 
 
+edt = ps.tools.get_edt()
 ps.settings.tqdm['disable'] = True
 
 

--- a/test/unit/test_metrics.py
+++ b/test/unit/test_metrics.py
@@ -1,20 +1,16 @@
 import os
 from pathlib import Path
 import numpy as np
-
 import porespy as ps
 import pytest
 import scipy.ndimage as spim
 from numpy.testing import assert_allclose
 from skimage import io
 from skimage.morphology import ball
-
-try:
-    from pyedt import edt
-except ModuleNotFoundError:
-    from edt import edt
+from porespy.tools import get_edt
 
 
+edt = get_edt()
 ps.settings.tqdm['disable'] = True
 
 

--- a/test/unit/test_parallel_filters.py
+++ b/test/unit/test_parallel_filters.py
@@ -1,12 +1,8 @@
 import numpy as np
 import porespy as ps
 
-try:
-    from pyedt import edt
-except ModuleNotFoundError:
-    from edt import edt
 
-
+edt = ps.tools.get_edt()
 ps.settings.loglevel = "CRITICAL"
 ps.settings.tqdm['disable'] = True
 

--- a/test/unit/test_simulations.py
+++ b/test/unit/test_simulations.py
@@ -5,12 +5,10 @@ import scipy.ndimage as spim
 from skimage.morphology import disk, ball, skeletonize
 from skimage.util import random_noise
 from scipy.stats import norm
-try:
-    from pyedt import edt
-except ModuleNotFoundError:
-    from edt import edt
+from porespy.tools import get_edt
 
 
+edt = get_edt()
 ps.settings.tqdm['disable'] = True
 
 

--- a/test/unit/test_simulations_ibip.py
+++ b/test/unit/test_simulations_ibip.py
@@ -3,12 +3,10 @@ import porespy as ps
 import scipy.ndimage as spim
 from skimage.morphology import square
 from GenericTest import GenericTest
-try:
-    from pyedt import edt
-except ModuleNotFoundError:
-    from edt import edt
+from porespy.tools import get_edt
 
 
+edt = get_edt()
 ps.settings.tqdm['disable'] = True
 
 

--- a/test/unit/test_snow2.py
+++ b/test/unit/test_snow2.py
@@ -4,12 +4,8 @@ import porespy as ps
 import scipy.ndimage as spim
 from scipy import stats as spst
 
-try:
-    from pyedt import edt
-except ModuleNotFoundError:
-    from edt import edt
 
-
+edt = ps.tools.get_edt()
 ws = op.Workspace()
 ws.settings["loglevel"] = 50
 ps.settings.tqdm["disable"] = True

--- a/test/unit/test_tools.py
+++ b/test/unit/test_tools.py
@@ -6,12 +6,8 @@ import pytest
 import scipy.ndimage as spim
 import scipy.spatial as sptl
 
-try:
-    from pyedt import edt
-except ModuleNotFoundError:
-    from edt import edt
 
-
+edt = ps.tools.get_edt()
 ps.settings.tqdm['disable'] = True
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version < '3.11'",
@@ -331,7 +332,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -1125,7 +1126,7 @@ name = "ipykernel"
 version = "6.29.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "appnope", marker = "platform_system == 'Darwin'" },
+    { name = "appnope", marker = "sys_platform == 'darwin'" },
     { name = "comm" },
     { name = "debugpy" },
     { name = "ipython" },
@@ -2688,7 +2689,7 @@ name = "plumbum"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywin32", marker = "platform_python_implementation != 'PyPy' and platform_system == 'Windows'" },
+    { name = "pywin32", marker = "platform_python_implementation != 'PyPy' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f0/5d/49ba324ad4ae5b1a4caefafbce7a1648540129344481f2ed4ef6bb68d451/plumbum-1.9.0.tar.gz", hash = "sha256:e640062b72642c3873bd5bdc3effed75ba4d3c70ef6b6a7b907357a84d909219", size = 319083 }
 wheels = [
@@ -2720,7 +2721,6 @@ wheels = [
 
 [[package]]
 name = "porespy"
-version = "3.0.0a0.dev18"
 source = { editable = "." }
 dependencies = [
     { name = "dask" },
@@ -2794,6 +2794,11 @@ test = [
     { name = "pytest-split" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "porespy" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "codecov", marker = "extra == 'test'" },
@@ -2852,6 +2857,10 @@ requires-dist = [
     { name = "trimesh", marker = "extra == 'extras'" },
     { name = "trimesh", marker = "extra == 'extras-macos'" },
 ]
+provides-extras = ["build", "docs", "extras", "extras-macos", "interactive", "test"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "porespy", editable = "." }]
 
 [[package]]
 name = "prometheus-client"
@@ -4139,7 +4148,7 @@ name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737 }
 wheels = [


### PR DESCRIPTION
This PR adds several handy features for doing simple morphology related things:
1. An `erode` and `dilate` function have been added which use *only* round structuring elements, so you only need to specify `r`.
2. Functions for creating ball, sphere, square, and cube, which were removed from Skimage for some reason.
3. Add `get_strels` which are used for connectivity specifications in ndimage and skiage functions
4. Also adds `get_edt` function to deal with edt vs pyedt import

Closes #1057
Closes #1006
Closes #989
