### PR TITLE
Resolve deprecated usage of bitwise operators on Python Boolean types

### DIFF
--- a/test/unit/test_filters.py
+++ b/test/unit/test_filters.py
@@ -25,7 +25,7 @@ class FilterTest():
     def test_im_in_not_im_out(self):
         im = self.im[:, :, 50]
         for item in ps.filters.__dir__():
-            if ~item.startswith('__'):
+            if not item.startswith('__'):
                 temp = getattr(ps.filters, item)
                 assert temp is not im
 


### PR DESCRIPTION
# PR Summary
This small PR resolves the deprecation warnings coming from the bitwise operators on Python Boolean types:
```python
/Users/runner/work/porespy/porespy/test/unit/test_filters.py:28: DeprecationWarning: Bitwise inversion '~' on bool is deprecated and will be removed in Python 3.16. This returns the bitwise inversion of the underlying int object and is usually not what you expect from negating a bool. Use the 'not' operator for boolean negation or ~int(x) if you really want the bitwise inversion of the underlying int.
```
See [CI logs](https://github.com/PMEAL/porespy/actions/runs/14678020927/job/41197103505#step:7:343) for more information.