### PR TITLE
Clarify regionprops_3D `volume` matches skimage's `area`

### DIFF
--- a/src/porespy/metrics/_regionprops.py
+++ b/src/porespy/metrics/_regionprops.py
@@ -162,10 +162,13 @@ def regionprops_3D(im):
             region
 
         'volume'
-            Volume of the region in number of voxels.
+            Volume of the region. This is an alias for skimage's ``area``
+            property, which returns ``num_pixels * voxel_volume`` (i.e. the
+            voxel count when ``spacing`` is left at its default of 1).
 
         'bbox_volume'
-            Volume of the bounding box that contains the region.
+            Volume of the bounding box that contains the region, expressed
+            as a voxel count.
 
         'border'
             The edges of the region, found as the locations where the distance


### PR DESCRIPTION
Closes #979.

The `regionprops_3D` docstring claimed `volume` was "the number of voxels", but the property is just `self.area`, which in modern skimage is `num_pixels * voxel_volume`. With the default `spacing=1` the two are equal, so behaviour is unchanged — this just makes the docstring honest about what's actually returned.