### PR TITLE
Change throat.direct_length calculation to use float64

### DIFF
--- a/src/porespy/networks/_getnet_orig.py
+++ b/src/porespy/networks/_getnet_orig.py
@@ -253,7 +253,7 @@ def regions_to_network(
     PT1 = PT1-p_dia_local[P12[:, 0]]/2*voxel_size
     PT2 = PT2-p_dia_local[P12[:, 1]]/2*voxel_size
     dist = (p_coords[P12[:, 0]] - p_coords[P12[:, 1]])*voxel_size
-    net['throat.direct_length'] = np.sqrt(np.sum(dist**2, axis=1, dtype=np.int64))
+    net['throat.direct_length'] = np.sqrt(np.sum(dist**2, axis=1, dtype=np.float64))
     net['throat.perimeter'] = np.array(t_perimeter)*voxel_size
     if (accuracy == 'high') and (im.ndim == 2):
         msg = "accuracy='high' only available in 3D, reverting to 'standard'"


### PR DESCRIPTION
Previously it was int64 which gave accuracy issues (especially for small voxel sizes);

For example with a voxel size of 1e-4 and similarly sized pores and throats; the `direct_length` calculation outputted zeros. 
Now `direct_length` corresponds with openPNM `models.network.pore_to_pore_distance`