### PR TITLE
Add optional `voxel_size` to `porosity_profile` and `satn_profile`

### DIFF
--- a/src/porespy/metrics/_funcs.py
+++ b/src/porespy/metrics/_funcs.py
@@ -447,7 +447,7 @@ def porosity(im, mask=None, fill_closed=False, fill_surface=False):
     return e
 
 
-def porosity_profile(im, axis=0, span=1, mode="tile"):
+def porosity_profile(im, axis=0, span=1, mode="tile", voxel_size=None):
     r"""
     Computes the porosity profile along the specified axis
 
@@ -473,6 +473,10 @@ def porosity_profile(im, axis=0, span=1, mode="tile"):
                  provides more data points but is slower.
         ======== ==============================================================
 
+    voxel_size : scalar, optional
+        If given, the returned ``position`` values are scaled by this factor.
+        If ``None`` (default), positions are returned in voxel units.
+
     Returns
     -------
     results : dataclass
@@ -484,7 +488,7 @@ def porosity_profile(im, axis=0, span=1, mode="tile"):
         position      The position along the given axis at which porosity
                       values are computed, corresponding to the middle of each
                       slice, whether the mode was `'tile'` or `'slide'`.
-                      The units are in voxels.
+                      The units are in voxels unless ``voxel_size`` is given.
         porosity      The local porosity value at each position.
         ============= =========================================================
 
@@ -510,6 +514,8 @@ def porosity_profile(im, axis=0, span=1, mode="tile"):
         denom = ((im[s] == 1) + (im[s] == 0)).sum(dtype=np.float64)
         eps[i] = num / denom
         z[i] = (s[axis].start + s[axis].stop) / 2
+    if voxel_size is not None:
+        z = z * voxel_size
     results = Results()
     results.position = z
     results.porosity = eps
@@ -1394,7 +1400,8 @@ def pc_map_to_pc_curve(
     return results
 
 
-def satn_profile(satn, s=None, im=None, axis=0, span=10, mode="tile"):
+def satn_profile(satn, s=None, im=None, axis=0, span=10, mode="tile",
+                 voxel_size=None):
     r"""
     Computes a saturation profile from an image of fluid invasion
 
@@ -1430,6 +1437,10 @@ def satn_profile(satn, s=None, im=None, axis=0, span=10, mode="tile"):
                  provides more data points but is slower.
         ======== ==============================================================
 
+    voxel_size : scalar, optional
+        If given, the returned ``position`` values are scaled by this factor.
+        If ``None`` (default), positions are returned in voxel units.
+
     Returns
     -------
     results : dataclass
@@ -1439,7 +1450,8 @@ def satn_profile(satn, s=None, im=None, axis=0, span=10, mode="tile"):
         Attribute     Description
         ============= =========================================================
         position      The position along the given axis at which saturation
-                      values are computed.  The units are in voxels.
+                      values are computed.  The units are in voxels unless
+                      ``voxel_size`` is given.
         saturation    The local saturation value at each position.
         ============= =========================================================
 
@@ -1472,6 +1484,8 @@ def satn_profile(satn, s=None, im=None, axis=0, span=10, mode="tile"):
         y[i] = nwp.sum(dtype=np.int64) / void.sum(dtype=np.int64)
         z[i] = (slab[axis].start + slab[axis].stop) / 2
 
+    if voxel_size is not None:
+        z = z * voxel_size
     results = Results()
     results.position = z
     results.saturation = y

--- a/test/unit/test_metrics.py
+++ b/test/unit/test_metrics.py
@@ -123,6 +123,13 @@ class MetricsTest:
         with pytest.raises(Exception):
             ps.metrics.porosity_profile(self.im2D, axis=2)
 
+    def test_porosity_profile_voxel_size(self):
+        im = ps.generators.lattice_spheres(shape=[200, 200], r=15, spacing=38)
+        p_vox = ps.metrics.porosity_profile(im, axis=0)
+        p_phys = ps.metrics.porosity_profile(im, axis=0, voxel_size=2.5e-6)
+        assert_allclose(p_phys.position, p_vox.position * 2.5e-6)
+        assert_allclose(p_phys.porosity, p_vox.porosity)
+
     def test_linear_density(self):
         im = ps.filters.distance_transform_lin(self.im2D, axis=0, mode="both")
         ps.metrics.lineal_path_distribution(im)
@@ -311,6 +318,16 @@ class MetricsTest:
         # assert len(prof1.saturation) == 80
         assert prof1.saturation[31] == 1 / 30
         assert prof1.saturation[48] == 0.6
+
+    def test_satn_profile_voxel_size(self):
+        satn = np.tile(np.atleast_2d(np.linspace(1, 0.01, 100)), (100, 1))
+        satn[:25, :] = 0
+        satn[-25:, :] = -1
+        p_vox = ps.metrics.satn_profile(satn=satn, s=0.5, axis=1, span=1)
+        p_phys = ps.metrics.satn_profile(
+            satn=satn, s=0.5, axis=1, span=1, voxel_size=2.5e-6)
+        assert_allclose(p_phys.position, p_vox.position * 2.5e-6)
+        assert_allclose(p_phys.saturation, p_vox.saturation)
 
     def test_satn_profile_threshold(self):
         satn = np.tile(np.atleast_2d(np.linspace(1, 0.01, 100)), (100, 1))


### PR DESCRIPTION
Closes #1039

Both functions now accept `voxel_size`, defaulting to `None`. When `None`, `position` stays in voxel units (current behaviour, so existing code is unaffected). When a number is passed, `position` is scaled by it. The numerical results (porosity / saturation) are untouched either way.

I had pushed back on this earlier on the grounds that an incorrect voxel size means redoing expensive work, but with an opt-in default of `None` that concern goes away — users have to explicitly ask for the rescaling.