### PR TITLE
Fix `align_image_with_openpnm` mirror bug (Paraview alignment)

### DIFF
--- a/src/porespy/tools/_funcs.py
+++ b/src/porespy/tools/_funcs.py
@@ -673,20 +673,31 @@ def marching_map(path, start):
 
 def align_image_with_openpnm(im):
     r"""
-    Rotates an image to agree with the coordinates used in OpenPNM.
+    Permute image axes so they align with OpenPNM ``pore.coords`` when the
+    image is loaded into ParaView (or any tool whose TIFF reader treats
+    numpy axis 0 as the z-stack).
 
-    This is necessary for overlaying the image and the network in Paraview.
+    OpenPNM treats ``pore.coords`` as ``(x, y, z)``, but the centroids that
+    PoreSpy hands to OpenPNM are in numpy index order ``(axis0, axis1, axis2)``.
+    A TIFF-style reader interprets axis 0 as z, axis 1 as y, axis 2 as x, so
+    swapping axes 0 and 2 (or 0 and 1 in 2D) makes the image's voxel order
+    match OpenPNM's coordinate order.
+
+    Note that this function is **not** needed when writing the image with
+    ``porespy.io.to_vtk`` — pyevtk preserves numpy axis order, so ParaView
+    already lines the network up with the image.
 
     Parameters
     ----------
     im : ndarray
-        The image to be rotated.  Can be the Boolean image of the pore space
-        or any other image of interest.
+        The 2D or 3D image to be aligned. Can be the Boolean image of the
+        pore space or any other image of interest.
 
     Returns
     -------
     image : ndarray
-        Returns a copy of ``im`` rotated accordingly.
+        A copy of ``im`` with axes swapped so it overlays correctly with
+        the OpenPNM network in ParaView when saved via TIFF.
 
     Examples
     --------
@@ -696,14 +707,11 @@ def align_image_with_openpnm(im):
 
     """
     _check_for_singleton_axes(im)
-    im = np.copy(im)
     if im.ndim == 2:
-        im = (np.swapaxes(im, 1, 0))
-        im = im[-1::-1, :]
-    elif im.ndim == 3:
-        im = (np.swapaxes(im, 2, 0))
-        im = im[:, -1::-1, :]
-    return im
+        return np.swapaxes(im, 0, 1).copy()
+    if im.ndim == 3:
+        return np.swapaxes(im, 0, 2).copy()
+    return np.copy(im)
 
 
 def recombine(ims, slices, overlap):

--- a/test/unit/test_tools.py
+++ b/test/unit/test_tools.py
@@ -119,6 +119,24 @@ class ToolsTest():
         im = ps.tools.align_image_with_openpnm(np.ones([40, 50, 60]))
         assert im.shape == (60, 50, 40)
 
+    def test_align_image_w_openpnm_is_a_pure_swap_no_flip(self):
+        # Regression test for #872: the function used to swap *and* flip,
+        # producing a mirror. A marker placed at numpy index (i, j, k) must
+        # land at (k, j, i) after alignment — no axis is reversed.
+        im2d = np.zeros((10, 20), dtype=np.uint8)
+        im2d[3, 7] = 1
+        out2d = ps.tools.align_image_with_openpnm(im2d)
+        assert out2d.shape == (20, 10)
+        assert out2d[7, 3] == 1
+        assert out2d.sum() == 1
+
+        im3d = np.zeros((10, 20, 30), dtype=np.uint8)
+        im3d[3, 7, 25] = 1
+        out3d = ps.tools.align_image_with_openpnm(im3d)
+        assert out3d.shape == (30, 20, 10)
+        assert out3d[25, 7, 3] == 1
+        assert out3d.sum() == 1
+
     def test_inhull(self):
         X = np.random.rand(25, 2)
         hull = sptl.ConvexHull(X)


### PR DESCRIPTION
Closes #872. Addresses #710.

The 3D branch was `swapaxes(0, 2)` followed by `[:, ::-1, :]`, and the 2D branch the analogous swap+flip. The swap is what's needed; the flip was just mirroring the output, which is what shillcoat reported. Confirmed with `vtkTIFFReader` (the reader ParaView uses) that a marker at numpy `(3, 7, 25)` lands at ParaView world `(x=25, y=7, z=3)` after a TIFF round-trip, so the pure axis swap is what aligns the image with `pore.coords` from `snow2`. ParaView's reader doesn't apply a y-flip, so neither should we.

Docstring now says when the helper applies (TIFF export for ParaView) and that `porespy.io.to_vtk` doesn't need it since pyevtk preserves numpy axis order. New test pins element placement; the old shape-only one couldn't catch the mirror.

On #710, I don't think bundling a rotated image into `snow2`'s `Results` is the right move since the transform depends on where the image is going. With this helper working, TIFF→ParaView is one line and `to_vtk` is zero.

@jgostick if you'd rather see a rotated image bundled into `Results`, let me know.