### PR TITLE
Fix memory leak in `diffusive_size_factor_DNS`

### DIFF
--- a/src/porespy/networks/_size_factors.py
+++ b/src/porespy/networks/_size_factors.py
@@ -162,48 +162,53 @@ def _calc_g_val(im):
     mask = ~(mask1 + mask2)
     n = im.shape
     meds = op.network.Cubic(shape=[n[0], n[1], n[2]], spacing=1)
-    meds["pore.region1"] = mask1.copy()
-    meds["pore.region2"] = mask2.copy()
-    # Trim nodes that are located in solid phase/not ROI
-    op.topotools.trim(meds, pores=mask)
-    meds.add_model(propname="pore.cluster_number", model=op.models.network.cluster_number)
-    meds.add_model(propname="pore.cluster_size", model=op.models.network.cluster_size)
-    cluster_size = np.max(meds["pore.cluster_size"])
-    trim_pores = meds["pore.cluster_size"] < cluster_size
-    op.topotools.trim(network=meds, pores=trim_pores)
-    phss = op.phase.Phase(network=meds)
-    # A diffusive conductance of 1 ensures a finite difference approach
-    #   where each node is located at the corner of each voxel
-    phss["throat.diffusive_conductance"] = 1
-    algs = op.algorithms.FickianDiffusion(network=meds, phase=phss)
-    # Find centroid of each pore region in the finite difference nodes
-    pr1 = closest_node(centroids[0], meds["pore.coords"])
-    pr2 = closest_node(centroids[1], meds["pore.coords"])
-    algs.set_value_BC(pores=pr1, values=c1)
-    algs.set_value_BC(pores=pr2, values=c2)
-    algs.run()
-    # Calculate average concentrations within inscribed spheres
-    r1 = p_dia_local[0] / 2
-    r2 = p_dia_local[1] / 2
-    if np.round(r1) == 0:
-        # This prevent error in find_nearby_pores for narrow regions
-        # If the region is narrow, use the entire region for average concentration
-        c1_avr = algs["pore.concentration"][meds["pore.region1"]].mean()
-    else:
-        # use the inscribed sphere within the region for average concentration
-        pores1 = meds.find_nearby_pores(pr1, r=np.round(r1), flatten=True, include_input=True)
-        pores1 = np.append(pores1, pr1)
-        pores1 = np.unique(pores1)
-        c1_avr = algs["pore.concentration"][pores1].mean()
-    if np.round(r2) == 0:
-        c2_avr = algs["pore.concentration"][meds["pore.region2"]].mean()
-    else:
-        pores2 = meds.find_nearby_pores(pr2, r=np.round(r2), flatten=True, include_input=True)
-        pores2 = np.append(pores2, pr2)
-        pores2 = np.unique(pores2)
-        c2_avr = algs["pore.concentration"][pores2].mean()
-    g = abs(algs.rate(pores=pr1)[0] / (c1_avr - c2_avr))
-    return g
+    # Each OpenPNM object created below registers a project on the global
+    # Workspace; close it at the end so repeated calls don't accumulate.
+    try:
+        meds["pore.region1"] = mask1.copy()
+        meds["pore.region2"] = mask2.copy()
+        # Trim nodes that are located in solid phase/not ROI
+        op.topotools.trim(meds, pores=mask)
+        meds.add_model(propname="pore.cluster_number", model=op.models.network.cluster_number)
+        meds.add_model(propname="pore.cluster_size", model=op.models.network.cluster_size)
+        cluster_size = np.max(meds["pore.cluster_size"])
+        trim_pores = meds["pore.cluster_size"] < cluster_size
+        op.topotools.trim(network=meds, pores=trim_pores)
+        phss = op.phase.Phase(network=meds)
+        # A diffusive conductance of 1 ensures a finite difference approach
+        #   where each node is located at the corner of each voxel
+        phss["throat.diffusive_conductance"] = 1
+        algs = op.algorithms.FickianDiffusion(network=meds, phase=phss)
+        # Find centroid of each pore region in the finite difference nodes
+        pr1 = closest_node(centroids[0], meds["pore.coords"])
+        pr2 = closest_node(centroids[1], meds["pore.coords"])
+        algs.set_value_BC(pores=pr1, values=c1)
+        algs.set_value_BC(pores=pr2, values=c2)
+        algs.run()
+        # Calculate average concentrations within inscribed spheres
+        r1 = p_dia_local[0] / 2
+        r2 = p_dia_local[1] / 2
+        if np.round(r1) == 0:
+            # This prevent error in find_nearby_pores for narrow regions
+            # If the region is narrow, use the entire region for average concentration
+            c1_avr = algs["pore.concentration"][meds["pore.region1"]].mean()
+        else:
+            # use the inscribed sphere within the region for average concentration
+            pores1 = meds.find_nearby_pores(pr1, r=np.round(r1), flatten=True, include_input=True)
+            pores1 = np.append(pores1, pr1)
+            pores1 = np.unique(pores1)
+            c1_avr = algs["pore.concentration"][pores1].mean()
+        if np.round(r2) == 0:
+            c2_avr = algs["pore.concentration"][meds["pore.region2"]].mean()
+        else:
+            pores2 = meds.find_nearby_pores(pr2, r=np.round(r2), flatten=True, include_input=True)
+            pores2 = np.append(pores2, pr2)
+            pores2 = np.unique(pores2)
+            c2_avr = algs["pore.concentration"][pores2].mean()
+        g = abs(algs.rate(pores=pr1)[0] / (c1_avr - c2_avr))
+        return g
+    finally:
+        op.Workspace().close_project(meds.project)
 
 
 def closest_node(extracted_nodes, fd_nodes):

--- a/test/unit/test_network_size_factor.py
+++ b/test/unit/test_network_size_factor.py
@@ -1,6 +1,7 @@
 import pytest
 
 import numpy as np
+import openpnm as op
 
 import porespy as ps
 
@@ -15,6 +16,16 @@ class NetworkSizeFactorTest():
         self.im = im[:15, :15, :15]
         self.snow = ps.networks.snow2(self.im, boundary_width=0,
                                       parallel_kw=None)
+
+    def test_diffusive_size_factor_DNS_does_not_leak_projects(self):
+        # Regression test for #835: each call used to register an OpenPNM
+        # project on the global Workspace and never close it.
+        regions = self.snow.regions
+        conns = self.snow.network['throat.conns'][:3]
+        ws = op.Workspace()
+        n_before = len(ws)
+        ps.networks.diffusive_size_factor_DNS(regions, throat_conns=conns)
+        assert len(ws) == n_before
 
     @pytest.mark.skip(reason="Skip until we figure out what's wrong")
     def test_diffusive_size_factor_DNS(self):


### PR DESCRIPTION
Closes #835. Every call to `diffusive_size_factor_DNS` was leaking an OpenPNM project on the global `Workspace`, so memory grew linearly with the number of throat pairs (64 GB out at a few thousand pairs, per the original report).

`_calc_g_val` builds a `Cubic` network, a `Phase`, and a `FickianDiffusion` algorithm. Each of those constructors calls `ws.new_project()` (`openpnm/core/_base2.py:75`), and nothing ever closed them. Fix is a `try/finally` around the OpenPNM work that calls `Workspace().close_project(meds.project)` on exit.

Reproduced on current `dev` with a 100³ blob image, 30 throat pairs:

|  | Workspace projects | RSS delta |
| --- | --- | --- |
| before | 30 | +69.6 MB |
| after | 0 | +28.7 MB |

The remaining delta is bounded; it doesn't scale with iteration count anymore. New regression test asserts `len(Workspace())` is unchanged after a call.