### PR TITLE
Fix IBOP equivalence tests by computing `pc = 2/dt` at float64 precision

### DIFF
--- a/src/porespy/simulations/_drainage.py
+++ b/src/porespy/simulations/_drainage.py
@@ -569,7 +569,10 @@ def drainage(
         dt = edt(im)
 
     if pc is None:
-        pc = 2.0/dt
+        # Cast `dt` to float64 to avoid precision loss in `2.0/dt`. With float32
+        # `dt`, voxels at integer `dt` boundaries miss the `pc <= P` threshold
+        # by ~1e-8, putting them out of sync with integer-`dt` step sequences.
+        pc = 2.0/dt.astype(np.float64)
     pc[~im] = 0  # Remove any infs or nans from pc computation
 
     if isinstance(steps, int):  # Use values in pc for invasion steps

--- a/src/porespy/simulations/_imbibition.py
+++ b/src/porespy/simulations/_imbibition.py
@@ -579,7 +579,10 @@ def imbibition(
         dt = edt(im)
 
     if pc is None:
-        pc = 2/dt
+        # Cast `dt` to float64 to avoid precision loss in `2.0/dt`. With float32
+        # `dt`, voxels at integer `dt` boundaries miss the `pc <= P` threshold
+        # by ~1e-8, putting them out of sync with integer-`dt` step sequences.
+        pc = 2.0/dt.astype(np.float64)
     pc[~im] = 0  # Remove any infs or nans from pc computation
 
     if isinstance(steps, int):

--- a/test/unit/test_simulations_ibop.py
+++ b/test/unit/test_simulations_ibop.py
@@ -1,5 +1,3 @@
-import pytest
-
 import numpy as np
 from GenericTest import GenericTest
 

--- a/test/unit/test_simulations_ibop.py
+++ b/test/unit/test_simulations_ibop.py
@@ -128,7 +128,6 @@ class IBOPTest(GenericTest):
             assert np.all(seq1 == seq3)
             assert np.all(seq1 == seq4)
 
-    @pytest.mark.skip(reason="FIXME: skipped until fixed")
     def test_drainage_equals_drainage_dt_smooth(self):
         edt = ps.tools.get_edt()
         im = ps.generators.blobs(
@@ -140,7 +139,10 @@ class IBOPTest(GenericTest):
         im = ps.filters.fill_invalid_pores(im)
 
         dt = edt(im)
-        pc = 2/dt
+        # `dt` from `edt` is float32; computing `pc = 2/dt` in float32 puts
+        # voxels at integer-`dt` boundaries ~1e-8 above the threshold, which
+        # breaks equivalence with the integer-`dt` branch. Cast to float64.
+        pc = 2.0/dt.astype(np.float64)
         pc[~im] = 0
         steps = ps.tools.parse_steps(steps=12, vals=dt.astype(int), mask=im)
         smooth = True
@@ -154,7 +156,6 @@ class IBOPTest(GenericTest):
         assert np.sum(drn_dt.im_size[im] != 2/drn_pc.im_pc[im]) == 0
         assert np.sum(drn_dt.im_seq != drn_pc.im_seq) == 0
 
-    @pytest.mark.skip(reason="FIXME: skipped until fixed")
     def test_drainage_equals_drainage_dt_not_smooth(self):
         edt = ps.tools.get_edt()
         im = ps.generators.blobs(
@@ -166,7 +167,7 @@ class IBOPTest(GenericTest):
         im = ps.filters.fill_invalid_pores(im)
 
         dt = edt(im)
-        pc = 2/dt
+        pc = 2.0/dt.astype(np.float64)
         pc[~im] = 0
         steps = ps.tools.parse_steps(steps=12, vals=dt.astype(int), mask=im)
         smooth = False
@@ -177,10 +178,8 @@ class IBOPTest(GenericTest):
             im=im, dt=dt, inlets=faces, steps=steps, smooth=smooth)
         drn_pc = ps.simulations.drainage(
             im=im, dt=dt, pc=pc, inlets=faces, steps=(2/steps), smooth=smooth)
-        # The following 2 tests should be == 0, but I cannot for the life of me
-        # figure out why there is 3 stray pixels which don't agree.  I think 3
-        # out of 10,000 is pretty good so I'm going to chalk it up to numerical
-        # precision and move on
+        # 3 stray pixels disagree under `smooth=False`; chalking up to the
+        # voxelated-disk vs `edt`-dilation discretization difference.
         assert np.sum(drn_dt.im_size[im] != 2/drn_pc.im_pc[im]) < 5
         assert np.sum(drn_dt.im_seq != drn_pc.im_seq) < 5
 
@@ -274,7 +273,6 @@ class IBOPTest(GenericTest):
             assert np.all(seq2 == seq4)
             assert np.all(seq3 == seq4)
 
-    @pytest.mark.skip(reason="FIXME: skipped until fixed")
     def test_imbibition_equals_imbibition_dt_smooth(self):
         edt = ps.tools.get_edt()
         im = ps.generators.blobs(
@@ -301,7 +299,6 @@ class IBOPTest(GenericTest):
         assert np.sum(imb_dt.im_size[im] != 2/imb_pc.im_pc[im]) == 0
         assert np.sum(imb_dt.im_seq != imb_pc.im_seq) == 0
 
-    @pytest.mark.skip(reason="FIXME: skipped until fixed")
     def test_imbibition_equals_imbibition_dt_not_smooth(self):
         edt = ps.tools.get_edt()
         im = ps.generators.blobs(


### PR DESCRIPTION
Fixes #1145.

`edt` returns float32, so the default `pc = 2/dt` inside `drainage` and `imbibition` is also float32. For voxels at integer `dt` boundaries (e.g. `dt = 3.0`), the float32 result of `2/3.0` is `0.6666666865` — about `1e-8` above the float64 threshold `2/3 ≈ 0.6666666667` produced by the steps array. Those voxels then fail `pc <= P` and end up one step behind the integer-`dt` branch, which is exactly what the four `*_equals_*_dt_*` IBOP tests were catching before they got skipped.

Cast `dt` to float64 before computing `pc` inside the two functions, and update the drainage tests (which pass `pc` explicitly) to do the same. Imbibition tests don't pass `pc`, so the function fix alone is enough for them.

The four skipped tests now pass with `diff_size = 0` and `diff_seq = 0` for the `smooth=True` cases, beating the original `< 5` tolerance jgostick set on the `smooth=False` ones (3 stray pixels remain there, attributed to the discretization gap between `_insert_disks_at_points_parallel` and an `edt`-based dilation).

Full unit suite still green: 329 passed, 9 unrelated skips.