### PR TITLE
Fix `regions_to_network` when there are no throats

### DIFF
--- a/src/porespy/networks/_getnet_orig.py
+++ b/src/porespy/networks/_getnet_orig.py
@@ -221,6 +221,9 @@ def regions_to_network(
     if im.ndim == 2:  # If 2D, add 0's in 3rd dimension
         p_coords = np.vstack((p_coords_cm.T, np.zeros((Np, )))).T
         t_coords = np.vstack((np.array(t_coords).T, np.zeros((Nt, )))).T
+    if Nt == 0:  # No throats: ensure consistent (Nt, 3) and (Nt, 2) shapes
+        t_coords = np.empty(shape=(0, 3))
+        t_conns = np.empty(shape=(0, 2), dtype=int)
 
     net = {}
     ND = im.ndim

--- a/test/unit/test_network_extraction.py
+++ b/test/unit/test_network_extraction.py
@@ -70,6 +70,26 @@ class NetworkExtractionTest():
         with pytest.raises(Exception):
             mapped = ps.networks.map_to_regions(regions, values)
 
+    def test_regions_to_network_no_throats(self):
+        # Two well-separated regions in 2D — no throats should form
+        regions_2d = np.zeros((50, 50), dtype=int)
+        regions_2d[5:15, 5:15] = 1
+        regions_2d[35:45, 35:45] = 2
+        net_2d = ps.networks.regions_to_network(regions_2d)
+        assert net_2d['throat.conns'].shape == (0, 2)
+        assert net_2d['throat.all'].shape == (0,)
+        assert net_2d['throat.global_peak'].shape == (0, 3)
+        assert net_2d['pore.coords'].shape == (2, 3)
+        # Same in 3D
+        regions_3d = np.zeros((30, 30, 30), dtype=int)
+        regions_3d[2:8, 2:8, 2:8] = 1
+        regions_3d[20:28, 20:28, 20:28] = 2
+        net_3d = ps.networks.regions_to_network(regions_3d)
+        assert net_3d['throat.conns'].shape == (0, 2)
+        assert net_3d['throat.all'].shape == (0,)
+        assert net_3d['throat.global_peak'].shape == (0, 3)
+        assert net_3d['pore.coords'].shape == (2, 3)
+
     def test_planar_2d_image(self):
         im1 = ps.generators.blobs(
             shape=[100, 100, 1], seed=1, porosity=0.4998, periodic=False,)


### PR DESCRIPTION
Closes #745.

When the regions image has no adjacent pores, `t_conns` and `t_coords` end up as empty lists, so `np.array(t_conns)` is shape `(0,)` and `net['throat.conns'][:, 0]` raises `IndexError`. Forcing them to `(0, 2)` and `(0, 3)` keeps the rest of the function happy. Added a regression test in 2D and 3D.