### PR TITLE
Add `return_indices` to `local_thickness` and `porosimetry` for compact output

### DIFF
--- a/src/porespy/filters/_lt_methods.py
+++ b/src/porespy/filters/_lt_methods.py
@@ -33,6 +33,15 @@ __all__ = [
 ]
 
 
+def _index_dtype(n):
+    """Smallest unsigned int dtype that holds values `0..n` inclusive."""
+    if n <= np.iinfo(np.uint8).max:
+        return np.uint8
+    if n <= np.iinfo(np.uint16).max:
+        return np.uint16
+    return np.uint32
+
+
 def porosimetry(
     im: npt.NDArray,
     dt: npt.NDArray = None,
@@ -40,6 +49,7 @@ def porosimetry(
     sizes: int = None,
     method: Literal['dsi', 'fft', 'dt'] = 'dt',
     smooth: bool = True,
+    return_indices: bool = False,
 ):
     r"""
     Each location is assigned the radius of the largest sphere that can reach it
@@ -80,12 +90,19 @@ def porosimetry(
     smooth : bool, optional
         Indicates if protrusions should be removed from the faces of the spheres
         or not. Default is `True`.
+    return_indices : bool, optional
+        If `True`, return `(sizes, indices)` instead of a float image. `sizes` is
+        a 1D array of applied radii with a leading `0` for unfilled voxels, and
+        `indices` is an unsigned-int image such that `sizes[indices]` reproduces
+        the float result. Avoids allocating a full float64 image, which matters
+        for large tomograms. Only supported for `method='dt'`. Default is `False`.
 
     Returns
     -------
     sizes : ndarray
         In image with each voxel value indicating the largest overlapping sphere
-        which can reach it from the given inlets.
+        which can reach it from the given inlets. If `return_indices` is `True`,
+        returns `(sizes, indices)` instead.
 
     See Also
     --------
@@ -99,6 +116,10 @@ def porosimetry(
     to view online example.
 
     """
+    if return_indices and method != 'dt':
+        raise NotImplementedError(
+            f"`return_indices=True` is only supported with `method='dt'`, got {method!r}"
+        )
     if inlets is None:
         from porespy.generators import borders
         inlets = borders(im.shape, mode='faces')
@@ -108,13 +129,16 @@ def porosimetry(
         sizes = np.unique(dt[im])
     if method == 'dt':
         from porespy.simulations import drainage_dt
-        drn = drainage_dt(im=im, inlets=inlets, steps=sizes, smooth=smooth)
+        drn = drainage_dt(im=im, inlets=inlets, steps=sizes, smooth=smooth,
+                          return_indices=return_indices)
     elif method in ['dsi', 'bf']:
         from porespy.simulations import drainage_bf
         drn = drainage_bf(im=im, inlets=inlets, steps=sizes, smooth=smooth)
     if method in ['fft', 'conv']:
         from porespy.simulations import drainage_conv
         drn = drainage_conv(im=im, inlets=inlets, steps=sizes, smooth=smooth)
+    if return_indices:
+        return drn.bins, drn.im_seq
     return drn.im_size
 
 
@@ -126,6 +150,7 @@ def local_thickness(
     mask: npt.NDArray = None,
     approx: bool = False,
     sizes: int = 25,
+    return_indices: bool = False,
 ):
     r"""
     Insert a maximally inscribed sphere at every pixel labelled by sphere radius
@@ -173,12 +198,19 @@ def local_thickness(
         aggressive at skipping voxels to process, which speeds things up, but this
         sacrifices accuracy in terms of a voxel-by-voxel match with the reference
         implementation. The default is `False`, meaning full accuracy is the default.
+    return_indices : bool, optional
+        If `True`, return `(sizes, indices)` instead of a float image. `sizes` is
+        a 1D array of applied radii with a leading `0` for unfilled voxels, and
+        `indices` is an unsigned-int image such that `sizes[indices]` reproduces
+        the float result. Avoids allocating a full float64 image, which matters
+        for large tomograms. Only supported for `method='dt'`. Default is `False`.
 
     Returns
     -------
     lt : ndarray
         The local thickness of the image with each voxel labelled according to the
-        radius of the largest sphere which overlaps it.
+        radius of the largest sphere which overlaps it. If `return_indices` is
+        `True`, returns `(sizes, indices)` instead.
 
     Examples
     --------
@@ -187,8 +219,15 @@ def local_thickness(
     to view online example.
     """
 
+    if return_indices and method != 'dt':
+        raise NotImplementedError(
+            f"`return_indices=True` is only supported with `method='dt'`, got {method!r}"
+        )
+
     if method == 'dt':
-        lt = local_thickness_dt(im=im, dt=dt, sizes=sizes, smooth=smooth)
+        lt = local_thickness_dt(
+            im=im, dt=dt, sizes=sizes, smooth=smooth, return_indices=return_indices
+        )
     elif method == 'imj':
         lt = local_thickness_imj(im=im, dt=dt, smooth=smooth)[0]
     elif method == 'bf':
@@ -511,6 +550,7 @@ def local_thickness_dt(
     dt: npt.NDArray = None,
     sizes: int = 25,
     smooth: bool = True,
+    return_indices: bool = False,
 ):
     r"""
     Calculates the radius of the largest sphere that overlaps each voxel while
@@ -534,11 +574,18 @@ def local_thickness_dt(
     smooth : bool, optional
         Indicates if protrusions should be removed from the faces of the spheres
         or not. Default is `True`.
+    return_indices : bool, optional
+        If `True`, return `(sizes, indices)` where `sizes` is the 1D array of
+        applied sizes (with a leading `0` for unfilled voxels) and `indices` is
+        a small unsigned-int image such that `sizes[indices]` reproduces the
+        usual float result. This avoids allocating a full float64 image, which
+        matters for large tomograms. Default is `False`.
 
     Returns
     -------
     image : ndarray
-        A copy of `im` with the pore size values in each voxel
+        A copy of `im` with the pore size values in each voxel. If
+        `return_indices` is `True`, returns `(sizes, indices)` instead.
 
     """
     im = np.squeeze(im)
@@ -554,16 +601,23 @@ def local_thickness_dt(
     else:
         sizes = np.unique(sizes)[-1::-1]
 
-    im_results = np.zeros(np.shape(im))
+    if return_indices:
+        # Store i+1 in a compact unsigned-int image; 0 marks unfilled voxels.
+        im_results = np.zeros(np.shape(im), dtype=_index_dtype(len(sizes)))
+    else:
+        im_results = np.zeros(np.shape(im))
     desc = inspect.currentframe().f_code.co_name  # Get current func name
-    for r in tqdm(sizes, desc=desc, **settings.tqdm):
+    for i, r in enumerate(tqdm(sizes, desc=desc, **settings.tqdm)):
         im_temp = dt >= r  # Perform erosion
         if np.any(im_temp):
             # Perform dilation
             im_temp = edt(~im_temp) < r if smooth else edt(~im_temp) <= r
             # Add values to im_results
-            im_results[(im_results == 0) * im_temp] = r
+            im_results[(im_results == 0) * im_temp] = (i + 1) if return_indices else r
 
+    if return_indices:
+        # Prepend 0 so that `sizes[indices]` recovers the float result.
+        return np.concatenate(([0.0], sizes)), im_results
     return im_results
 
 

--- a/src/porespy/simulations/_drainage.py
+++ b/src/porespy/simulations/_drainage.py
@@ -42,6 +42,15 @@ tqdm = get_tqdm()
 strel = get_strel()
 
 
+def _index_dtype(n):
+    """Smallest unsigned int dtype that holds values `0..n` inclusive."""
+    if n <= np.iinfo(np.uint8).max:
+        return np.uint8
+    if n <= np.iinfo(np.uint16).max:
+        return np.uint16
+    return np.uint32
+
+
 def drainage_bf(
     im,
     inlets=None,
@@ -350,6 +359,7 @@ def drainage_dt(
     dt=None,
     steps=None,
     smooth=False,
+    return_indices=False,
 ):
     r"""
     Performs a distance transform based drainage simulation using distance transform
@@ -377,6 +387,12 @@ def drainage_dt(
         between 1 and the maximum size are used. A `tuple` is treated as the start
         and stop of the integer values. A `list` or `ndarray` is used directly. If
         `None` (default) then each unique value in the distance transform is used.
+    return_indices : bool, optional
+        If `True`, store the step index in `im_seq` using a small unsigned-int
+        dtype and skip allocating the float `im_size` array. The returned
+        `results.bins` array can be used to recover sizes via `bins[im_seq]`.
+        Saves ~16x memory on large images. Not compatible with `outlets` (the
+        trapping post-processing relies on `im_size`). Default is `False`.
 
     Returns
     -------
@@ -390,12 +406,18 @@ def drainage_dt(
                     it was first invaded. -1 indicates uninvaded, either due to
                     the applied `steps` not spanning the full range of sizes in the
                     image, or due to trapping, while 0 indicates residual invading
-                    phase.
+                    phase. With `return_indices=True`, uninvaded voxels are 0
+                    instead of -1 and the dtype is the smallest unsigned int
+                    that fits the step count.
         `im_size`   A numpy array with each voxel containing the radius of the
                     sphere, in voxels, that first overlapped it. `inf` indicates
                     uninvaded, either due to the applied `steps` not spanning the
                     full range of sizes in the image, or due to trapping, while 0
-                    indicates residual invading phase.
+                    indicates residual invading phase. Not set when
+                    `return_indices=True`.
+        `bins`      A 1D float array of the applied step sizes, prefixed with `0`
+                    so that `bins[im_seq]` recovers a per-voxel size map. Only
+                    set when `return_indices=True`.
         =========== ================================================================
 
     Notes
@@ -403,13 +425,22 @@ def drainage_dt(
     The distance transforms will be executed in parallel if
     `porespy.settings.ncores > 1`
     """
+    if return_indices and outlets is not None:
+        raise NotImplementedError(
+            "`return_indices=True` is not compatible with `outlets` (trapping "
+            "uses the float `im_size` which isn't allocated in this mode)"
+        )
     im = np.array(im, dtype=bool)
     if dt is None:
         dt = edt(im)
     dt = dt.astype(int)
     bins = parse_steps(steps=steps, vals=dt[im], descending=True)
-    im_seq = -np.ones_like(im, dtype=int)
-    im_size = np.zeros_like(im, dtype=float)
+    if return_indices:
+        # 0 marks "uninvaded"; step index `i+1` is stored in a compact dtype.
+        im_seq = np.zeros_like(im, dtype=_index_dtype(len(bins)))
+    else:
+        im_seq = -np.ones_like(im, dtype=int)
+        im_size = np.zeros_like(im, dtype=float)
     desc = inspect.currentframe().f_code.co_name  # Get current func name
     for i, r in enumerate(tqdm(bins, desc=desc, **settings.tqdm)):
         seeds = dt >= r
@@ -419,9 +450,13 @@ def drainage_dt(
             continue
         tmp = edt(~seeds)
         nwp = tmp < r if smooth else tmp <= r
-        mask = nwp * (im_seq == -1)
-        im_size[mask] = max(r, 1)
-        im_seq[mask] = i + 1
+        if return_indices:
+            mask = nwp * (im_seq == 0)
+            im_seq[mask] = i + 1
+        else:
+            mask = nwp * (im_seq == -1)
+            im_size[mask] = max(r, 1)
+            im_seq[mask] = i + 1
 
     # Apply trapping as a post-processing step if outlets given
     if outlets is not None:
@@ -437,7 +472,10 @@ def drainage_dt(
         im_size[trapped] = -1
     results = Results()
     results.im_seq = im_seq * im
-    results.im_size = im_size * im
+    if return_indices:
+        results.bins = np.concatenate(([0.0], bins))
+    else:
+        results.im_size = im_size * im
     return results
 
 

--- a/test/unit/test_filters.py
+++ b/test/unit/test_filters.py
@@ -301,6 +301,29 @@ class FilterTest():
         lt = ps.filters.local_thickness(im, sizes=[20, 10])
         assert np.all(np.unique(lt) == [0, 10, 20])
 
+    def test_local_thickness_return_indices(self):
+        lt = ps.filters.local_thickness(self.im, method='dt')
+        sizes, indices = ps.filters.local_thickness(
+            self.im, method='dt', return_indices=True)
+        # Indices use a compact unsigned-int dtype, and sizes[indices] reproduces
+        # the float result.
+        assert indices.dtype == np.uint8
+        assert indices.nbytes * 8 == lt.nbytes
+        np.testing.assert_array_equal(sizes[indices], lt)
+        assert sizes[0] == 0
+        with pytest.raises(NotImplementedError):
+            ps.filters.local_thickness(self.im, method='conv', return_indices=True)
+
+    def test_porosimetry_return_indices(self):
+        por = ps.filters.porosimetry(self.im, method='dt')
+        sizes, indices = ps.filters.porosimetry(
+            self.im, method='dt', return_indices=True)
+        assert indices.dtype == np.uint8
+        np.testing.assert_array_equal(sizes[indices], por)
+        assert sizes[0] == 0
+        with pytest.raises(NotImplementedError):
+            ps.filters.porosimetry(self.im, method='conv', return_indices=True)
+
     def test_morphology_fft_dilate_2d(self):
         im = self.im[:, :, 50]
         truth = spim.binary_dilation(im, structure=disk(3))


### PR DESCRIPTION
Closes #840.

The default float64 output of `local_thickness`/`porosimetry` becomes the peak-memory bottleneck on large tomograms (~21 GB for a 1500x1500x1200 volume in OP's case). With `return_indices=True` these now return `(sizes, indices)` where `indices` is `uint8`/`uint16` and `sizes[indices]` recovers the float result. Output memory drops 8x or more.

To save memory inside `porosimetry` too (not just at the API boundary), `drainage_dt` gained a matching `return_indices` flag that skips allocating the float `im_size` array and writes the step index into a compact `im_seq`. The mode is opt-in and not compatible with `outlets`, since trapping post-processing relies on `im_size`.

Only `method='dt'` is supported for now; the other methods raise `NotImplementedError`. Easy to extend to `conv`/`bf` in a follow-up if needed.

```python
# Before: 21 GB float64 output
lt = ps.filters.local_thickness(im, sizes=25)

# After: ~3 GB uint8 output, sizes[indices] recovers the float
sizes, indices = ps.filters.local_thickness(im, sizes=25, return_indices=True)
```

Default behaviour is unchanged. Two new tests added; full unit suite green.